### PR TITLE
[vx-responsive] add withParentSize enhancer

### DIFF
--- a/packages/vx-responsive/src/enhancers/withParentSize.js
+++ b/packages/vx-responsive/src/enhancers/withParentSize.js
@@ -40,7 +40,7 @@ export default function withParentSize(BaseComponent) {
       const { parentWidth, parentHeight } = this.state;
       return (
         <div
-          style={{ width: '100%', height: '100%', background: 'LightYellow' }}
+          style={{ width: '100%', height: '100%' }}
           ref={(ref) => { this.container = ref; }}
         >
           {parentWidth !== null && parentHeight !== null &&

--- a/packages/vx-responsive/src/enhancers/withParentSize.js
+++ b/packages/vx-responsive/src/enhancers/withParentSize.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import debounce from 'lodash.debounce';
+
+export default function withParentSize(BaseComponent) {
+  class WrappedComponent extends React.Component {
+    constructor(props) {
+      super(props);
+
+      this.state = {
+        parentWidth: null,
+        parentHeight: null,
+      }
+
+      this.handleResize = debounce(
+        this.resize.bind(this),
+        props.windowResizeDebounceTime
+      ).bind(this);
+    }
+
+    componentDidMount() {
+      window.addEventListener('resize', this.handleResize, false);
+      this.resize();
+    }
+
+    componentWillUnmount() {
+      window.removeEventListener('resize', this.handleResize, false);
+    }
+
+    resize(event) {
+      if (this.container) {
+        var boundingRect = this.container.getBoundingClientRect();
+        this.setState((prevState, props) => ({
+          parentWidth: boundingRect.width,
+          parentHeight: boundingRect.height,
+        }));
+      }
+    }
+
+    render() {
+      const { parentWidth, parentHeight } = this.state;
+      return (
+        <div
+          style={{ width: '100%', height: '100%', background: 'LightYellow' }}
+          ref={(ref) => { this.container = ref; }}
+        >
+          {parentWidth !== null && parentHeight !== null &&
+            <BaseComponent
+              parentWidth={parentWidth}
+              parentHeight={parentHeight}
+              {...this.props}
+            />}
+        </div>
+      );
+    }
+  }
+
+  WrappedComponent.defaultProps = {
+    windowResizeDebounceTime: 300,
+  };
+
+  return WrappedComponent;
+}

--- a/packages/vx-responsive/src/index.js
+++ b/packages/vx-responsive/src/index.js
@@ -1,2 +1,3 @@
 export { default as ScaleSVG } from './components/ScaleSVG';
+export { default as withParentSize } from './enhancers/withParentSize';
 export { default as withScreenSize } from './enhancers/withScreenSize';

--- a/packages/vx-responsive/test/withParentSize.test.js
+++ b/packages/vx-responsive/test/withParentSize.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { withParentSize } from '../src';
+
+describe('withParentSize', () => {
+  beforeAll(() => { // mock getBoundingClientRect
+    Element.prototype.getBoundingClientRect = jest.fn(() => ({
+      width: 220,
+      height: 120,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0,
+    }));
+  });
+
+  test('it should be defined', () => {
+    expect(withParentSize).toBeDefined();
+  });
+
+  test('it chould pass parentWidth and parentHeight props to its child', () => {
+    const Component = (props) => <div />;
+    const HOC = withParentSize(Component);
+    const wrapper = mount(<HOC />);
+    const RenderedComponent = wrapper.find(Component);
+    expect(Element.prototype.getBoundingClientRect).toHaveBeenCalled();
+    expect(RenderedComponent.prop('parentWidth')).toBe(220);
+    expect(RenderedComponent.prop('parentHeight')).toBe(120);
+  });
+})


### PR DESCRIPTION
This PR adds a new `withParentSize` enhancer to `vx-responsive` to allow a chart to get its parent size if `screenSize` doesn't suffice. Let me know if you think a different approach would be better.

Tested with `@data-ui/xy-chart` and with `jest`, yellow is the HOC's container:
![withparentsize](https://cloud.githubusercontent.com/assets/4496521/26652353/7e86ade2-4604-11e7-8815-3367da831156.gif)

```js
const ResponsiveXYChart = withParentSize(({ parentWidth, children, ...rest }) => (
  <XYChart
    theme={theme}
    width={parentWidth}
    height={parentWidth / 1.9}
    {...rest}
  >
    {children}
  </XYChart>
));
```