### PR TITLE
[Axis] add `rangePadding`

### DIFF
--- a/packages/vx-axis/src/axis/Axis.js
+++ b/packages/vx-axis/src/axis/Axis.js
@@ -13,6 +13,7 @@ export default function Axis({
   orientation,
   top = 0,
   left = 0,
+  rangePadding = 0,
   stroke = 'black',
   strokeWidth = 1,
   strokeDasharray,
@@ -41,8 +42,8 @@ export default function Axis({
     if (tickFormat) format = tickFormat;
 
     const range = scale.range();
-    const range0 = range[0] + 0.5;
-    const range1 = range[range.length - 1] + 0.5;
+    const range0 = range[0] + 0.5 - rangePadding;
+    const range1 = range[range.length - 1] + 0.5 + rangePadding;
 
     const horizontal = orientation !== ORIENT.left && orientation !== ORIENT.right;
     const isLeft = orientation === ORIENT.left;

--- a/packages/vx-axis/src/axis/AxisBottom.js
+++ b/packages/vx-axis/src/axis/AxisBottom.js
@@ -10,6 +10,7 @@ export default function AxisBottom({
   stroke,
   strokeWidth,
   strokeDasharray,
+  rangePadding,
   label,
   labelOffset = 8,
   numTicks,
@@ -41,6 +42,7 @@ export default function AxisBottom({
       stroke={stroke}
       strokeWidth={strokeWidth}
       strokeDasharray={strokeDasharray}
+      rangePadding={rangePadding}
       labelComponent={
         typeof label === 'string' ?
         <text

--- a/packages/vx-axis/src/axis/AxisLeft.js
+++ b/packages/vx-axis/src/axis/AxisLeft.js
@@ -10,6 +10,7 @@ export default function AxisLeft({
   stroke,
   strokeWidth,
   strokeDasharray,
+  rangePadding
   label,
   labelOffset = 36,
   numTicks,
@@ -42,6 +43,7 @@ export default function AxisLeft({
       stroke={stroke}
       strokeWidth={strokeWidth}
       strokeDasharray={strokeDasharray}
+      rangePadding={rangePadding}
       labelComponent={
         typeof label === 'string' ?
         <text

--- a/packages/vx-axis/src/axis/AxisLeft.js
+++ b/packages/vx-axis/src/axis/AxisLeft.js
@@ -10,7 +10,7 @@ export default function AxisLeft({
   stroke,
   strokeWidth,
   strokeDasharray,
-  rangePadding
+  rangePadding,
   label,
   labelOffset = 36,
   numTicks,

--- a/packages/vx-axis/src/axis/AxisRight.js
+++ b/packages/vx-axis/src/axis/AxisRight.js
@@ -47,7 +47,7 @@ export default function AxisRight({
       labelComponent={
         typeof label === 'string' ?
         <text
-          textAnchor="start"
+          textAnchor="middle"
           fontFamily="Arial"
           fontSize={10}
           fill="black"

--- a/packages/vx-axis/src/axis/AxisRight.js
+++ b/packages/vx-axis/src/axis/AxisRight.js
@@ -10,6 +10,7 @@ export default function AxisRight({
   stroke,
   strokeWidth,
   strokeDasharray,
+  rangePadding,
   label,
   labelOffset = 36,
   numTicks,
@@ -42,6 +43,7 @@ export default function AxisRight({
       stroke={stroke}
       strokeWidth={strokeWidth}
       strokeDasharray={strokeDasharray}
+      rangePadding={rangePadding}
       labelComponent={
         typeof label === 'string' ?
         <text

--- a/packages/vx-axis/src/axis/AxisTop.js
+++ b/packages/vx-axis/src/axis/AxisTop.js
@@ -10,6 +10,7 @@ export default function AxisTop({
   stroke,
   strokeWidth,
   strokeDasharray,
+  rangePadding,
   label,
   labelOffset = 8,
   numTicks,
@@ -41,6 +42,7 @@ export default function AxisTop({
       stroke={stroke}
       strokeWidth={strokeWidth}
       strokeDasharray={strokeDasharray}
+      rangePadding={rangePadding}
       labelComponent={
         typeof label === 'string' ?
         <text


### PR DESCRIPTION
@hshoff in working with bar charts that don't have band scales (e.g., for time), you have to compute the bar width manually and also the offset from the tick position (see [this discussion](https://stackoverflow.com/questions/18835053/d3-js-calculate-width-of-bars-in-time-scale-with-changing-range) on StackOverflow).

Even if you compute this width and offset the `x` position of the _bars_, the scale itself doesn't account for the offset so the `Axis` is missing padding that you get for free with band scales:

I tried a few different ways of doing this including overriding the `Axis` position function,  but I think simply padding the range is a reasonable way to approach it (e.g., VictoryCharts [supports a `domainPadding` prop](http://formidable.com/open-source/victory/docs/victory-chart/#domainpadding)). Let me know what you think.

No `rangePadding` / before:
![screen shot 2017-05-23 at 3 50 50 pm](https://cloud.githubusercontent.com/assets/4496521/26416947/7601ef08-406c-11e7-92ac-0c30cde24213.png)

with `rangePadding` = `barWidth / 2`:
![screen shot 2017-05-23 at 3 55 21 pm](https://cloud.githubusercontent.com/assets/4496521/26416967/90356f76-406c-11e7-93fe-ef48594aa120.png)

