### PR TITLE
Add script to compile Markdown into HTML docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "charts"
   ],
   "author": "@hshoff",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "cheerio": "^0.22.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,5 @@
     "charts"
   ],
   "author": "@hshoff",
-  "license": "MIT",
-  "dependencies": {
-    "cheerio": "^0.22.0"
-  }
+  "license": "MIT"
 }

--- a/packages/vx-demo/pages/docs.js
+++ b/packages/vx-demo/pages/docs.js
@@ -7,17 +7,16 @@ export default () => (
     <div className="page-left">
       <div className="comingsoon">
         <h1><a name="packages" />Packages</h1>
-        <code>// TODO: write docs</code>
       </div>
       <ul>
         <li>
-          @vx/annotation
+          <a href="/static/docs/vx-annotation.html"> @vx/annotation </a>
           <ul>
             <li>LinePath</li>
           </ul>
         </li>
         <li>
-          @vx/axis
+          <a href="/static/docs/vx-axis.html"> @vx/axis </a>
           <ul>
             <li>
               <strong>/axis</strong>
@@ -47,7 +46,7 @@ export default () => (
           </ul>
         </li>
         <li>
-          @vx/curve
+          <a href="/static/docs/vx-curve.html"> @vx/curve </a>
           <ul>
             <li>curveBasis</li>
             <li>curveBasisClose</li>
@@ -70,14 +69,14 @@ export default () => (
           </ul>
         </li>
         <li>
-          @vx/glyph
+          <a href="/static/docs/vx-glyph.html"> @vx/glyph </a>
           <ul>
             <li>GlyphDot</li>
             <li>Glyph</li>
           </ul>
         </li>
         <li>
-          @vx/grid
+          <a href="/static/docs/vx-grid.html"> @vx/grid </a>
           <ul>
             <li>Grid</li>
             <li>Columns</li>
@@ -85,19 +84,19 @@ export default () => (
           </ul>
         </li>
         <li>
-          @vx/group
+          <a href="/static/docs/vx-group.html"> @vx/group </a>
           <ul>
             <li>Group</li>
           </ul>
         </li>
         <li>
-          @vx/marker
+          <a href="/static/docs/vx-marker.html"> @vx/marker </a>
           <ul>
             <li>Marker</li>
           </ul>
         </li>
         <li>
-          @vx/mock-data
+          <a href="/static/docs/vx-mock-data.html"> @vx/mock-data </a>
           <ul>
             <li>
               <strong>/generators</strong>
@@ -117,7 +116,7 @@ export default () => (
           </ul>
         </li>
         <li>
-          @vx/pattern
+          <a href="/static/docs/vx-pattern.html"> @vx/pattern </a>
           <ul>
             <li>PatternCircles</li>
             <li>PatternHexagons</li>
@@ -129,13 +128,15 @@ export default () => (
           </ul>
         </li>
         <li>
-          @vx/point
+          <a href="/static/docs/vx-point.html">
+            @vx/point
+          </a>
           <ul>
             <li>Point</li>
           </ul>
         </li>
         <li>
-          @vx/responsive
+          <a href="/static/docs/vx-responsive.html"> @vx/responsive </a>
           <ul>
             <li>
               <strong>/components</strong>
@@ -152,7 +153,7 @@ export default () => (
           </ul>
         </li>
         <li>
-          @vx/scale
+          <a href="/static/docs/vx-scale.html"> @vx/scale </a>
           <ul>
             <li>scaleBand</li>
             <li>scalePoint</li>
@@ -163,7 +164,7 @@ export default () => (
           </ul>
         </li>
         <li>
-          @vx/shape
+          <a href="/static/docs/vx-shape.html"> @vx/shape </a>
           <ul>
             <li>AreaClosed</li>
             <li>AreaStack</li>
@@ -173,7 +174,7 @@ export default () => (
           </ul>
         </li>
         <li>
-          @vx/text
+          <a href="/static/docs/vx-text.html"> @vx/text </a>
           <ul>
             <li>TextBackground</li>
             <li>TextOutline</li>

--- a/packages/vx-demo/static/doc_styles.css
+++ b/packages/vx-demo/static/doc_styles.css
@@ -1,0 +1,8 @@
+body {
+  padding: 50px;
+  font: 15px/1.6 Helvetica, Arial, sans-serif;
+}
+
+img {
+  max-width: 100%;
+}

--- a/packages/vx-demo/static/docs/vx-annotation.html
+++ b/packages/vx-demo/static/docs/vx-annotation.html
@@ -1,0 +1,153 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    <h1 id="-vx-annotation">@vx/annotation</h1>
+<h2 id="linepathannotation">LinePathAnnotation</h2>
+<p>Line Path Annotations add a bit of text and a line coming from a point. They&#39;re useful for adding info to your graphs.</p>
+<pre><code class="lang-javascript">import { LinePathAnnotation } from &#39;@vx/annotation&#39;;
+// or
+// import * as Annotation from &#39;@vx/annotation&#39;; 
+// &lt;Annotation.LinePathAnnotation /&gt;
+
+const annotation = (
+  &lt;LinePathAnnotation
+    label={&#39;expected from deploy&#39;}
+    stroke={&#39;white&#39;}
+    labelFill={&#39;white&#39;}
+    labelStroke={&#39;none&#39;}
+    labelStrokeWidth={2}
+    points={[
+      annotationPoint,
+      new Point({
+        x: annotationPoint.x + (width / allData.length),
+        y: annotationPoint.y - (height / allData.length),
+      })
+    ]}
+  /&gt;
+);
+</code></pre>
+<p><img src="http://i.imgur.com/o5jnHFS.png" alt="image output"></p>
+<h1 id="properties">Properties</h1>
+<table>
+<thead>
+<tr>
+<th style="text-align:left">Name</th>
+<th style="text-align:left">Default</th>
+<th style="text-align:left">Type</th>
+<th style="text-align:left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left">top</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">Margin on top</td>
+</tr>
+<tr>
+<td style="text-align:left">left</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">Margin on left</td>
+</tr>
+<tr>
+<td style="text-align:left">points</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">array</td>
+<td style="text-align:left">Points describing the line path</td>
+</tr>
+<tr>
+<td style="text-align:left">stroke</td>
+<td style="text-align:left">black</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The color of the line</td>
+</tr>
+<tr>
+<td style="text-align:left">strokeWidth</td>
+<td style="text-align:left">1</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The pixel width of the line</td>
+</tr>
+<tr>
+<td style="text-align:left">className</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The class name associated of the LinePath shape</td>
+</tr>
+<tr>
+<td style="text-align:left">label</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The text for your label</td>
+</tr>
+<tr>
+<td style="text-align:left">labelAnchor</td>
+<td style="text-align:left">left</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The label&#39;s textAnchor</td>
+</tr>
+<tr>
+<td style="text-align:left">labelDx</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The x-coordinate shift to the label</td>
+</tr>
+<tr>
+<td style="text-align:left">labelDy</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The y-coordinate shift to the label</td>
+</tr>
+<tr>
+<td style="text-align:left">labelFill</td>
+<td style="text-align:left"><stroke></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The color of label. Defaults to the stroke color</td>
+</tr>
+<tr>
+<td style="text-align:left">labelFontSize</td>
+<td style="text-align:left">10</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The font size of the label text</td>
+</tr>
+<tr>
+<td style="text-align:left">labelStroke</td>
+<td style="text-align:left">white</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The color of the label</td>
+</tr>
+<tr>
+<td style="text-align:left">labelStrokeWidth</td>
+<td style="text-align:left">3</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The stroke width of the label text</td>
+</tr>
+<tr>
+<td style="text-align:left">labelPaintOrder</td>
+<td style="text-align:left">stroke</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The label&#39;s SVG <a href="https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/paint-order">paint-order</a>.</td>
+</tr>
+</tbody>
+</table>
+<h2 id="vx-packages">vx packages</h2>
+<ul>
+<li>@vx/annotation</li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-axis">@vx/axis</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-curve">@vx/curve</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-demo">@vx/demo</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-glyph">@vx/glyph</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-grid">@vx/grid</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-group">@vx/group</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-marker">@vx/marker</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-mock-data">@vx/mock-data</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-point">@vx/point</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-responsive">@vx/responsive</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-scale">@vx/scale</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-shape">@vx/shape</a></li>
+</ul>
+
+  </html>

--- a/packages/vx-demo/static/docs/vx-axis.html
+++ b/packages/vx-demo/static/docs/vx-axis.html
@@ -1,0 +1,31 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    <h1 id="-vx-axis">@vx/axis</h1>
+<ul>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-axis/src/axis/Axis.js"><code>&lt;Axis /&gt;</code></a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-axis/src/axis/AxisLeft.js"><code>&lt;AxisLeft /&gt;</code></a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-axis/src/axis/AxisBottom.js"><code>&lt;AxisBottom /&gt;</code></a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-axis/src/axis/AxisTop.js"><code>&lt;AxisTop /&gt;</code></a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-axis/src/axis/AxisRight.js"><code>&lt;AxisRight /&gt;</code></a></li>
+</ul>
+<h2 id="vx-packages">vx packages</h2>
+<ul>
+<li>@vx/axis</li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-curve">@vx/curve</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-demo">@vx/demo</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-glyph">@vx/glyph</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-grid">@vx/grid</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-group">@vx/group</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-marker">@vx/marker</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-mock-data">@vx/mock-data</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-point">@vx/point</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-responsive">@vx/responsive</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-scale">@vx/scale</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-shape">@vx/shape</a></li>
+</ul>
+
+  </html>

--- a/packages/vx-demo/static/docs/vx-brush.html
+++ b/packages/vx-demo/static/docs/vx-brush.html
@@ -1,0 +1,9 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    <h1 id="-vx-brush">@vx/brush</h1>
+
+  </html>

--- a/packages/vx-demo/static/docs/vx-curve.html
+++ b/packages/vx-demo/static/docs/vx-curve.html
@@ -1,0 +1,122 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    <h1 id="-vx-curve">@vx/curve</h1>
+<h2 id="overview">Overview</h2>
+<p>A curve is a function that can be passed into other vx objects, mainly a LinePath to change the way the line is structured.</p>
+<p>For example, checkout the difference between a <code>Curve.natural</code>:</p>
+<p><img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/natural.png" alt="natural curve"></p>
+<p>and a <code>Curve.step</code>:</p>
+<p><img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/step.png" alt="step curve"></p>
+<p>The <code>@vx/curve</code> package is a wrapper over <a href="https://github.com/d3/d3-shape">d3-shape</a> curve functions.</p>
+<p>Any function with the prefix <code>curve</code> in d3 can be used through <code>vx</code> like so:</p>
+<pre><code class="lang-javascript">import { curveCatmullRomOpen } from &#39;@vx/curve&#39;;
+let line = (&lt;Shape.LinePath curve={curveCatmullRomOpen} /&gt;)
+
+// or if you want namespace all Curves under the `Curve`
+import * as Curve from `@vx/curve`;
+let line = (&lt;Shape.LinePath curve={Curve.curveCatmullRomOpen} /&gt;)
+</code></pre>
+<h2 id="functions">Functions</h2>
+<table>
+<thead>
+<tr>
+<th>vx</th>
+<th>d3</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>curveBasis</td>
+<td><a href="https://github.com/d3/d3-shape#curveBasis">curveBasis</a></td>
+</tr>
+<tr>
+<td>curveBasisClose</td>
+<td><a href="https://github.com/d3/d3-shape#curveBasisClosed">curveBasisClosed</a></td>
+</tr>
+<tr>
+<td>curveBasisOpen</td>
+<td><a href="https://github.com/d3/d3-shape#curveBasisOpen">curveBasisOpen</a></td>
+</tr>
+<tr>
+<td>curveStep</td>
+<td><a href="https://github.com/d3/d3-shape#curveStep">curveStep</a></td>
+</tr>
+<tr>
+<td>curveStepAfter</td>
+<td><a href="https://github.com/d3/d3-shape#curveStepAfter">curveStepAfter</a></td>
+</tr>
+<tr>
+<td>curveStepBefore</td>
+<td><a href="https://github.com/d3/d3-shape#curveStepBefore">curveStepbefore</a></td>
+</tr>
+<tr>
+<td>curveBundle</td>
+<td><a href="https://github.com/d3/d3-shape#curveBundle">curveBundle</a></td>
+</tr>
+<tr>
+<td>curveLinear</td>
+<td><a href="https://github.com/d3/d3-shape#curveLinear">curveLinear</a></td>
+</tr>
+<tr>
+<td>curveLinearClosed</td>
+<td><a href="https://github.com/d3/d3-shape#curveLinearClosed">curveLinearClosed</a></td>
+</tr>
+<tr>
+<td>curveMonotoneX</td>
+<td><a href="https://github.com/d3/d3-shape#curveMonotoneX">curveMonotoneX</a></td>
+</tr>
+<tr>
+<td>curveMonotoneY</td>
+<td><a href="https://github.com/d3/d3-shape#curveMonotoneY">curveMonotoneY</a></td>
+</tr>
+<tr>
+<td>curveCardinal</td>
+<td><a href="https://github.com/d3/d3-shape#curveCardinal">curveCardinal</a></td>
+</tr>
+<tr>
+<td>curveCardinalClosed</td>
+<td><a href="https://github.com/d3/d3-shape#curveCardinalClosed">curveCardinalClosed</a></td>
+</tr>
+<tr>
+<td>curveCardinalOpen</td>
+<td><a href="https://github.com/d3/d3-shape#curveCardinalOpen">curveCardinalOpen</a></td>
+</tr>
+<tr>
+<td>curveCatmullRom</td>
+<td><a href="https://github.com/d3/d3-shape#curveCatmullRom">curveCatmullRom</a></td>
+</tr>
+<tr>
+<td>curveCatmullRomClosed</td>
+<td><a href="https://github.com/d3/d3-shape#curveCatmullRomClosed">curveCatmullRomClosed</a></td>
+</tr>
+<tr>
+<td>curveCatmullRomOpen</td>
+<td><a href="https://github.com/d3/d3-shape#curveCatmullRomOpen">curveCatmullRomOpen</a></td>
+</tr>
+<tr>
+<td>curveNatural</td>
+<td><a href="https://github.com/d3/d3-shape#curveNatural">curveNatural</a></td>
+</tr>
+</tbody>
+</table>
+<h2 id="vx-packages">vx packages</h2>
+<ul>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-axis">@vx/axis</a></li>
+<li>@vx/curve</li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-demo">@vx/demo</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-glyph">@vx/glyph</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-grid">@vx/grid</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-group">@vx/group</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-marker">@vx/marker</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-mock-data">@vx/mock-data</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-point">@vx/point</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-responsive">@vx/responsive</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-scale">@vx/scale</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-shape">@vx/shape</a></li>
+</ul>
+
+  </html>

--- a/packages/vx-demo/static/docs/vx-demo.html
+++ b/packages/vx-demo/static/docs/vx-demo.html
@@ -1,0 +1,29 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    <h1 id="-vx-demo">@vx/demo</h1>
+<ul>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-demo/src/demos/charts/SimpleAreaChart.js">Simple line chart</a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-demo/src/demos/charts/SimpleLineWithGlyphsChart.js">Simple line with glyphs chart</a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-demo/src/demos/charts/SimpleAreaChart.js">Simple area chart</a></li>
+</ul>
+<h2 id="vx-packages">vx packages</h2>
+<ul>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-axis">@vx/axis</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-curve">@vx/curve</a></li>
+<li>@vx/demo</li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-glyph">@vx/glyph</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-grid">@vx/grid</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-group">@vx/group</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-marker">@vx/marker</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-mock-data">@vx/mock-data</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-point">@vx/point</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-responsive">@vx/responsive</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-scale">@vx/scale</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-shape">@vx/shape</a></li>
+</ul>
+
+  </html>

--- a/packages/vx-demo/static/docs/vx-drag.html
+++ b/packages/vx-demo/static/docs/vx-drag.html
@@ -1,0 +1,8 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    
+  </html>

--- a/packages/vx-demo/static/docs/vx-event.html
+++ b/packages/vx-demo/static/docs/vx-event.html
@@ -1,0 +1,9 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    <h1 id="-vx-event">@vx/event</h1>
+
+  </html>

--- a/packages/vx-demo/static/docs/vx-glyph.html
+++ b/packages/vx-demo/static/docs/vx-glyph.html
@@ -1,0 +1,138 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    <h1 id="-vx-glyph">@vx/glyph</h1>
+<p>Glyphs are small icons that you can use in your graphs. Some elements, like <code>LinePath</code>, can take a function that returns a glyph.</p>
+<p>For example:</p>
+<pre><code class="lang-js">import { LinePath } from &#39;@vx/shape&#39;;
+import { GlyphDot } from &#39;@vx/glyph&#39;;
+
+let line = (
+  &lt;LinePath
+    ...
+    glyph={(d, i) =&gt; {
+      return (
+        &lt;GlyphDot
+          className={&quot;glyph-dots&quot;}
+          key={&#39;line-dot-{i}&#39;}
+          cx={xScale(x(d))}
+          cy={yScale(y(d))}
+          r={6}
+          fill={&quot;white&quot;}
+          stroke={&quot;black&quot;}
+          strokeWidth={3} /&gt;
+      )
+    }}
+  /&gt;
+)
+</code></pre>
+<p>You also can incorporate child elements into your glyph to add labels and such.</p>
+<pre><code class="lang-js">import { Dot } from &#39;@vx/glyph&#39;;
+
+&lt;GlyphDot ... &gt;
+  &lt;text
+    x={xScale(x(d))}
+    y={yScale(y(d))}
+    dx={10}
+    fill={&quot;white&quot;}
+    stroke={&quot;black&quot;}
+    strokeWidth={6}
+    fontSize={11}
+  &gt;
+    {&quot;Hi there!&quot;}
+  &lt;/text&gt;
+&lt;/GlyphDot&gt;
+</code></pre>
+<h2 id="-glyph-glyphdot-"><code>Glyph.GlyphDot</code></h2>
+<table>
+<thead>
+<tr>
+<th style="text-align:left">Name</th>
+<th style="text-align:left">Default</th>
+<th style="text-align:left">Type</th>
+<th style="text-align:left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left">top</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">Margin on top</td>
+</tr>
+<tr>
+<td style="text-align:left">left</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">Margin on left</td>
+</tr>
+<tr>
+<td style="text-align:left">className</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The class name associated of the LinePath shape</td>
+</tr>
+<tr>
+<td style="text-align:left">cx</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The x-axis coordinate at the center of the circle</td>
+</tr>
+<tr>
+<td style="text-align:left">cy</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The y-axis coordinate at the center of the circle</td>
+</tr>
+<tr>
+<td style="text-align:left">r</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The radius of the circle</td>
+</tr>
+<tr>
+<td style="text-align:left">fill</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The color of the circle&#39;s fill</td>
+</tr>
+<tr>
+<td style="text-align:left">stroke</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The color of the circle&#39;s stroke</td>
+</tr>
+<tr>
+<td style="text-align:left">strokeWidth</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The width of the circle&#39;s stroke</td>
+</tr>
+<tr>
+<td style="text-align:left">strokeDasharray</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">array</td>
+<td style="text-align:left">An array that controls the pattern of dashes in the stroke. <a href="https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray">See more here.</a></td>
+</tr>
+</tbody>
+</table>
+<h2 id="vx-packages">vx packages</h2>
+<ul>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-axis">@vx/axis</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-curve">@vx/curve</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-demo">@vx/demo</a></li>
+<li>@vx/glyph</li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-grid">@vx/grid</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-group">@vx/group</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-marker">@vx/marker</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-mock-data">@vx/mock-data</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-point">@vx/point</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-responsive">@vx/responsive</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-scale">@vx/scale</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-shape">@vx/shape</a></li>
+</ul>
+
+  </html>

--- a/packages/vx-demo/static/docs/vx-gradient.html
+++ b/packages/vx-demo/static/docs/vx-gradient.html
@@ -1,0 +1,73 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    <h1 id="-vx-gradient">@vx/gradient</h1>
+<p>Inspired by: <a href="https://dribbble.com/shots/3380672-Sketch-Gradients-Freebie">https://dribbble.com/shots/3380672-Sketch-Gradients-Freebie</a></p>
+<h2 id="example">Example</h2>
+<pre><code class="lang-js">import { AreaClose } from &#39;@vx/shape&#39;;
+import { GradientPinkBlue } from &#39;@vx/gradient&#39;;
+
+const GradientArea = () =&gt; {
+    return (
+      &lt;svg&gt;
+        &lt;GradientPinkBlue id=&quot;gradient&quot; /&gt;
+        &lt;AreaClose fill=&quot;url(&#39;#gradient&#39;)&quot; /&gt;
+      &lt;/svg&gt;
+    );
+}
+</code></pre>
+<h2 id="the-definition-caveat">The Definition Caveat</h2>
+<p>Like patterns, gradients are &quot;defined.&quot; When you put down a <code>&lt;PinkBlue /&gt;</code>, it&#39;s putting a <a href="https://developer.mozilla.org/en-US/docs/Web/SVG/Element/linearGradient"><code>&lt;linearGradient/&gt;</code></a> attribute inside a <code>&lt;def&gt;</code> in the SVG.</p>
+<p>It&#39;s often better to think of these as variable definitions rather than true DOM elements. When you use <code>fill=&quot;url(&#39;#gradient&#39;)&quot;</code> you&#39;re referencing the gradient&#39;s id: <code>gradient</code>.</p>
+<h2 id="premades">Premades</h2>
+<p>vx comes with a couple pre-made gradients for you to use.</p>
+<table>
+<thead>
+<tr>
+<th>Gradients Available</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>GradientDarkgreenGreen</code></td>
+</tr>
+<tr>
+<td><code>GradientLightgreenGreen</code></td>
+</tr>
+<tr>
+<td><code>GradientOrangeRed</code></td>
+</tr>
+<tr>
+<td><code>GradientPinkBlue</code></td>
+</tr>
+<tr>
+<td><code>GradientPinkRed</code></td>
+</tr>
+<tr>
+<td><code>GradientPurpleOrange</code></td>
+</tr>
+<tr>
+<td><code>GradientPurpleTeal</code></td>
+</tr>
+<tr>
+<td><code>GradientSteelPurple</code></td>
+</tr>
+<tr>
+<td><code>GradientTealBlue</code></td>
+</tr>
+</tbody>
+</table>
+<h2 id="make-your-own-">Make your own!</h2>
+<p>You can make any linear gradient like so:</p>
+<pre><code class="lang-js">import { LinearGradient } from &#39;@vx/gradient&#39;;
+
+&lt;LinearGradient
+  from=&#39;#a18cd1&#39;
+  to=&#39;#fbc2eb&#39;
+/&gt;
+</code></pre>
+
+  </html>

--- a/packages/vx-demo/static/docs/vx-grid.html
+++ b/packages/vx-demo/static/docs/vx-grid.html
@@ -1,0 +1,29 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    <h1 id="-vx-grid">@vx/grid</h1>
+<ul>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-grid/src/grids/Grid.js"><code>&lt;Grid /&gt;</code></a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-grid/src/grids/Rows.js"><code>&lt;Rows /&gt;</code></a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-grid/src/grids/Columns.js"><code>&lt;Columns /&gt;</code></a></li>
+</ul>
+<h2 id="vx-packages">vx packages</h2>
+<ul>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-axis">@vx/axis</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-curve">@vx/curve</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-demo">@vx/demo</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-glyph">@vx/glyph</a></li>
+<li>@vx/grid</li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-group">@vx/group</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-marker">@vx/marker</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-mock-data">@vx/mock-data</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-point">@vx/point</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-responsive">@vx/responsive</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-scale">@vx/scale</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-shape">@vx/shape</a></li>
+</ul>
+
+  </html>

--- a/packages/vx-demo/static/docs/vx-group.html
+++ b/packages/vx-demo/static/docs/vx-group.html
@@ -1,0 +1,68 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    <h1 id="-vx-group">@vx/group</h1>
+<p>A Group is a container for other objects. It lets you pass in a top and left margin and a classname.</p>
+<p>Example usage:</p>
+<pre><code class="lang-js">import { Group } from &#39;@vx/group&#39;;
+const myGroup = (
+  &lt;Group top={50} left={20}&gt;
+    /* Children here */
+  &lt;/Group&gt;
+)
+</code></pre>
+<h2 id="properties">Properties</h2>
+<table>
+<thead>
+<tr>
+<th style="text-align:left">Name</th>
+<th style="text-align:left">Default</th>
+<th style="text-align:left">Type</th>
+<th style="text-align:left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left">top</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">Margin on top</td>
+</tr>
+<tr>
+<td style="text-align:left">left</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">Margin on left</td>
+</tr>
+<tr>
+<td style="text-align:left">className</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The class name associated with the svg <code>g</code> element.</td>
+</tr>
+</tbody>
+</table>
+<h2 id="source-for-components">Source For Components</h2>
+<ul>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-group/src/index.js"><code>&lt;Group /&gt;</code></a></li>
+</ul>
+<h2 id="vx-packages">vx packages</h2>
+<ul>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-axis">@vx/axis</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-curve">@vx/curve</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-demo">@vx/demo</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-glyph">@vx/glyph</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-grid">@vx/grid</a></li>
+<li>@vx/group</li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-marker">@vx/marker</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-mock-data">@vx/mock-data</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-point">@vx/point</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-responsive">@vx/responsive</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-scale">@vx/scale</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-shape">@vx/shape</a></li>
+</ul>
+
+  </html>

--- a/packages/vx-demo/static/docs/vx-marker.html
+++ b/packages/vx-demo/static/docs/vx-marker.html
@@ -1,0 +1,168 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    <h1 id="-vx-marker">@vx/marker</h1>
+<p>A Marker is a line with a piece of text attached to it. It&#39;s great for highlighting locations in your graph.  </p>
+<h2 id="example">Example</h2>
+<p><img src="http://i.imgur.com/vbW3Ysa.png" alt="marker example"></p>
+<pre><code class="lang-js">&lt;Marker
+  from={markerFrom}
+  to={markerTo}
+  stroke={&#39;white&#39;}
+  label={&#39;deploy&#39;}
+  labelStroke={&#39;none&#39;}
+  labelDx={6}
+  labelDy={15}
+/&gt;
+</code></pre>
+<h2 id="properties">Properties</h2>
+<table>
+<thead>
+<tr>
+<th style="text-align:left">Name</th>
+<th style="text-align:left">Default</th>
+<th style="text-align:left">Type</th>
+<th style="text-align:left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left">top</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The margin on top.</td>
+</tr>
+<tr>
+<td style="text-align:left">left</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The margin on the left.</td>
+</tr>
+<tr>
+<td style="text-align:left">from</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">point</td>
+<td style="text-align:left">The start point for the line.</td>
+</tr>
+<tr>
+<td style="text-align:left">to</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">point</td>
+<td style="text-align:left">The end point for the line.</td>
+</tr>
+<tr>
+<td style="text-align:left">stroke</td>
+<td style="text-align:left">magenta</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The color of the stroke for the line.</td>
+</tr>
+<tr>
+<td style="text-align:left">strokeWidth</td>
+<td style="text-align:left">2</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The width of the stroke for the line.</td>
+</tr>
+<tr>
+<td style="text-align:left">strokeDasharray</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">array</td>
+<td style="text-align:left">The <a href="https://mzl.la/1l7EiTQ">pattern of dashes</a> in the stroke.</td>
+</tr>
+<tr>
+<td style="text-align:left">fill</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The color for the fill of the line.</td>
+</tr>
+<tr>
+<td style="text-align:left">transform</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">An <a href="https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform">SVG transform</a>.</td>
+</tr>
+<tr>
+<td style="text-align:left">label</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The text for the label.</td>
+</tr>
+<tr>
+<td style="text-align:left">labelAnchor</td>
+<td style="text-align:left">left</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The label&#39;s <code>textAnchor</code></td>
+</tr>
+<tr>
+<td style="text-align:left">labelDx</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The x-coordinate shift to the label.</td>
+</tr>
+<tr>
+<td style="text-align:left">labelDy</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The y-coordinate shift to the label.</td>
+</tr>
+<tr>
+<td style="text-align:left">labelFill</td>
+<td style="text-align:left"><stroke></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The fill color for the label.</td>
+</tr>
+<tr>
+<td style="text-align:left">labelFontSize</td>
+<td style="text-align:left">10</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The font size for the label text.</td>
+</tr>
+<tr>
+<td style="text-align:left">labelStroke</td>
+<td style="text-align:left">white</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The color for the label&#39;s stroke.</td>
+</tr>
+<tr>
+<td style="text-align:left">labelStrokeWidth</td>
+<td style="text-align:left">3</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The width of the label&#39;s stroke.</td>
+</tr>
+<tr>
+<td style="text-align:left">labelPaintOrder</td>
+<td style="text-align:left">stroke</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The label&#39;s SVG <a href="https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/paint-order">paint-order</a>.</td>
+</tr>
+<tr>
+<td style="text-align:left">className</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The class name for the line.</td>
+</tr>
+</tbody>
+</table>
+<h2 id="source-for-components">Source For Components</h2>
+<ul>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-marker/src/markers/Marker.js"><code>&lt;Marker /&gt;</code></a></li>
+</ul>
+<h2 id="vx-packages">vx packages</h2>
+<ul>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-axis">@vx/axis</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-curve">@vx/curve</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-demo">@vx/demo</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-glyph">@vx/glyph</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-grid">@vx/grid</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-group">@vx/group</a></li>
+<li>@vx/marker</li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-mock-data">@vx/mock-data</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-point">@vx/point</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-responsive">@vx/responsive</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-scale">@vx/scale</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-shape">@vx/shape</a></li>
+</ul>
+
+  </html>

--- a/packages/vx-demo/static/docs/vx-mock-data.html
+++ b/packages/vx-demo/static/docs/vx-mock-data.html
@@ -1,0 +1,165 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    <h1 id="-vx-mock-data">@vx/mock-data</h1>
+<p>The <code>@vx/mock-data</code> package is here to help you test out your graphs.</p>
+<h2 id="generators">Generators</h2>
+<p>Generators can create simple generic data for you like this:</p>
+<pre><code class="lang-js">import Mock from &#39;@vx/mock-data&#39;;
+const points = Mock.genRandomNormalPoints();
+</code></pre>
+<h3 id="-mock-genrandomnormalpoints-"><code>Mock.genRandomNormalPoints()</code></h3>
+<p>Returns a series of random normal x,y points.  </p>
+<h3 id="-mock-getdatevalue-n-"><code>Mock.getDateValue(n)</code></h3>
+<p>Generates <code>n</code> date values an hour apart from each other starting with the current time. </p>
+<h2 id="mocks">Mocks</h2>
+<p>Mock are essentially a bunch of data dumps that you can use like this:</p>
+<pre><code class="lang-js">import Mock from &#39;@vx/mock-data&#39;;
+const data = Mock.cityTemperature;
+</code></pre>
+<h3 id="-mock-applestock-"><code>Mock.appleStock</code></h3>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>date</td>
+</tr>
+<tr>
+<td>close</td>
+</tr>
+</tbody>
+</table>
+<h3 id="-mock-browserusage-"><code>Mock.browserUsage</code></h3>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>date</td>
+</tr>
+<tr>
+<td>Google Chrome</td>
+</tr>
+<tr>
+<td>Internet Explorer</td>
+</tr>
+<tr>
+<td>Firefox</td>
+</tr>
+<tr>
+<td>Safari</td>
+</tr>
+<tr>
+<td>Microsoft Edge</td>
+</tr>
+<tr>
+<td>Opera</td>
+</tr>
+<tr>
+<td>Mozilla</td>
+</tr>
+<tr>
+<td>Other/Unknown</td>
+</tr>
+</tbody>
+</table>
+<h3 id="-mock-citytemperature-"><code>Mock.cityTemperature</code></h3>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>date</td>
+</tr>
+<tr>
+<td>New York</td>
+</tr>
+<tr>
+<td>San Francisco</td>
+</tr>
+<tr>
+<td>Austin</td>
+</tr>
+</tbody>
+</table>
+<h3 id="-mock-groupdatevalue-"><code>Mock.groupDateValue</code></h3>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>date</td>
+</tr>
+<tr>
+<td>key</td>
+</tr>
+<tr>
+<td>value</td>
+</tr>
+</tbody>
+</table>
+<h3 id="-mock-letterfrequency-"><code>Mock.letterFrequency</code></h3>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>letter</td>
+</tr>
+<tr>
+<td>frequency</td>
+</tr>
+</tbody>
+</table>
+<h2 id="source-for-components">Source For Components</h2>
+<ul>
+<li>generators/<ul>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-mock-data/src/generators/genDateValue.js">genDateValue()</a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-mock-data/src/generators/genRandomNormalPoints.js">genRandomNormalPoints()</a></li>
+</ul>
+</li>
+<li>mocks/<ul>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-mock-data/src/mocks/appleStock.js">appleStock</a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-mock-data/src/mocks/browserUsage.js">browserUsage</a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-mock-data/src/mocks/cityTemperature.js">cityTemperature</a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-mock-data/src/mocks/groupDateValue.js">groupDateValue</a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-mock-data/src/mocks/letterFrequency.js">letterFrequency</a></li>
+</ul>
+</li>
+</ul>
+<h2 id="vx-packages">vx packages</h2>
+<ul>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-axis">@vx/axis</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-curve">@vx/curve</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-demo">@vx/demo</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-glyph">@vx/glyph</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-grid">@vx/grid</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-group">@vx/group</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-marker">@vx/marker</a></li>
+<li>@vx/mock-data</li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-point">@vx/point</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-responsive">@vx/responsive</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-scale">@vx/scale</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-shape">@vx/shape</a></li>
+</ul>
+
+  </html>

--- a/packages/vx-demo/static/docs/vx-pattern.html
+++ b/packages/vx-demo/static/docs/vx-pattern.html
@@ -1,0 +1,84 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    <h1 id="-vx-pattern">@vx/pattern</h1>
+<p>Inspired by: <a href="http://riccardoscalco.github.io/textures/">http://riccardoscalco.github.io/textures/</a></p>
+<h2 id="example">Example</h2>
+<pre><code class="lang-js">import { AreaClose } from &#39;@vx/shape&#39;;
+import { PatternLines } from &#39;@vx/pattern&#39;;
+
+const PatternArea = () =&gt; {
+    return (
+      &lt;svg&gt;
+        &lt;PatternLines
+          id=&quot;lines&quot;
+          height={5}
+          width={5}
+          stroke={&#39;black&#39;}
+          strokeWidth={1}
+          orientation={[&#39;diagonal&#39;]}
+        /&gt;
+        &lt;AreaClose fill=&quot;url(&#39;#lines&#39;)&quot; /&gt;
+      &lt;/svg&gt;
+    );
+};
+</code></pre>
+<h2 id="the-definition-caveat">The Definition Caveat</h2>
+<p>Like gradients, patterns are &quot;defined.&quot; When you put down a <code>&lt;PatternXYZ /&gt;</code>, it&#39;s putting a <a href="https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Patterns"><code>&lt;pattern/&gt;</code></a> attribute in the SVG.</p>
+<p>It&#39;s often better to think of these as variable definitions rather than true DOM elements. When you use <code>fill=&quot;url(&#39;#pattern&#39;)&quot;</code> you&#39;re referencing the pattern&#39;s id: <code>pattern</code>.</p>
+<h2 id="pre-made-patterns">Pre-Made Patterns</h2>
+<h3 id="-patternscircles-"><code>PatternsCircles</code></h3>
+<p><img src="http://i.imgur.com/jd9YGJi.png" alt="circles example"></p>
+<pre><code class="lang-js">&lt;PatternCircles
+  id=&quot;circles&quot;
+  height={6}
+  width={6}
+  stroke={&#39;black&#39;}
+  strokeWidth={1}
+/&gt;
+</code></pre>
+<h3 id="-patternshexagons-"><code>PatternsHexagons</code></h3>
+<p><img src="http://i.imgur.com/3EL1Lza.png" alt="hexagon example"></p>
+<pre><code class="lang-js">&lt;PatternHexagons
+  id=&quot;hexagons&quot;
+  height={3}
+  size={8}
+  stroke={&#39;red&#39;}
+  strokeWidth={1}
+/&gt;
+</code></pre>
+<h3 id="-patternslines-"><code>PatternsLines</code></h3>
+<p><img src="http://i.imgur.com/E3cTmLZ.png" alt="lines example"></p>
+<pre><code class="lang-js">&lt;PatternLines
+  id=&quot;lines&quot;
+  height={5}
+  width={5}
+  stroke={&#39;black&#39;}
+  strokeWidth={1}
+  orientation={[&#39;diagonal&#39;]}
+/&gt;
+</code></pre>
+<h3 id="-patternswaves-"><code>PatternsWaves</code></h3>
+<p><img src="http://i.imgur.com/4fdwbhv.png" alt="waves example"></p>
+<pre><code class="lang-js">&lt;PatternWaves
+  id=&quot;waves&quot;
+  height={4}
+  width={4}
+  stroke={&#39;blue&#39;}
+  strokeWidth={1}
+/&gt;
+</code></pre>
+<h2 id="source-for-components">Source For Components</h2>
+<ul>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-pattern/src/patterns/Circles.js"><code>&lt;PatternCircles /&gt;</code></a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-pattern/src/patterns/Hexagons.js"><code>&lt;PatternHexagons /&gt;</code></a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-pattern/src/patterns/Lines.js"><code>&lt;PatternLines /&gt;</code></a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-pattern/src/patterns/Path.js"><code>&lt;PatternPath /&gt;</code></a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-pattern/src/patterns/Pattern.js"><code>&lt;PatternPattern /&gt;</code></a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-pattern/src/patterns/Waves.js"><code>&lt;PatternPath /&gt;</code></a></li>
+</ul>
+
+  </html>

--- a/packages/vx-demo/static/docs/vx-point.html
+++ b/packages/vx-demo/static/docs/vx-point.html
@@ -1,0 +1,37 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    <h1 id="-vx-point">@vx/point</h1>
+<p>A simple class to represent an x, y coordinate.</p>
+<h2 id="example-usage">Example Usage</h2>
+<pre><code class="lang-js">import { Point } from &#39;@vx/point&#39;;
+
+let point  = new Point({ x: 2, y: 3 });
+let {x, y} = point.value()   // Get the cords from the point
+let array  = point.toArray() // Convert point to array
+</code></pre>
+<h2 id="methods">Methods</h2>
+<h3 id="-point-value-"><code>point.value()</code></h3>
+<p>Returns an <code>{x, y}</code> object with the x and y coordinates.</p>
+<h3 id="-point-toarray-"><code>point.toArray()</code></h3>
+<p>Returns the coordinates as an array <code>[x, y]</code>.</p>
+<h2 id="vx-packages">vx packages</h2>
+<ul>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-axis">@vx/axis</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-curve">@vx/curve</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-demo">@vx/demo</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-glyph">@vx/glyph</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-grid">@vx/grid</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-group">@vx/group</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-marker">@vx/marker</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-mock-data">@vx/mock-data</a></li>
+<li>@vx/point</li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-responsive">@vx/responsive</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-scale">@vx/scale</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-shape">@vx/shape</a></li>
+</ul>
+
+  </html>

--- a/packages/vx-demo/static/docs/vx-responsive.html
+++ b/packages/vx-demo/static/docs/vx-responsive.html
@@ -1,0 +1,24 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    <h1 id="-vx-responsive">@vx/responsive</h1>
+<h2 id="vx-packages">vx packages</h2>
+<ul>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-axis">@vx/axis</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-curve">@vx/curve</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-demo">@vx/demo</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-glyph">@vx/glyph</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-grid">@vx/grid</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-group">@vx/group</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-marker">@vx/marker</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-mock-data">@vx/mock-data</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-point">@vx/point</a></li>
+<li>@vx/responsive</li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-scale">@vx/scale</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-shape">@vx/shape</a></li>
+</ul>
+
+  </html>

--- a/packages/vx-demo/static/docs/vx-scale.html
+++ b/packages/vx-demo/static/docs/vx-scale.html
@@ -1,0 +1,156 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    <h1 id="-vx-scale">@vx/scale</h1>
+<h2 id="overview-of-scaling">Overview of Scaling</h2>
+<p>The <code>@vx/scale</code> package aims to provide a wrapper around existing d3 scaling originally defined in the <a href="https://github.com/d3/d3-scale">d3-scale</a> package.</p>
+<p>Scales are functions that help you map your data to the physical pixel size that your graph requires. For example, let&#39;s say you wanted to create a bar chart to show populations per country. If you were to use a 1-to-1 scale (IE: 1 pixel per y value) your bar for the USA would be about 321.4 million pixels high!</p>
+<p>Instead, you can tell vx a function to use that takes a value (like your population per country) and spits out another value.</p>
+<p>For example, we could create a linear scale like this:</p>
+<pre><code class="lang-javascript">const graphHeight = 500; // We&#39;ll have a 500 pixel high graph
+const maxPopulation = getMostPopulatedCountryInTheWorld();
+
+const yScale = Scale.scaleLinear({
+  rangeRound: [graphHeight, 0],
+  domain: [0, maxPopulation],
+});
+
+// ...
+
+const bars = data.map((d, i) =&gt; {
+  const barHeight = graphHeight - yScale(d.y);
+  return &lt;Shape.Bar height={barHeight} y={graphHeight - barHeight} /&gt;
+})
+</code></pre>
+<p><strong>Note:</strong> This example represents how to use a yScale, but skipped a lot of details about how to make a bar chart. If you&#39;re trying to do that, you should check out <a href="https://github.com/hshoff/vx/blob/master/packages/vx-demo/components/charts/SimpleBar.js">this example</a>.</p>
+<h2 id="current-scaling-options">Current Scaling Options</h2>
+<h3 id="color-scaling">Color Scaling</h3>
+<p>Color scales convert a point to a series of colors. D3 comes with a number of schemes that you can use just like any other scale.</p>
+<p><a href="https://github.com/d3/d3-scale/blob/master/README.md#schemeCategory10">Original d3 docs with colors</a></p>
+<h4 id="scale-10-colors">Scale 10 colors</h4>
+<p><img src="https://raw.githubusercontent.com/d3/d3-scale/master/img/category10.png" alt="scale10 colors"></p>
+<h4 id="scale-20-colors">Scale 20 colors</h4>
+<p><img src="https://raw.githubusercontent.com/d3/d3-scale/master/img/category20.png" alt="scale20 colors"></p>
+<h4 id="scale-20b-colors">Scale 20b colors</h4>
+<p><img src="https://raw.githubusercontent.com/d3/d3-scale/master/img/category20b.png" alt="scale20b colors"></p>
+<h4 id="scale-20c-colors">Scale 20c colors</h4>
+<p><img src="https://raw.githubusercontent.com/d3/d3-scale/master/img/category20c.png" alt="scale20c colors"></p>
+<p>Example:</p>
+<pre><code class="lang-javascript">const scale10 = Scale.schemeCategory10({ /* range, domain, unknown */})
+const scale20 = Scale.schemeCategory20({ /* range, domain, unknown */})
+const scale20b = Scale.schemeCategory20b({ /* range, domain, unknown */})
+const scale20c = Scale.schemeCategory20c({ /* range, domain, unknown */})
+</code></pre>
+<h3 id="band-scaling">Band Scaling</h3>
+<p><a href="https://github.com/d3/d3-scale/blob/master/README.md#_band">Original d3 docs</a></p>
+<p>Example:</p>
+<pre><code class="lang-javascript">const scale = Scale.scaleBand({
+  /*
+    range,
+    rangeRound,
+    domain,
+    padding,
+    nice = false
+  */
+});
+</code></pre>
+<h3 id="linear-scaling">Linear Scaling</h3>
+<p><a href="https://github.com/d3/d3-scale/blob/master/README.md#scaleLinear">Original d3 docs</a></p>
+<p>Example:</p>
+<pre><code class="lang-javascript">const scale = Scale.scaleLinear({
+  /*
+    range,
+    rangeRound,
+    domain,
+    nice = false,
+    clamp = false,
+  */
+});
+</code></pre>
+<h3 id="log-scaling">Log Scaling</h3>
+<p><a href="https://github.com/d3/d3-scale/blob/master/README.md#scaleLog">Original d3 docs</a></p>
+<p>Example:</p>
+<pre><code class="lang-javascript">const scale = Scale.scaleLog({
+  /*
+    range,
+    rangeRound,
+    domain,
+    base,
+    nice = false,
+    clamp = false,
+  */
+});
+</code></pre>
+<h3 id="ordinal-scaling">Ordinal Scaling</h3>
+<p><a href="https://github.com/d3/d3-scale/blob/master/README.md#scaleOrdinal">Original d3 docs</a></p>
+<p>Example:</p>
+<pre><code class="lang-javascript">const scale = Scale.scaleOrdinal({
+  /*
+    range,
+    domain,
+    unknown,
+  */
+});
+</code></pre>
+<h3 id="point-scaling">Point Scaling</h3>
+<p><a href="https://github.com/d3/d3-scale/blob/master/README.md#scalePoint">Original d3 docs</a></p>
+<p>Example:</p>
+<pre><code class="lang-javascript">const scale = Scale.scalePoint({
+  /*
+    range,
+    rangeRound,
+    domain,
+    padding,
+    align,
+    nice = false,
+  */
+});
+</code></pre>
+<h3 id="power-scaling">Power Scaling</h3>
+<p><a href="https://github.com/d3/d3-scale/blob/master/README.md#scalePow">Original d3 docs</a></p>
+<p>Example:</p>
+<pre><code class="lang-javascript">const scale = Scale.scalePower({
+  /*
+    range,
+    rangeRound,
+    domain,
+    base,
+    nice = false,
+    clamp = false,
+  */
+});
+</code></pre>
+<h3 id="time-scaling">Time Scaling</h3>
+<p><a href="https://github.com/d3/d3-scale/blob/master/README.md#scaleTime">Original d3 docs</a></p>
+<p>Example:</p>
+<pre><code class="lang-javascript">const scale = Scale.scaleTime({
+  /*
+    range,
+    rangeRound,
+    domain,
+    nice = false,
+    clamp = false,
+    scaleUtc = false,
+   */
+})
+</code></pre>
+<h2 id="vx-packages">vx packages</h2>
+<ul>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-axis">@vx/axis</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-curve">@vx/curve</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-demo">@vx/demo</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-glyph">@vx/glyph</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-grid">@vx/grid</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-group">@vx/group</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-marker">@vx/marker</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-mock-data">@vx/mock-data</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-point">@vx/point</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-responsive">@vx/responsive</a></li>
+<li>@vx/scale</li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-shape">@vx/shape</a></li>
+</ul>
+
+  </html>

--- a/packages/vx-demo/static/docs/vx-shape.html
+++ b/packages/vx-demo/static/docs/vx-shape.html
@@ -1,0 +1,549 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    <h1 id="-vx-shape">@vx/shape</h1>
+<p>Shapes are the core elements of vx. Most of what you see on the screen, like lines, bars, and areas are shapes.</p>
+<h2 id="-areaclosed-"><code>&lt;AreaClosed /&gt;</code></h2>
+<p>AreaClosed is a closed area under a curve.</p>
+<h3 id="example">Example</h3>
+<p><img src="http://i.imgur.com/hT0q8qx.png" alt="AreaClosed Example"></p>
+<pre><code class="lang-js">&lt;AreaClosed
+  data={myData}
+  xScale={myXScale}
+  yScale={myYScale}
+  x={myX}
+  y={myY}
+  strokeWidth={2}
+  stroke={&#39;url(#linear)&#39;}
+  fill={&#39;url(#linear)&#39;}
+/&gt;
+</code></pre>
+<h3 id="properties">Properties</h3>
+<table>
+<thead>
+<tr>
+<th style="text-align:left">Name</th>
+<th style="text-align:left">Default</th>
+<th style="text-align:left">Type</th>
+<th style="text-align:left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left">x</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">A function that takes in a data element and returns the x value.</td>
+</tr>
+<tr>
+<td style="text-align:left">y</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">A function that takes in a data element and returns the y value.</td>
+</tr>
+<tr>
+<td style="text-align:left">xScale</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">A <a href="https://github.com/hshoff/vx/tree/master/packages/vx-scale">scale function</a> for the xs.</td>
+</tr>
+<tr>
+<td style="text-align:left">yScale</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">A <a href="https://github.com/hshoff/vx/tree/master/packages/vx-scale">scale function</a> for the ys.</td>
+</tr>
+<tr>
+<td style="text-align:left">data</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">array</td>
+<td style="text-align:left">An array of x and y data.</td>
+</tr>
+<tr>
+<td style="text-align:left">defined</td>
+<td style="text-align:left"><code>d =&gt; y(d) &amp;&amp; x(d)</code></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">A <a href="https://github.com/d3/d3-shape/blob/master/README.md#area_defined">function</a> called by <code>area.defined()</code>.</td>
+</tr>
+<tr>
+<td style="text-align:left">className</td>
+<td style="text-align:left"><code>vx-area-closed</code></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The class name for the <code>path</code> element.</td>
+</tr>
+<tr>
+<td style="text-align:left">strokeDasharray</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">array</td>
+<td style="text-align:left">The <a href="https://mzl.la/1l7EiTQ">pattern of dashes</a> in the stroke.</td>
+</tr>
+<tr>
+<td style="text-align:left">strokeWidth</td>
+<td style="text-align:left">2</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The size of the stroke.</td>
+</tr>
+<tr>
+<td style="text-align:left">stroke</td>
+<td style="text-align:left">black</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The color of the stroke.</td>
+</tr>
+<tr>
+<td style="text-align:left">fill</td>
+<td style="text-align:left">rgba(0,0,0,0.3)</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The color of the fill.</td>
+</tr>
+<tr>
+<td style="text-align:left">curve</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">The <a href="https://github.com/hshoff/vx/tree/master/packages/vx-curve">curve function</a></td>
+</tr>
+</tbody>
+</table>
+<h2 id="-areastack-"><code>&lt;AreaStack /&gt;</code></h2>
+<p>An <code>&lt;AreaStack /&gt;</code> is used to represent several area&#39;s stacked on top of each other.</p>
+<h3 id="example">Example</h3>
+<p><img src="http://i.imgur.com/Gh930t7.png" alt="AreaStack Example"></p>
+<pre><code class="lang-js">&lt;AreaStack
+  reverse
+  top={margin.top}
+  left={margin.left}
+  keys={keys}
+  data={data}
+  x={(d) =&gt; xScale(x(d.data))}
+  y0={(d) =&gt; yScale(d[0] / 100)}
+  y1={(d) =&gt; yScale(d[1] / 100)}
+  stroke={(d,i) =&gt; colorScale(i)}
+  strokeWidth={1}
+  fillOpacity={(d,i) =&gt; selected.includes(browserNames[i]) ? 0.8 : 0.2}
+  fill={(d,i) =&gt; colorScale(i)}
+  onMouseEnter={(d, i) =&gt; event =&gt; {
+    updateSelected((prevState) =&gt; ([browserNames[i]]))
+  }}
+  onMouseLeave={(d,i) =&gt; event =&gt; {
+    updateSelected(prevState =&gt; {
+      if (prevState.includes(browserNames[i])) return [];
+      return prevState;
+    })
+  }}
+/&gt;
+</code></pre>
+<h3 id="properties">Properties</h3>
+<table>
+<thead>
+<tr>
+<th style="text-align:left">Name</th>
+<th style="text-align:left">Default</th>
+<th style="text-align:left">Type</th>
+<th style="text-align:left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left">className</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The class name for the <code>path</code> element.</td>
+</tr>
+<tr>
+<td style="text-align:left">top</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The margin on top.</td>
+</tr>
+<tr>
+<td style="text-align:left">left</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The margin on the left.</td>
+</tr>
+<tr>
+<td style="text-align:left">keys</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">array</td>
+<td style="text-align:left">Keys for the <a href="https://github.com/d3/d3-shape/blob/master/README.md#stack">d3.stack.</a></td>
+</tr>
+<tr>
+<td style="text-align:left">data</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">array</td>
+<td style="text-align:left">The data for each stack.</td>
+</tr>
+<tr>
+<td style="text-align:left">curve</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">The <a href="https://github.com/hshoff/vx/tree/master/packages/vx-curve">curve function</a></td>
+</tr>
+<tr>
+<td style="text-align:left">defined</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">A <a href="https://github.com/d3/d3-shape/blob/master/README.md#area_defined">function</a> called by <code>area.defined()</code>.</td>
+</tr>
+<tr>
+<td style="text-align:left">x</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">The d3 <a href="https://github.com/d3/d3-shape#area_x">x function.</a></td>
+</tr>
+<tr>
+<td style="text-align:left">x0</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">The d3 <a href="https://github.com/d3/d3-shape#area_x0">x0 function.</a></td>
+</tr>
+<tr>
+<td style="text-align:left">x1</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">The d3 <a href="https://github.com/d3/d3-shape#area_x1">x1 function.</a></td>
+</tr>
+<tr>
+<td style="text-align:left">y0</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">The d3 <a href="https://github.com/d3/d3-shape#area_y0">y0 function.</a></td>
+</tr>
+<tr>
+<td style="text-align:left">y1</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">The d3 <a href="https://github.com/d3/d3-shape#area_y1">y1 function.</a></td>
+</tr>
+<tr>
+<td style="text-align:left">glyph</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">glyph</td>
+<td style="text-align:left"><a href="https://github.com/hshoff/vx/tree/master/packages/vx-glyph">A glyph</a> to be added to the stack.</td>
+</tr>
+<tr>
+<td style="text-align:left">reverse</td>
+<td style="text-align:left">false</td>
+<td style="text-align:left">bool</td>
+<td style="text-align:left">If true, reverses the order of stacks.</td>
+</tr>
+</tbody>
+</table>
+<h2 id="-bar-"><code>&lt;Bar /&gt;</code></h2>
+<p>A simple rectangle (a <code>&lt;rect&gt;</code> element) to use in your graphs.</p>
+<h3 id="example">Example</h3>
+<p><img src="http://i.imgur.com/pvV9BJU.png" alt="bar example"></p>
+<pre><code class="lang-js">&lt;Bar
+  width={xScale.bandwidth()}
+  height={barHeight}
+  x={xScale(x(d))}
+  y={yMax - barHeight}
+  fill=&quot;url(&#39;#lines&#39;)&quot;
+  stroke={&#39;black&#39;}
+  strokeWidth={1}
+/&gt;
+</code></pre>
+<h3 id="properties">Properties</h3>
+<table>
+<thead>
+<tr>
+<th style="text-align:left">Name</th>
+<th style="text-align:left">Default</th>
+<th style="text-align:left">Type</th>
+<th style="text-align:left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left">className</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The class name for the <code>path</code> element.</td>
+</tr>
+<tr>
+<td style="text-align:left">x</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">A number or function for the x coordinate.</td>
+</tr>
+<tr>
+<td style="text-align:left">y</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">A number or function for the y coordinate.</td>
+</tr>
+<tr>
+<td style="text-align:left">width</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The pixel width of the bar.</td>
+</tr>
+<tr>
+<td style="text-align:left">height</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The pixel height of the bar.</td>
+</tr>
+<tr>
+<td style="text-align:left">rx</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The pixel value of the corner radius.</td>
+</tr>
+<tr>
+<td style="text-align:left">ry</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The pixel value of the corner radius.</td>
+</tr>
+<tr>
+<td style="text-align:left">fill</td>
+<td style="text-align:left">steelblue</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The color for the fill of the rect element.</td>
+</tr>
+<tr>
+<td style="text-align:left">fillOpacity</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The opacity for the fill of the rect element</td>
+</tr>
+<tr>
+<td style="text-align:left">stroke</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The color for the stroke of the rect element.</td>
+</tr>
+<tr>
+<td style="text-align:left">strokeWidth</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The pixel width of the stroke.</td>
+</tr>
+<tr>
+<td style="text-align:left">strokeDasharray</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">array</td>
+<td style="text-align:left">The <a href="https://mzl.la/1l7EiTQ">pattern of dashes</a> in the stroke.</td>
+</tr>
+<tr>
+<td style="text-align:left">strokeLinecap</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The svg <a href="https://mzl.la/2pM1786">linecap</a> of the stroke.</td>
+</tr>
+<tr>
+<td style="text-align:left">strokeLinejoin</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The svg <a href="https://mzl.la/2pzdxEB">linejoin</a> of the stroke.</td>
+</tr>
+<tr>
+<td style="text-align:left">strokeMiterlimit</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The svg <a href="https://mzl.la/2pLVE13">Miterlimit</a> of the stroke.</td>
+</tr>
+<tr>
+<td style="text-align:left">strokeOpacity</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The svg opacity.</td>
+</tr>
+</tbody>
+</table>
+<h2 id="-line-"><code>&lt;Line /&gt;</code></h2>
+<p>A simple line. Good for drawing in the sand.</p>
+<h3 id="example">Example</h3>
+<pre><code class="lang-js">&lt;Line
+  from={new Point({x:0, y:3})}
+  to={new Point({x:0, y:10})}
+/&gt;
+</code></pre>
+<h3 id="properties">Properties</h3>
+<table>
+<thead>
+<tr>
+<th style="text-align:left">Name</th>
+<th style="text-align:left">Default</th>
+<th style="text-align:left">Type</th>
+<th style="text-align:left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left">from</td>
+<td style="text-align:left">new Point({ x: 0 y: 0 })</td>
+<td style="text-align:left">Point</td>
+<td style="text-align:left">The beginning <a href="https://github.com/hshoff/vx/tree/master/packages/vx-point">point</a>.</td>
+</tr>
+<tr>
+<td style="text-align:left">to</td>
+<td style="text-align:left">new Point({ x: 1 y: 1 })</td>
+<td style="text-align:left">Point</td>
+<td style="text-align:left">The end <a href="https://github.com/hshoff/vx/tree/master/packages/vx-point">point</a>.</td>
+</tr>
+<tr>
+<td style="text-align:left">stroke</td>
+<td style="text-align:left">black</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The color of the stroke.</td>
+</tr>
+<tr>
+<td style="text-align:left">strokeWidth</td>
+<td style="text-align:left">1</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The pixel width of the stroke.</td>
+</tr>
+<tr>
+<td style="text-align:left">strokeDasharray</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">array</td>
+<td style="text-align:left">The <a href="https://mzl.la/1l7EiTQ">pattern of dashes</a> in the stroke.</td>
+</tr>
+<tr>
+<td style="text-align:left">transform</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">An <a href="https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform">SVG transform.</a></td>
+</tr>
+<tr>
+<td style="text-align:left">className</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The class name for the <code>line</code> element.</td>
+</tr>
+</tbody>
+</table>
+<h2 id="-linepath-"><code>&lt;LinePath /&gt;</code></h2>
+<p>A more complicated line path. A <code>&lt;LinePath /&gt;</code> is useful for making line graphs and drawing.</p>
+<h3 id="example">Example</h3>
+<p><img src="http://i.imgur.com/YoDZrGi.png" alt="Linepath example"></p>
+<pre><code class="lang-js">&lt;LinePath
+  data={dataset[1].data}
+  xScale={xScale}
+  yScale={yScale}
+  x={x}
+  y={y}
+  stroke={&quot;black&quot;}
+  strokeWidth={2}
+/&gt;
+</code></pre>
+<h3 id="properties">Properties</h3>
+<table>
+<thead>
+<tr>
+<th style="text-align:left">Name</th>
+<th style="text-align:left">Default</th>
+<th style="text-align:left">Type</th>
+<th style="text-align:left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left">data</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">array</td>
+<td style="text-align:left">The data in x, y.</td>
+</tr>
+<tr>
+<td style="text-align:left">xScale</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">A <a href="https://github.com/hshoff/vx/tree/master/packages/vx-scale">scale function</a> for the xs.</td>
+</tr>
+<tr>
+<td style="text-align:left">yScale</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">A <a href="https://github.com/hshoff/vx/tree/master/packages/vx-scale">scale function</a> for the ys.</td>
+</tr>
+<tr>
+<td style="text-align:left">x</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">A function that takes in a data element and returns the x value.</td>
+</tr>
+<tr>
+<td style="text-align:left">y</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">A function that takes in a data element and returns the y value.</td>
+</tr>
+<tr>
+<td style="text-align:left">defined</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">A <a href="https://github.com/d3/d3-shape/blob/master/README.md#line_defined">function</a> called by <code>line.defined()</code>.</td>
+</tr>
+<tr>
+<td style="text-align:left">className</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The class name for the <code>path</code> element.</td>
+</tr>
+<tr>
+<td style="text-align:left">stroke</td>
+<td style="text-align:left">steelblue</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The color of the stroke.</td>
+</tr>
+<tr>
+<td style="text-align:left">strokeWidth</td>
+<td style="text-align:left">2</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The pixel value for the stroke.</td>
+</tr>
+<tr>
+<td style="text-align:left">strokeDasharray</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">array</td>
+<td style="text-align:left">The <a href="https://mzl.la/1l7EiTQ">pattern of dashes</a> in the stroke.</td>
+</tr>
+<tr>
+<td style="text-align:left">fill</td>
+<td style="text-align:left">none</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The color of the fill for the <code>path</code> element.</td>
+</tr>
+<tr>
+<td style="text-align:left">curve</td>
+<td style="text-align:left">Curve.linear</td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">The <a href="https://github.com/hshoff/vx/tree/master/packages/vx-curve">curve function</a></td>
+</tr>
+<tr>
+<td style="text-align:left">glyph</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">glyph</td>
+<td style="text-align:left"><a href="https://github.com/hshoff/vx/tree/master/packages/vx-glyph">A glyph</a> to be added to the line.</td>
+</tr>
+</tbody>
+</table>
+<h2 id="sources-for-components">Sources For Components</h2>
+<ul>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/AreaClosed.js"><code>&lt;AreaClosed /&gt;</code></a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/AreaStack.js"><code>&lt;AreaStack /&gt;</code></a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/Bar.js"><code>&lt;Bar /&gt;</code></a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/Line.js"><code>&lt;Line /&gt;</code></a></li>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/LinePath.js"><code>&lt;LinePath /&gt;</code></a></li>
+</ul>
+<h2 id="vx-packages">vx packages</h2>
+<ul>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-axis">@vx/axis</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-curve">@vx/curve</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-demo">@vx/demo</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-glyph">@vx/glyph</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-grid">@vx/grid</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-group">@vx/group</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-marker">@vx/marker</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-mock-data">@vx/mock-data</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-point">@vx/point</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-responsive">@vx/responsive</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-scale">@vx/scale</a></li>
+<li>@vx/shape</li>
+</ul>
+
+  </html>

--- a/packages/vx-demo/static/docs/vx-text.html
+++ b/packages/vx-demo/static/docs/vx-text.html
@@ -1,0 +1,149 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    <h1 id="-vx-text">@vx/text</h1>
+<p>The <code>@vx/text</code> package contains components useful for adding labels to your graphs.</p>
+<h2 id="-textoutline-"><code>&lt;TextOutline /&gt;</code></h2>
+<p>TextOutline can add an outline around your text to help it be more readable.</p>
+<h2 id="example">Example</h2>
+<p><img src="http://i.imgur.com/mpbbNTn.png" alt="text outline picture"></p>
+<pre><code class="lang-js">import { TextOutline } from &#39;@vx/text&#39;;
+
+&lt;TextOutline
+  fontSize={10}
+  x={x}
+  y={y}
+  dy={&#39;.5em&#39;}
+  textAnchor={&#39;end&#39;}
+  fill=&quot;black&quot;
+  outlineStroke={&quot;white&quot;}
+  outlineStrokeWidth={3}
+  fontFamily={&quot;Roboto Mono&quot;}
+&gt;
+  {&quot;Woo text!&quot;}
+&lt;/TextOutline&gt;
+</code></pre>
+<h3 id="properties">Properties</h3>
+<table>
+<thead>
+<tr>
+<th style="text-align:left">Name</th>
+<th style="text-align:left">Default</th>
+<th style="text-align:left">Type</th>
+<th style="text-align:left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left">x</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The x coordinate position.</td>
+</tr>
+<tr>
+<td style="text-align:left">y</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The y coordinate position.</td>
+</tr>
+<tr>
+<td style="text-align:left">dx</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The x-offset.</td>
+</tr>
+<tr>
+<td style="text-align:left">dy</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The y-offset.</td>
+</tr>
+<tr>
+<td style="text-align:left">fontSize</td>
+<td style="text-align:left">12</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The fontSize for the text.</td>
+</tr>
+<tr>
+<td style="text-align:left">fontFamily</td>
+<td style="text-align:left">Arial</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The fontFamily for the text.</td>
+</tr>
+<tr>
+<td style="text-align:left">fill</td>
+<td style="text-align:left">white</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The fill color for the inner text.</td>
+</tr>
+<tr>
+<td style="text-align:left">stroke</td>
+<td style="text-align:left">none</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The stroke color for the inner text.</td>
+</tr>
+<tr>
+<td style="text-align:left">strokeWidth</td>
+<td style="text-align:left">0</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The strokeWidth for the inner text.</td>
+</tr>
+<tr>
+<td style="text-align:left">outlineFill</td>
+<td style="text-align:left">white</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The fill color for the outline.</td>
+</tr>
+<tr>
+<td style="text-align:left">outlineStroke</td>
+<td style="text-align:left">magenta</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The stroke color of the outline.</td>
+</tr>
+<tr>
+<td style="text-align:left">outlineStrokeWidth</td>
+<td style="text-align:left">3</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">The stroke width in pixels of the outline.</td>
+</tr>
+<tr>
+<td style="text-align:left">textAnchor</td>
+<td style="text-align:left">start</td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">The <a href="https://mzl.la/2pDkPXM">svg textAnchor</a> for the text.</td>
+</tr>
+<tr>
+<td style="text-align:left">className</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">string</td>
+<td style="text-align:left">A classname to be applied to both the inner and outer text.</td>
+</tr>
+</tbody>
+</table>
+<h2 id="source-for-components">Source For Components</h2>
+<ul>
+<li><a href="https://github.com/hshoff/vx/blob/master/packages/vx-text/src/text/TextOutline.js"><code>&lt;TextOutline /&gt;</code></a></li>
+<li>:warning: <a href="https://github.com/hshoff/vx/blob/master/packages/vx-text/src/text/TextWrap.js"><code>&lt;TextWrap /&gt;</code></a></li>
+</ul>
+<h2 id="vx-packages">vx packages</h2>
+<ul>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-annotation">@vx/annotation</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-axis">@vx/axis</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-curve">@vx/curve</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-demo">@vx/demo</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-glyph">@vx/glyph</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-grid">@vx/grid</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-group">@vx/group</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-marker">@vx/marker</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-mock-data">@vx/mock-data</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-point">@vx/point</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-responsive">@vx/responsive</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-scale">@vx/scale</a></li>
+<li><a href="https://github.com/hshoff/vx/tree/master/packages/vx-shape">@vx/shape</a></li>
+<li>@vx/text</li>
+</ul>
+
+  </html>

--- a/packages/vx-demo/static/docs/vx-zoom.html
+++ b/packages/vx-demo/static/docs/vx-zoom.html
@@ -1,0 +1,8 @@
+
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="../doc_styles.css">
+    </head>
+
+    
+  </html>

--- a/scripts/docs/README.md
+++ b/scripts/docs/README.md
@@ -1,0 +1,10 @@
+# Doc Generating Script
+
+This script takes the README's from each of the packages and converts them into HTML.
+
+## Usage
+
+From the root of the project.
+```
+node scripts/docs/index.js
+```

--- a/scripts/docs/constants.js
+++ b/scripts/docs/constants.js
@@ -1,0 +1,13 @@
+const DOCS = "packages/vx-demo/static/docs";
+const PACKAGES = "packages";
+const README = "README.md";
+const ASSETS = "assets";
+const CSS_PATH = "../doc_styles.css";
+
+module.exports = {
+  DOCS,
+  PACKAGES,
+  README,
+  ASSETS,
+  CSS_PATH,
+};

--- a/scripts/docs/index.js
+++ b/scripts/docs/index.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const jetpack = require('fs-jetpack'); // filesystem
+const marked = require('marked'); // markdown parser
+const {
+  DOCS,
+  PACKAGES,
+  README,
+  ASSETS,
+  CSS_PATH,
+} = require('./constants.js');
+
+// Stop someone from running the script from it's directory
+const ROOT = process.cwd();
+if (ROOT === __dirname) {
+  throw `Oops! It looks like you might not be running this from the project's
+  root directory.`;
+}
+
+/**
+ * Returns a fs-jetpack file pointer to the packages directory.
+ */
+function atPackagesDirectory() {
+  return jetpack.cwd(ROOT).dir(PACKAGES);
+}
+
+function atDocsDirectory() {
+  return jetpack.cwd(ROOT).dir(DOCS);
+}
+
+/**
+ * Returns the text of a README at a specific package
+ */
+function getReadmeText(pkg) {
+  const text = atPackagesDirectory().dir(pkg).read(README);
+  if (text) return text;
+  else return ''; // don't return "undefined"
+}
+
+/**
+ * From a package directory, get the html from the markdown
+ * @return {pkg, html}
+ */
+function getDocObject(dir) {
+  const markdown = getReadmeText(dir);
+  const html = marked(markdown);
+  const cleanedHTML = prepareHTML(html);
+  return {pkg: dir, html: cleanedHTML};
+}
+
+/**
+ * Wraps HTML content in a proper <html> and
+ * adds css.
+ */
+function prepareHTML(html) {
+  const cssPath = `../doc_styles.css`;
+
+  return `
+  <html>
+    <head>
+      <link rel="stylesheet" type="text/css" href="${cssPath}">
+    </head>
+
+    ${html}
+  </html>`;
+}
+
+function readDocs() {
+  const dirs = atPackagesDirectory().list(); // Get all the pkg directories
+
+  const docs = [];
+  for (let pkg of dirs) {
+    docs.push(getDocObject(pkg));
+  }
+
+  return docs;
+}
+
+function writeDocs(docs) {
+  const filePointer = atDocsDirectory();
+
+  for (let { pkg, html } of docs) {
+    const fileName = `${pkg}.html`;
+    filePointer.write(fileName, html);
+  }
+}
+
+const docs = readDocs();
+writeDocs(docs);

--- a/scripts/docs/package.json
+++ b/scripts/docs/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "docs",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "fs-jetpack": "^1.0.0",
+    "marked": "^0.3.6"
+  }
+}

--- a/scripts/docs/package.json
+++ b/scripts/docs/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "fs-jetpack": "^1.0.0",
     "marked": "^0.3.6"


### PR DESCRIPTION
- A script to compile Markdown to HTML docs -> Issue #9

This might not be exactly what you meant, but it might help get the docs onto the website for the moment. Let me know your thoughts, I'm not attached to anything in particular and can do something different if you'd like. 

# This PR adds 
- A new top-level folder `scripts`
- A script `docs` that compiles each package's README into an HTML doc with the same name inside a folder called `docs` inside `vx-demo`.
- Alters the `docs.js` file in `vx-demo` to link to each html page.

# Upsides
- It's really easy to make docs! Woo! `$ node scripts/docs/index.js`
- The docs are in the website immediately so they're easy for people who are interested in VX to view right now! :D 

# Downsides

## Static (not React)
The HTML docs are static individual files stored inside of the `static` folder (so mixing react and static stuff).

## No Links
The docs don't have individual links to other docs (or even back to the home page). 

--- 
# Next steps
A better way to do this would probably be to use something like [react-markdown](https://github.com/rexxars/react-markdown) to compile the markdown docs into react components. 