### PR TITLE
[Bug fix] Move `scaleUtc` into it's own function

### DIFF
--- a/packages/vx-scale/Readme.md
+++ b/packages/vx-scale/Readme.md
@@ -167,7 +167,6 @@ const scale = Scale.scaleTime({
     domain,
     nice = false,
     clamp = false,
-    scaleUtc = false,
    */
 })
 ```

--- a/packages/vx-scale/Readme.md
+++ b/packages/vx-scale/Readme.md
@@ -171,6 +171,8 @@ const scale = Scale.scaleTime({
 })
 ```
 
+
+
 ## vx packages
 
 - [@vx/axis](https://github.com/hshoff/vx/tree/master/packages/vx-axis)

--- a/packages/vx-scale/Readme.md
+++ b/packages/vx-scale/Readme.md
@@ -168,10 +168,23 @@ const scale = Scale.scaleTime({
     nice = false,
     clamp = false,
    */
-})
+});
 ```
 
+You also can scale time with Coordinated Universal Time via `scaleUtc`.
 
+Example:
+``` javascript
+const scale = Scale.scaleUtc({
+  /*
+    range,
+    rangeRound,
+    domain,
+    nice = false,
+    clamp = false,
+   */
+});
+```
 
 ## vx packages
 

--- a/packages/vx-scale/src/index.js
+++ b/packages/vx-scale/src/index.js
@@ -2,6 +2,7 @@ export { default as scaleBand } from './scales/band';
 export { default as scalePoint } from './scales/point';
 export { default as scaleLinear } from './scales/linear';
 export { default as scaleTime } from './scales/time';
+export { default as scaleUtc } from './scales/utc';
 export { default as scaleLog } from './scales/log';
 export { default as scalePower } from './scales/power';
 export { default as scaleOrdinal } from './scales/ordinal';

--- a/packages/vx-scale/src/scales/time.js
+++ b/packages/vx-scale/src/scales/time.js
@@ -6,7 +6,6 @@ export default ({
   domain,
   nice = false,
   clamp = false,
-  scaleUtc = false,
 }) => {
   const scale = scaleTime();
 
@@ -15,7 +14,6 @@ export default ({
   if (domain) scale.domain(domain);
   if (nice) scale.nice();
   if (clamp) scale.clamp(true);
-  if (scaleUtc) scale.scaleUtc();
 
   return scale;
 }

--- a/packages/vx-scale/src/scales/utc.js
+++ b/packages/vx-scale/src/scales/utc.js
@@ -1,0 +1,19 @@
+import { scaleUtc } from 'd3-scale';
+
+export default ({
+  range,
+  rangeRound,
+  domain,
+  nice = false,
+  clamp = false,
+}) => {
+  const scale = scaleUtc();
+
+  if (range) scale.range(range)
+  if (rangeRound) scale.rangeRound(rangeRound);
+  if (domain) scale.domain(domain);
+  if (nice) scale.nice();
+  if (clamp) scale.clamp(true);
+
+  return scale;
+}

--- a/packages/vx-scale/test/scaleUtc.test.js
+++ b/packages/vx-scale/test/scaleUtc.test.js
@@ -1,6 +1,6 @@
 import { scaleUtc } from '../src';
 
-describe('scaleTime', () => {
+describe('scaleUtc', () => {
   test('it should be defined', () => {
     expect(scaleUtc).toBeDefined()
   })

--- a/packages/vx-scale/test/scaleUtc.test.js
+++ b/packages/vx-scale/test/scaleUtc.test.js
@@ -1,0 +1,7 @@
+import { scaleUtc } from '../src';
+
+describe('scaleTime', () => {
+  test('it should be defined', () => {
+    expect(scaleUtc).toBeDefined()
+  })
+})


### PR DESCRIPTION

# What the bug was
Currently there's a bug where adding a `scaleUtc=true` to your `scaleTime` function will cause JS to crash:
``` js
// Crashes! 🚨🚨
scaleTime({
  scaleUtc=true, 
  ...
});
```

This was happening because the `time.js` file was calling `scale.scaleUtc();`, which isn't a function defined by d3. However, d3 does have a function called `scaleUtc` which works exactly like the `scaleTime` function but instead returns time vars in UTC format.  

# What this PR does
1. Removes the `scaleUtc` option from the `scaleTime` function in `vx-scale`.
2. Adds a new scale: `scaleUtc` to a `utc.js` file.
3. Updates readme to reflect changes.
4. Adds sanity test for` scaleUtc`.
