### PR TITLE
Fix styles typo

### DIFF
--- a/packages/vx-responsive/src/components/ScaleSVG.js
+++ b/packages/vx-responsive/src/components/ScaleSVG.js
@@ -13,7 +13,7 @@ export default function ResponsiveSVG({
       display: 'inline-block',
       position: 'relative',
       width: '100%',
-      verticalAling: 'top',
+      verticalAlign: 'top',
       overflow: 'hidden',
     }}>
       <svg


### PR DESCRIPTION
Just stumbled across this codebase a spotted a typo in the styles for `@vx/responsive`. Not sure what impact this'll have, but I figured, if it's in there, it should probably be spelt right :)