### PR TITLE
[Group] add restProps support

### DIFF
--- a/packages/vx-group/src/Group.js
+++ b/packages/vx-group/src/Group.js
@@ -7,11 +7,13 @@ export default function Group({
   transform,
   className,
   children,
+  ...restProps,
 }) {
   return (
     <g
       className={cx('cx-group', className)}
       transform={transform || `translate(${left}, ${top})`}
+      {...restProps}
     >
       {children}
     </g>

--- a/packages/vx-group/test/Group.test.js
+++ b/packages/vx-group/test/Group.test.js
@@ -4,18 +4,18 @@ import { Group } from '../src';
 
 describe('<Group />', () => {
   test('it should be defined', () => {
-    expect(Group).toBeDefined()
-  })
+    expect(Group).toBeDefined();
+  });
 
   test('it should have class=\'cx-group\'', () => {
-    const wrapper = shallow(<Group />)
-    expect(wrapper.prop('className')).toEqual('cx-group')
-  })
+    const wrapper = shallow(<Group />);
+    expect(wrapper.prop('className')).toEqual('cx-group');
+  });
 
   test('it should default props top=0 left=0', () => {
-    const wrapper = shallow(<Group />)
-    expect(wrapper.prop('transform')).toEqual('translate(0, 0)')
-  })
+    const wrapper = shallow(<Group />);
+    expect(wrapper.prop('transform')).toEqual('translate(0, 0)');
+  });
 
   test('it should set props top, left, className', () => {
     const wrapper = shallow(
@@ -24,8 +24,14 @@ describe('<Group />', () => {
         top={3}
         left={4}
       />
-    )
-    expect(wrapper.prop('transform')).toEqual('translate(4, 3)')
-    expect(wrapper.prop('className')).toEqual('cx-group test')
-  })
-})
+    );
+    expect(wrapper.prop('transform')).toEqual('translate(4, 3)');
+    expect(wrapper.prop('className')).toEqual('cx-group test');
+  });
+
+  test('it should set restProps', () => {
+    const wrapper = shallow(<Group clipPath="url(#myClip)" stroke="mapleSyrup" />);
+    expect(wrapper.prop('clipPath')).toEqual('url(#myClip)');
+    expect(wrapper.prop('stroke')).toEqual('mapleSyrup');
+  });
+});


### PR DESCRIPTION
This PR adds support for `...restProps` in `<Group />`. I've needed a couple of things like `clipPath` and [`<g>` elements support many other attributes](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/g) so this seems useful generally.

Tested with `jest`.