### PR TITLE
[axis] fix label transform

### DIFF
--- a/packages/vx-axis/src/utils/labelTransform.js
+++ b/packages/vx-axis/src/utils/labelTransform.js
@@ -14,11 +14,11 @@ export default function labelTransform({
 
   let x, y, transform = null;
   if (orientation === ORIENT.top || orientation === ORIENT.bottom) {
-    x = range[1] / 2;
+    x = Math.max(...range) / 2;
     y = sign * (tickLength + labelOffset + tickLabelFontSize +
       (orientation === ORIENT.bottom ? fontSize : 0));
   } else {
-    x = sign * (range[0] / 2);
+    x = sign * (Math.max(...range) / 2);
     y = -(tickLength + labelOffset);
     transform = `rotate(${sign * 90})`;
   }


### PR DESCRIPTION
This PR fixes a bug with the (y-axis) label transform logic. For y-axes you often have a pattern where you set the following domain and range to correct for the upper-right `(0,0)` svg coord:

```javascript
domain = [min val, max val];
range = [height, 0] 
// y-axis has `min val` at the bottom and `max val` at the top
```
If you want to have the min value at the _top_ of the scale you actually invert the range to `[0, height]`. The current y-label transform assumes the former and this PR fixes it.

Before:
![screen shot 2017-06-09 at 3 02 10 pm](https://user-images.githubusercontent.com/4496521/26996237-02a52388-4d26-11e7-91e5-14e8b20ca104.png)

After:
![screen shot 2017-06-09 at 3 04 05 pm](https://user-images.githubusercontent.com/4496521/26996240-055b7500-4d26-11e7-95cd-a6a02563b04e.png)

Verified that current transforms still work as expected:
![screen shot 2017-06-09 at 3 05 54 pm](https://user-images.githubusercontent.com/4496521/26996244-0c582fba-4d26-11e7-862e-c4021c4e370c.png)
![screen shot 2017-06-09 at 3 05 40 pm](https://user-images.githubusercontent.com/4496521/26996245-0c58f5a8-4d26-11e7-87e0-2e6aa2f76226.png)
