### PR TITLE
pass in axis label components explicitly

### DIFF
--- a/packages/vx-axis/src/axis/Axis.js
+++ b/packages/vx-axis/src/axis/Axis.js
@@ -19,10 +19,8 @@ export default function Axis({
   tickFormat,
   tickStroke = 'black',
   tickLength = 8,
-  tickLabelPadding = 14,
-  tickOffset = 0,
+  tickLabelOffset = 14,
   tickTransform,
-  axisPadding = 0.5,
   hideAxisLine = false,
   hideTicks = false,
   hideZero = false,
@@ -51,16 +49,14 @@ export default function Axis({
     if (tickFormat) format = tickFormat;
 
     const range = scale.range();
-    const range0 = range[0] + axisPadding;
-    const range1 = range[range.length - 1] + axisPadding;
+    const range0 = range[0] + 0.5;
+    const range1 = range[range.length - 1] + 0.5;
 
     const horizontal = orientation !== ORIENT.left && orientation !== ORIENT.right;
     const isLeft = orientation === ORIENT.left;
     const isTop = orientation === ORIENT.top;
     const tickSign = isLeft || isTop ? -1 : 1;
-    const totalTickSize = tickLength + Math.abs(tickLabelPadding) + Math.abs(tickOffset);
 
-    const transform = horizontal ? '' : `translate(${tickOffset})`;
     const position = (scale.bandwidth ? center : identity)(scale.copy());
 
     const axisFromPoint = new Point({
@@ -78,7 +74,9 @@ export default function Axis({
     const labelProps = {
       transform: horizontal ?  '' : `rotate(${tickSign * 90})`,
       x: horizontal ? range1 / 2 : tickSign * (range0 / 2),
-      y: horizontal ? tickSign * totalTickSize : (isLeft ? 1 : -1) * tickSign * totalTickSize,
+      y: horizontal ?
+        (tickSign * (tickLength + tickLabelOffset + tickLabelFontSize + (!isTop ? labelFontSize : 0)))
+        : (isLeft ? 1 : -1) * tickSign * (tickLength + tickLabelOffset),
     };
 
     return (
@@ -95,24 +93,24 @@ export default function Axis({
             y: horizontal ? 0 : position(val),
           });
           const tickToPoint = new Point({
-            x: horizontal ? position(val) : tickLength,
-            y: horizontal ? tickLength : position(val),
+            x: horizontal ? position(val) : (tickSign * tickLength),
+            y: horizontal ? (tickLength * tickSign) : position(val),
           });
            const tickLabelProps = {
-            x: (!horizontal ? tickSign : 1) * tickToPoint.x,
-            y: (horizontal ? tickSign : 1) * (tickToPoint.y + (horizontal && !isTop ? tickLabelFontSize : 0)),
+            x: tickToPoint.x,
+            y: tickToPoint.y + (horizontal && !isTop ? tickLabelFontSize : 0),
           };
 
           return (
             <Group
               key={`vx-tick-${val}-${i}`}
               className='vx-axis-ticks'
+              transform={tickTransform}
             >
               {!hideTicks &&
                 <Line
                   from={tickFromPoint}
                   to={tickToPoint}
-                  transform={tickTransform || transform}
                   stroke={tickStroke || stroke}
                 />
               }

--- a/packages/vx-axis/src/axis/Axis.js
+++ b/packages/vx-axis/src/axis/Axis.js
@@ -5,6 +5,7 @@ import { Point } from '@vx/point';
 import { Group } from '@vx/group';
 import center from '../utils/center';
 import identity from '../utils/identity';
+import getLabelTransform from '../utils/labelTransform';
 import ORIENT from '../constants/orientation';
 
 export default function Axis({
@@ -19,21 +20,12 @@ export default function Axis({
   tickFormat,
   tickStroke = 'black',
   tickLength = 8,
-  tickLabelOffset = 14,
   tickTransform,
   hideAxisLine = false,
   hideTicks = false,
   hideZero = false,
-  labelComponent = (
-    <text
-      textAnchor="middle"
-      fontFamily="Arial"
-      fontSize={10}
-      fill="black"
-    >
-      default label
-    </text>
-  ),
+  labelOffset = 14,
+  labelComponent,
   tickLabelComponent = (
     <text
       textAnchor="middle"
@@ -68,16 +60,16 @@ export default function Axis({
       y: horizontal ? 0 : range1,
     });
 
-    const labelFontSize = labelComponent.props.fontSize || 10;
     const tickLabelFontSize = tickLabelComponent.props.fontSize || 10;
 
-    const labelProps = {
-      transform: horizontal ?  '' : `rotate(${tickSign * 90})`,
-      x: horizontal ? range1 / 2 : tickSign * (range0 / 2),
-      y: horizontal ?
-        (tickSign * (tickLength + tickLabelOffset + tickLabelFontSize + (!isTop ? labelFontSize : 0)))
-        : (isLeft ? 1 : -1) * tickSign * (tickLength + tickLabelOffset),
-    };
+    const labelTransform = getLabelTransform({
+      tickLength,
+      labelComponent,
+      labelOffset,
+      tickLabelFontSize,
+      orientation,
+      range,
+    });
 
     return (
       <Group
@@ -85,7 +77,7 @@ export default function Axis({
         top={top}
         left={left}
       >
-        {React.cloneElement(labelComponent, labelProps)}
+        {labelComponent && React.cloneElement(labelComponent, labelTransform)}
         {values.map((val, i) => {
           if (hideZero && val === 0) return null;
 

--- a/packages/vx-axis/src/axis/Axis.js
+++ b/packages/vx-axis/src/axis/Axis.js
@@ -85,6 +85,7 @@ export default function Axis({
         top={top}
         left={left}
       >
+        {React.cloneElement(labelComponent, labelProps)}
         {values.map((val, i) => {
           if (hideZero && val === 0) return null;
 

--- a/packages/vx-axis/src/axis/AxisBottom.js
+++ b/packages/vx-axis/src/axis/AxisBottom.js
@@ -3,29 +3,30 @@ import cx from 'classnames';
 import Axis from './Axis';
 import ORIENT from '../constants/orientation';
 
-export default function AxisRight({
+export default function AxisBottom({
   scale,
   top,
   left,
   stroke,
   strokeWidth,
   strokeDasharray,
-  fontSize,
   label,
   numTicks,
   tickFormat,
   tickStroke,
-  tickK = 1,
   tickOffset,
   tickTransform,
   tickLength = 8,
-  tickPadding = 2,
-  tickTextAnchor = "middle",
-  tickTextFontFamily = "Arial",
-  tickTextFontSize = 10,
-  tickTextFill = 'black',
-  tickTextDy,
-  tickTextDx,
+  tickLabelPadding = 14,
+  tickLabelComponent = (
+    <text
+      textAnchor="middle"
+      fontFamily="Arial"
+      fontSize={10}
+      fill="black"
+      dy="0.25em"
+    />
+  ),
   hideAxisLine,
   hideTicks,
   hideZero,
@@ -34,28 +35,33 @@ export default function AxisRight({
   return (
     <Axis
       className={cx('vx-axis-bottom', className)}
-      orient={ORIENT.bottom}
+      orientation={ORIENT.bottom}
       top={top}
       left={left}
       scale={scale}
       stroke={stroke}
       strokeWidth={strokeWidth}
       strokeDasharray={strokeDasharray}
-      label={label}
+      labelComponent={
+        typeof label === 'string' ?
+        <text
+          textAnchor="middle"
+          fontFamily="Arial"
+          fontSize={10}
+          fill="black"
+        >
+          {label}
+        </text>
+        : label
+      }
       numTicks={numTicks}
-      tickK={tickK}
       tickFormat={tickFormat}
       tickLength={tickLength}
-      tickOffset={tickOffset || tickK * tickLength}
+      tickOffset={tickOffset || tickLength}
       tickTransform={tickTransform || `translate(${tickOffset || 0})`}
       tickStroke={tickStroke}
-      tickPadding={tickPadding}
-      tickTextDy={tickTextDy || tickLength + tickPadding + tickTextFontSize}
-      tickTextDx={tickTextDx || 0}
-      tickTextAnchor={tickTextAnchor}
-      tickTextFontFamily={tickTextFontFamily}
-      tickTextFontSize={tickTextFontSize}
-      tickTextFill={tickTextFill}
+      tickLabelPadding={tickLabelPadding}
+      tickLabelComponent={tickLabelComponent}
       hideAxisLine={hideAxisLine}
       hideTicks={hideTicks}
       hideZero={hideZero}

--- a/packages/vx-axis/src/axis/AxisBottom.js
+++ b/packages/vx-axis/src/axis/AxisBottom.js
@@ -14,10 +14,9 @@ export default function AxisBottom({
   numTicks,
   tickFormat,
   tickStroke,
-  tickOffset,
   tickTransform,
   tickLength = 8,
-  tickLabelPadding = 14,
+  tickLabelOffset = 8,
   tickLabelComponent = (
     <text
       textAnchor="middle"
@@ -57,10 +56,9 @@ export default function AxisBottom({
       numTicks={numTicks}
       tickFormat={tickFormat}
       tickLength={tickLength}
-      tickOffset={tickOffset || tickLength}
-      tickTransform={tickTransform || `translate(${tickOffset || 0})`}
+      tickTransform={tickTransform}
       tickStroke={tickStroke}
-      tickLabelPadding={tickLabelPadding}
+      tickLabelOffset={tickLabelOffset}
       tickLabelComponent={tickLabelComponent}
       hideAxisLine={hideAxisLine}
       hideTicks={hideTicks}

--- a/packages/vx-axis/src/axis/AxisBottom.js
+++ b/packages/vx-axis/src/axis/AxisBottom.js
@@ -11,12 +11,12 @@ export default function AxisBottom({
   strokeWidth,
   strokeDasharray,
   label,
+  labelOffset = 8,
   numTicks,
   tickFormat,
   tickStroke,
   tickTransform,
   tickLength = 8,
-  tickLabelOffset = 8,
   tickLabelComponent = (
     <text
       textAnchor="middle"
@@ -58,7 +58,7 @@ export default function AxisBottom({
       tickLength={tickLength}
       tickTransform={tickTransform}
       tickStroke={tickStroke}
-      tickLabelOffset={tickLabelOffset}
+      labelOffset={labelOffset}
       tickLabelComponent={tickLabelComponent}
       hideAxisLine={hideAxisLine}
       hideTicks={hideTicks}

--- a/packages/vx-axis/src/axis/AxisLeft.js
+++ b/packages/vx-axis/src/axis/AxisLeft.js
@@ -10,22 +10,24 @@ export default function AxisLeft({
   stroke,
   strokeWidth,
   strokeDasharray,
-  fontSize,
   label,
   numTicks,
   tickFormat,
   tickStroke,
-  tickK = -1,
   tickOffset,
   tickTransform,
   tickLength = 8,
-  tickPadding = 2,
-  tickTextAnchor = "end",
-  tickTextFontFamily = "Arial",
-  tickTextFontSize = 10,
-  tickTextFill = 'black',
-  tickTextDy,
-  tickTextDx,
+  tickLabelPadding = 30,
+  tickLabelComponent = (
+    <text
+      textAnchor="end"
+      fontFamily="Arial"
+      fontSize={10}
+      fill="black"
+      dx="-0.25em"
+      dy="0.25em"
+    />
+  ),
   hideAxisLine,
   hideTicks,
   hideZero,
@@ -34,28 +36,33 @@ export default function AxisLeft({
   return (
     <Axis
       className={cx('vx-axis-left', className)}
-      orient={ORIENT.left}
+      orientation={ORIENT.left}
       top={top}
       left={left}
       scale={scale}
       stroke={stroke}
       strokeWidth={strokeWidth}
       strokeDasharray={strokeDasharray}
-      label={label}
+      labelComponent={
+        typeof label === 'string' ?
+        <text
+          textAnchor="middle"
+          fontFamily="Arial"
+          fontSize={10}
+          fill="black"
+        >
+          {label}
+        </text>
+        : label
+      }
       numTicks={numTicks}
-      tickK={tickK}
       tickFormat={tickFormat}
       tickLength={tickLength}
-      tickOffset={tickOffset || tickK * tickLength}
-      tickTransform={tickTransform || `translate(${tickOffset || tickK * tickLength})`}
+      tickOffset={tickOffset || -1 * tickLength}
+      tickTransform={tickTransform || `translate(${tickOffset || -1 * tickLength})`}
       tickStroke={tickStroke}
-      tickPadding={tickPadding}
-      tickTextDy={tickTextDy || tickTextFontSize / 3}
-      tickTextDx={tickTextDx || tickK * tickPadding + tickK * (hideTicks ? tickPadding : tickLength)}
-      tickTextAnchor={tickTextAnchor}
-      tickTextFontFamily={tickTextFontFamily}
-      tickTextFontSize={tickTextFontSize}
-      tickTextFill={tickTextFill}
+      tickLabelPadding={tickLabelPadding}
+      tickLabelComponent={tickLabelComponent}
       hideAxisLine={hideAxisLine}
       hideTicks={hideTicks}
       hideZero={hideZero}

--- a/packages/vx-axis/src/axis/AxisLeft.js
+++ b/packages/vx-axis/src/axis/AxisLeft.js
@@ -14,10 +14,9 @@ export default function AxisLeft({
   numTicks,
   tickFormat,
   tickStroke,
-  tickOffset,
   tickTransform,
   tickLength = 8,
-  tickLabelPadding = 30,
+  tickLabelOffset = 36,
   tickLabelComponent = (
     <text
       textAnchor="end"
@@ -58,10 +57,9 @@ export default function AxisLeft({
       numTicks={numTicks}
       tickFormat={tickFormat}
       tickLength={tickLength}
-      tickOffset={tickOffset || -1 * tickLength}
-      tickTransform={tickTransform || `translate(${tickOffset || -1 * tickLength})`}
+      tickTransform={tickTransform}
       tickStroke={tickStroke}
-      tickLabelPadding={tickLabelPadding}
+      tickLabelOffset={tickLabelOffset}
       tickLabelComponent={tickLabelComponent}
       hideAxisLine={hideAxisLine}
       hideTicks={hideTicks}

--- a/packages/vx-axis/src/axis/AxisLeft.js
+++ b/packages/vx-axis/src/axis/AxisLeft.js
@@ -11,12 +11,12 @@ export default function AxisLeft({
   strokeWidth,
   strokeDasharray,
   label,
+  labelOffset = 36,
   numTicks,
   tickFormat,
   tickStroke,
   tickTransform,
   tickLength = 8,
-  tickLabelOffset = 36,
   tickLabelComponent = (
     <text
       textAnchor="end"
@@ -59,7 +59,7 @@ export default function AxisLeft({
       tickLength={tickLength}
       tickTransform={tickTransform}
       tickStroke={tickStroke}
-      tickLabelOffset={tickLabelOffset}
+      labelOffset={labelOffset}
       tickLabelComponent={tickLabelComponent}
       hideAxisLine={hideAxisLine}
       hideTicks={hideTicks}

--- a/packages/vx-axis/src/axis/AxisRight.js
+++ b/packages/vx-axis/src/axis/AxisRight.js
@@ -10,22 +10,24 @@ export default function AxisRight({
   stroke,
   strokeWidth,
   strokeDasharray,
-  fontSize,
   label,
   numTicks,
   tickFormat,
   tickStroke,
-  tickK = 1,
   tickOffset,
   tickTransform,
   tickLength = 8,
-  tickPadding = 2,
-  tickTextAnchor = "start",
-  tickTextFontFamily = "Arial",
-  tickTextFontSize = 10,
-  tickTextFill = 'black',
-  tickTextDy,
-  tickTextDx,
+  tickLabelPadding = 30,
+  tickLabelComponent = (
+    <text
+      textAnchor="start"
+      fontFamily="Arial"
+      fontSize={10}
+      fill="black"
+      dx="0.25em"
+      dy="0.25em"
+    />
+  ),
   hideAxisLine,
   hideTicks,
   hideZero,
@@ -34,28 +36,33 @@ export default function AxisRight({
   return (
     <Axis
       className={cx('vx-axis-right', className)}
-      orient={ORIENT.right}
+      orientation={ORIENT.right}
       top={top}
       left={left}
       scale={scale}
       stroke={stroke}
       strokeWidth={strokeWidth}
       strokeDasharray={strokeDasharray}
-      label={label}
+      labelComponent={
+        typeof label === 'string' ?
+        <text
+          textAnchor="start"
+          fontFamily="Arial"
+          fontSize={10}
+          fill="black"
+        >
+          {label}
+        </text>
+        : label
+      }
       numTicks={numTicks}
-      tickK={tickK}
       tickFormat={tickFormat}
       tickLength={tickLength}
-      tickOffset={tickOffset || tickK * tickLength}
+      tickOffset={tickOffset || tickLength}
       tickTransform={tickTransform || `translate(${tickOffset || 0})`}
       tickStroke={tickStroke}
-      tickPadding={tickPadding}
-      tickTextDy={tickTextDy || tickTextFontSize / 3}
-      tickTextDx={tickTextDx || tickK * tickPadding + tickK * (hideTicks ? tickPadding : tickLength)}
-      tickTextAnchor={tickTextAnchor}
-      tickTextFontFamily={tickTextFontFamily}
-      tickTextFontSize={tickTextFontSize}
-      tickTextFill={tickTextFill}
+      tickLabelPadding={tickLabelPadding}
+      tickLabelComponent={tickLabelComponent}
       hideAxisLine={hideAxisLine}
       hideTicks={hideTicks}
       hideZero={hideZero}

--- a/packages/vx-axis/src/axis/AxisRight.js
+++ b/packages/vx-axis/src/axis/AxisRight.js
@@ -14,10 +14,9 @@ export default function AxisRight({
   numTicks,
   tickFormat,
   tickStroke,
-  tickOffset,
   tickTransform,
   tickLength = 8,
-  tickLabelPadding = 30,
+  tickLabelOffset = 36,
   tickLabelComponent = (
     <text
       textAnchor="start"
@@ -58,10 +57,9 @@ export default function AxisRight({
       numTicks={numTicks}
       tickFormat={tickFormat}
       tickLength={tickLength}
-      tickOffset={tickOffset || tickLength}
-      tickTransform={tickTransform || `translate(${tickOffset || 0})`}
+      tickTransform={tickTransform}
       tickStroke={tickStroke}
-      tickLabelPadding={tickLabelPadding}
+      tickLabelOffset={tickLabelOffset}
       tickLabelComponent={tickLabelComponent}
       hideAxisLine={hideAxisLine}
       hideTicks={hideTicks}

--- a/packages/vx-axis/src/axis/AxisRight.js
+++ b/packages/vx-axis/src/axis/AxisRight.js
@@ -11,12 +11,12 @@ export default function AxisRight({
   strokeWidth,
   strokeDasharray,
   label,
+  labelOffset = 36,
   numTicks,
   tickFormat,
   tickStroke,
   tickTransform,
   tickLength = 8,
-  tickLabelOffset = 36,
   tickLabelComponent = (
     <text
       textAnchor="start"
@@ -59,7 +59,7 @@ export default function AxisRight({
       tickLength={tickLength}
       tickTransform={tickTransform}
       tickStroke={tickStroke}
-      tickLabelOffset={tickLabelOffset}
+      labelOffset={labelOffset}
       tickLabelComponent={tickLabelComponent}
       hideAxisLine={hideAxisLine}
       hideTicks={hideTicks}

--- a/packages/vx-axis/src/axis/AxisTop.js
+++ b/packages/vx-axis/src/axis/AxisTop.js
@@ -11,14 +11,12 @@ export default function AxisTop({
   strokeWidth,
   strokeDasharray,
   label,
-  fontSize,
   numTicks,
   tickFormat,
   tickStroke,
-  tickOffset,
   tickTransform,
   tickLength = 8,
-  tickLabelPadding = 14,
+  tickLabelOffset = 8,
   tickLabelComponent = (
     <text
       textAnchor="middle"
@@ -58,10 +56,9 @@ export default function AxisTop({
       numTicks={numTicks}
       tickFormat={tickFormat}
       tickLength={tickLength}
-      tickOffset={tickOffset || -1 * tickLength}
-      tickTransform={tickTransform || `translate(0, ${tickOffset || -1 * tickLength})`}
+      tickTransform={tickTransform}
       tickStroke={tickStroke}
-      tickLabelPadding={tickLabelPadding}
+      tickLabelOffset={tickLabelOffset}
       tickLabelComponent={tickLabelComponent}
       hideAxisLine={hideAxisLine}
       hideTicks={hideTicks}

--- a/packages/vx-axis/src/axis/AxisTop.js
+++ b/packages/vx-axis/src/axis/AxisTop.js
@@ -11,12 +11,12 @@ export default function AxisTop({
   strokeWidth,
   strokeDasharray,
   label,
+  labelOffset = 8,
   numTicks,
   tickFormat,
   tickStroke,
   tickTransform,
   tickLength = 8,
-  tickLabelOffset = 8,
   tickLabelComponent = (
     <text
       textAnchor="middle"
@@ -58,7 +58,7 @@ export default function AxisTop({
       tickLength={tickLength}
       tickTransform={tickTransform}
       tickStroke={tickStroke}
-      tickLabelOffset={tickLabelOffset}
+      labelOffset={labelOffset}
       tickLabelComponent={tickLabelComponent}
       hideAxisLine={hideAxisLine}
       hideTicks={hideTicks}

--- a/packages/vx-axis/src/axis/AxisTop.js
+++ b/packages/vx-axis/src/axis/AxisTop.js
@@ -15,17 +15,19 @@ export default function AxisTop({
   numTicks,
   tickFormat,
   tickStroke,
-  tickK = -1,
   tickOffset,
   tickTransform,
   tickLength = 8,
-  tickPadding = 2,
-  tickTextAnchor = "middle",
-  tickTextFontFamily = "Arial",
-  tickTextFontSize = 10,
-  tickTextFill = 'black',
-  tickTextDy,
-  tickTextDx,
+  tickLabelPadding = 14,
+  tickLabelComponent = (
+    <text
+      textAnchor="middle"
+      fontFamily="Arial"
+      fontSize={10}
+      fill="black"
+      dy="-0.25em"
+    />
+  ),
   hideAxisLine,
   hideTicks,
   hideZero,
@@ -34,28 +36,33 @@ export default function AxisTop({
   return (
     <Axis
       className={cx('vx-axis-top', className)}
-      orient={ORIENT.top}
+      orientation={ORIENT.top}
       top={top}
       left={left}
       scale={scale}
       stroke={stroke}
       strokeWidth={strokeWidth}
       strokeDasharray={strokeDasharray}
-      label={label}
+      labelComponent={
+        typeof label === 'string' ?
+        <text
+          textAnchor="middle"
+          fontFamily="Arial"
+          fontSize={10}
+          fill="black"
+        >
+          {label}
+        </text>
+        : label
+      }
       numTicks={numTicks}
-      tickK={tickK}
       tickFormat={tickFormat}
       tickLength={tickLength}
-      tickOffset={tickOffset || tickK * tickLength}
-      tickTransform={tickTransform || `translate(0, ${tickOffset || tickK * tickLength})`}
+      tickOffset={tickOffset || -1 * tickLength}
+      tickTransform={tickTransform || `translate(0, ${tickOffset || -1 * tickLength})`}
       tickStroke={tickStroke}
-      tickPadding={tickPadding}
-      tickTextDy={tickTextDy || tickK * tickPadding + tickK * (hideTicks ? tickPadding : tickLength)}
-      tickTextDx={tickTextDx || 0}
-      tickTextAnchor={tickTextAnchor}
-      tickTextFontFamily={tickTextFontFamily}
-      tickTextFontSize={tickTextFontSize}
-      tickTextFill={tickTextFill}
+      tickLabelPadding={tickLabelPadding}
+      tickLabelComponent={tickLabelComponent}
       hideAxisLine={hideAxisLine}
       hideTicks={hideTicks}
       hideZero={hideZero}

--- a/packages/vx-axis/src/utils/isHorizontal.js
+++ b/packages/vx-axis/src/utils/isHorizontal.js
@@ -1,5 +1,0 @@
-import ORIENTATION from '../constants/orientation';
-
-export default function isHorizontal(orient) {
-  return orient !== ORIENTATION.left && orient !== ORIENTATION.right;
-}

--- a/packages/vx-axis/src/utils/isLeft.js
+++ b/packages/vx-axis/src/utils/isLeft.js
@@ -1,5 +1,0 @@
-import ORIENTATION from '../constants/orientation';
-
-export default function isLeft(orient) {
-  return orient === ORIENTATION.left;
-}

--- a/packages/vx-axis/src/utils/labelTransform.js
+++ b/packages/vx-axis/src/utils/labelTransform.js
@@ -1,0 +1,27 @@
+import ORIENT from '../constants/orientation';
+
+export default function labelTransform({
+  tickLength,
+  labelOffset,
+  tickLabelFontSize,
+  labelComponent,
+  orientation,
+  range,
+}) {
+  if (!labelComponent || !labelComponent.props) return {};
+  const sign = orientation === ORIENT.left || orientation === ORIENT.top ? -1 : 1;
+  const { fontSize = 10 } = labelComponent.props;
+
+  let x, y, transform = null;
+  if (orientation === ORIENT.top || orientation === ORIENT.bottom) {
+    x = range[1] / 2;
+    y = sign * (tickLength + labelOffset + tickLabelFontSize +
+      (orientation === ORIENT.bottom ? fontSize : 0));
+  } else {
+    x = sign * (range[0] / 2);
+    y = -(tickLength + labelOffset);
+    transform = `rotate(${sign * 90})`;
+  }
+
+  return { x, y, transform };
+}

--- a/packages/vx-demo/components/tiles/axis.js
+++ b/packages/vx-demo/components/tiles/axis.js
@@ -107,19 +107,54 @@ export default ({
         scale={yScale}
         hideZero
         numTicks={numTicksForHeight(height)}
-        label={'value'}
-        stroke={'#1b1a1e'}
-        tickTextFill={'#8e205f'}
+        label={
+          <text
+            fill="#8e205f"
+            textAnchor="middle"
+            fontSize={10}
+            fontFamily="Arial"
+          >
+            value
+          </text>
+        }
+        stroke="#1b1a1e"
+        tickLabelComponent={
+          <text
+            fill="#8e205f"
+            textAnchor="end"
+            fontSize={10}
+            fontFamily="Arial"
+            dx="-0.25em"
+            dy="0.25em"
+          />
+        }
       />
       <AxisBottom
         top={height - margin.bottom}
         left={margin.left}
         scale={xScale}
         numTicks={numTicksForWidth(width)}
-        label={'time'}
+        label={
+          <text
+            fill="#8e205f"
+            textAnchor="middle"
+            fontSize={10}
+            fontFamily="Arial"
+          >
+            time
+          </text>
+        }
         stroke={'#1b1a1e'}
         tickStroke={'#1b1a1e'}
-        tickTextFill={'#8e205f'}
+        tickLabelComponent={
+          <text
+            fill="#8e205f"
+            textAnchor="middle"
+            fontSize={10}
+            fontFamily="Arial"
+            dy="0.25em"
+          />
+        }
       />
     </svg>
   );

--- a/packages/vx-demo/pages/axis.js
+++ b/packages/vx-demo/pages/axis.js
@@ -108,19 +108,54 @@ export default ({
         scale={yScale}
         hideZero
         numTicks={numTicksForHeight(height)}
-        label='value'
-        stroke='#1b1a1e'
-        tickTextFill='#8e205f'
+        label={
+          <text
+            fill="#8e205f"
+            textAnchor="middle"
+            fontSize={10}
+            fontFamily="Arial"
+          >
+            value
+          </text>
+        }
+        stroke="#1b1a1e"
+        tickLabelComponent={
+          <text
+            fill="#8e205f"
+            textAnchor="end"
+            fontSize={10}
+            fontFamily="Arial"
+            dx="-0.25em"
+            dy="0.25em"
+          />
+        }
       />
       <AxisBottom
         top={height - margin.bottom}
         left={margin.left}
         scale={xScale}
         numTicks={numTicksForWidth(width)}
-        label={'time'}
-        stroke='#1b1a1e'
-        tickStroke='#1b1a1e'
-        tickTextFill='#8e205f'
+        label={
+          <text
+            fill="#8e205f"
+            textAnchor="middle"
+            fontSize={10}
+            fontFamily="Arial"
+          >
+            time
+          </text>
+        }
+        stroke={'#1b1a1e'}
+        tickStroke={'#1b1a1e'}
+        tickLabelComponent={
+          <text
+            fill="#8e205f"
+            textAnchor="middle"
+            fontSize={10}
+            fontFamily="Arial"
+            dy="0.25em"
+          />
+        }
       />
     </svg>
   );

--- a/packages/vx-group/src/Group.js
+++ b/packages/vx-group/src/Group.js
@@ -4,13 +4,14 @@ import cx from 'classnames';
 export default function Group({
   top = 0,
   left = 0,
+  transform,
   className,
   children,
 }) {
   return (
     <g
       className={cx('cx-group', className)}
-      transform={`translate(${left}, ${top})`}
+      transform={transform || `translate(${left}, ${top})`}
     >
       {children}
     </g>


### PR DESCRIPTION
@hshoff see what you think of this. Because the number of props for the `Axis` components was getting unwieldy, this PR updates them to expect explicit label components to enable full control over their appearance (though simple tweaks like color now require more code as you can see in the `demo -> axis.js`).

I got rid of some props like `tickK` because it seemed like there was mixed logic for using the `tickK` that was passed in for some computations but still inferring orientation with the `ORIENTATION` symbol...which seemed like it could cause bugs with some combos. If users wanted to customize the `tickTransform` they can still do this.

Tested the params by customizing in all directions:

![image](https://cloud.githubusercontent.com/assets/4496521/26270771/a02934e8-3cb2-11e7-9252-9fa3d0eeafb1.png)
