### PR TITLE
Add docs for several different packages.

### DIFF
--- a/packages/vx-annotation/Readme.md
+++ b/packages/vx-annotation/Readme.md
@@ -1,5 +1,52 @@
 # @vx/annotation
 
+
+## LinePathAnnotation
+
+Line Path Annotations add a bit of text and a line coming from a point. They're useful for adding info to your graphs.
+
+``` javascript
+const annotation = (
+  <Annotation.LinePathAnnotation
+    label={'expected from deploy'}
+    stroke={'white'}
+    labelFill={'white'}
+    labelStroke={'none'}
+    labelStrokeWidth={2}
+    points={[
+      annotationPoint,
+      new Point({
+        x: annotationPoint.x + (width / allData.length),
+        y: annotationPoint.y - (height / allData.length),
+      })
+    ]}
+  />
+);
+```
+
+![image output](http://i.imgur.com/o5jnHFS.png)
+
+# Properties
+
+|         Name         |  Default   |  Type  |                                              Description                                               |
+|:-------------------- |:---------- |:------ |:------------------------------------------------------------------------------------------------------ |
+| top                  | 0          | number | Margin on top                                                                                          |
+| left                 | 0          | number | Margin on left                                                                                         |
+| points               |            | array  | Points describing the line path                                                                        |
+| stroke               | black      | string | The color of the line                                                                                  |
+| strokeWidth          | 1          | number | The pixel width of the line                                                                            |
+| className            |            | string | The class name associated of the LinePath shape                                                        |
+| label                |            | string | The text for your label                                                                                |
+| labelAnchor          | left       | string | The label's textAnchor                                                                                 |
+| labelDx              | 0          | number | The x-coordinate shift to the label                                                                    |
+| labelDy              | 0          | number | The y-coordinate shift to the label                                                                    |
+| labelFill            | <stroke>   | string | The color of label. Defaults to the stroke color                                                       |
+| labelFontSize        | 10         | number | The font size of the label text                                                                        |
+| labelStroke          | white      | string | The color of the label                                                                                 |
+| labelStrokeWidth     | 3          | number | The stroke width of the label text                                                                     |
+| labelPaintOrder      | stroke     | string | The label's SVG [paint-order](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/paint-order). |
+
+
 ## vx packages
 
 - @vx/annotation

--- a/packages/vx-curve/Readme.md
+++ b/packages/vx-curve/Readme.md
@@ -1,5 +1,52 @@
 # @vx/curve
 
+## Overview
+
+A curve is a function that can be passed into other vx objects, mainly a LinePath to change the way the line is structured.
+
+For example, checkout the difference between a `Curve.natural`:
+
+![natural curve](https://raw.githubusercontent.com/d3/d3-shape/master/img/natural.png)
+
+and a `Curve.step`:
+
+![step curve](https://raw.githubusercontent.com/d3/d3-shape/master/img/step.png)
+
+The `@vx/curve` package is a wrapper over [d3-shape](https://github.com/d3/d3-shape) curve functions.
+
+Any function with the prefix `curve` in d3 can be used through `vx` like so:
+
+``` javascript
+import Curve from `@vx/curve`
+
+let curve = Curve.catmullRomOpen //Corresponds to `d3.curveCatmullRomOpen`
+
+let line = (<Shape.LinePath curve={curve} />)
+```
+
+## Functions
+
+|        vx        |                                      d3                                       |
+| ---------------- | ----------------------------------------------------------------------------- |
+| basis            | [curveBasis](https://github.com/d3/d3-shape#curveBasis)                       |
+| basisClose       | [curveBasisClosed](https://github.com/d3/d3-shape#curveBasisClosed)           |
+| basisOpen        | [curveBasisOpen](https://github.com/d3/d3-shape#curveBasisOpen)               |
+| step             | [curveStep](https://github.com/d3/d3-shape#curveStep)                         |
+| stepAfter        | [curveStepAfter](https://github.com/d3/d3-shape#curveStepAfter)               |
+| stepBefore       | [curveStepbefore](https://github.com/d3/d3-shape#curveStepBefore)             |
+| bundle           | [curveBundle](https://github.com/d3/d3-shape#curveBundle)                     |
+| linear           | [curveLinear](https://github.com/d3/d3-shape#curveLinear)                     |
+| linearClosed     | [curveLinearClosed](https://github.com/d3/d3-shape#curveLinearClosed)         |
+| monotoneX        | [curveMonotoneX](https://github.com/d3/d3-shape#curveMonotoneX)               |
+| monotoneY        | [curveMonotoneY](https://github.com/d3/d3-shape#curveMonotoneY)               |
+| cardinal         | [curveCardinal](https://github.com/d3/d3-shape#curveCardinal)                 |
+| cardinalClosed   | [curveCardinalClosed](https://github.com/d3/d3-shape#curveCardinalClosed)     |
+| cardinalOpen     | [curveCardinalOpen](https://github.com/d3/d3-shape#curveCardinalOpen)         |
+| catmullRom       | [curveCatmullRom](https://github.com/d3/d3-shape#curveCatmullRom)             |
+| catmullRomClosed | [curveCatmullRomClosed](https://github.com/d3/d3-shape#curveCatmullRomClosed) |
+| catmullRomOpen   | [curveCatmullRomOpen](https://github.com/d3/d3-shape#curveCatmullRomOpen)     |
+| natural          | [curveNatural](https://github.com/d3/d3-shape#curveNatural)                   |
+
 ## vx packages
 
 - [@vx/axis](https://github.com/hshoff/vx/tree/master/packages/vx-axis)

--- a/packages/vx-glyph/Readme.md
+++ b/packages/vx-glyph/Readme.md
@@ -1,5 +1,61 @@
 # @vx/glyph
 
+Glyphs are small icons that you can use in your graphs. Some elements, like `LinePath`, can take a function that returns a glyph.
+
+For example:
+``` javascript
+let line = (
+  <Shape.LinePath
+    ...
+    glyph={(d, i) => {
+      return (
+        <Glyph.Dot
+          className={"glyph-dots"}
+          key={'line-dot-{i}'}
+          cx={xScale(x(d))}
+          cy={yScale(y(d))}
+          r={6}
+          fill={"white"}
+          stroke={"black"}
+          strokeWidth={3} />
+      )
+    }}
+)
+```
+
+You also can incorporate child elements into your glyph to add labels and such.
+
+``` javascript
+<Glyph.Dot ... >
+  <text
+    x={xScale(x(d))}
+    y={yScale(y(d))}
+    dx={10}
+    fill={"white"}
+    stroke={"black"}
+    strokeWidth={6}
+    fontSize={11}
+  >
+    {"Hi there!"}
+  </text>
+</Glyph.Dot>
+```
+
+## `Glyph.Dot`
+
+|      Name       | Default |  Type  |                    Description                    |
+|:--------------- |:------- |:------ |:------------------------------------------------- |
+| top             | 0       | number | Margin on top                                     |
+| left            | 0       | number | Margin on left                                    |
+| className       |         | string | The class name associated of the LinePath shape   |
+| cx              |         | number | The x-axis coordinate at the center of the circle |
+| cy              |         | number | The y-axis coordinate at the center of the circle |
+| r               |         | number | The radius of the circle                          |
+| fill            |         | string | The color of the circle's fill                    |
+| stroke          |         | string | The color of the circle's stroke                  |
+| strokeWidth     |         | number | The width of the circle's stroke                  |
+| strokeDasharray |         | array  | An array that controls the pattern of dashes in the stroke. [See more here.](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray)                                                  |
+
 ## vx packages
 
 - [@vx/axis](https://github.com/hshoff/vx/tree/master/packages/vx-axis)

--- a/packages/vx-gradient/Readme.md
+++ b/packages/vx-gradient/Readme.md
@@ -2,6 +2,8 @@
 
 Inspired by: https://dribbble.com/shots/3380672-Sketch-Gradients-Freebie
 
+## Example
+
 ```js
 import Shape from '@vx/shape';
 import Gradient from '@vx/gradient';
@@ -14,4 +16,32 @@ const GradientArea = () => {
       </svg>
     );
 }
+```
+
+
+## Premades
+Vx comes with a couple pre-made gradients for you to use.
+
+|    Gradients Available     |
+| -------------------------- |
+| `Gradient.DarkgreenGreen`  |
+| `Gradient.LightgreenGreen` |
+| `Gradient.OrangeRed`       |
+| `Gradient.PinkBlue`        |
+| `Gradient.PinkRed`         |
+| `Gradient.PurpleOrange`    |
+| `Gradient.PurpleTeal`      |
+| `Gradient.SteelPurple`     |
+| `Gradient.TealBlue`        |
+
+
+## Make your own!
+
+You can make any linear gradient like so:
+
+``` js
+<Gradient.LinearGradient
+  from='#a18cd1'
+  to='#fbc2eb'
+/>
 ```

--- a/packages/vx-group/Readme.md
+++ b/packages/vx-group/Readme.md
@@ -1,5 +1,26 @@
 # @vx/group
 
+A Group is a container for other objects. It lets you pass in a top and left margin and a classname.
+
+Example usage:
+
+``` js
+const myGroup = (
+  <Group top={50} left={20}>
+    /* Children here */
+  </Group>
+)
+```
+
+## Properties
+
+|   Name    | Default |  Type  |                     Description                     |
+|:--------- |:------- |:------ |:--------------------------------------------------- |
+| top       | 0       | number | Margin on top                                       |
+| left      | 0       | number | Margin on left                                      |
+| className |         | string | The class name associated with the svg `g` element. |
+
+## Source For Components
 + [`<Group />`](https://github.com/hshoff/vx/blob/master/packages/vx-group/src/index.js)
 
 ## vx packages


### PR DESCRIPTION
I added some simple docs explaining an example for annotation and a markdown table for properties similar to what [Material-UI](http://www.material-ui.com/#/components/badge#properties) has for it's docs. 

Since working with markdown tables is kind of annoying, I did two things. First I got the [markdown-table-editor](https://atom.io/packages/markdown-table-editor) package for Atom. Then I [wrote a python script](https://gist.github.com/Flaque/beac1aff6ef313875cc6ef8043faf928) to take the function call params and fill out the name, type, and defaults of the table so there was less busy work. 

