### PR TITLE
[ClipPath] add ClipPath package

### DIFF
--- a/packages/vx-clip-path/.babelrc
+++ b/packages/vx-clip-path/.babelrc
@@ -1,0 +1,19 @@
+{
+  "presets": ["es2015", "react", "stage-0"],
+  "plugins": [],
+  "env": {
+    "development": {
+      "plugins": [
+        ["react-transform", {
+          "transforms": [{
+            "transform": "react-transform-hmr",
+            "imports": ["react"],
+            "locals": ["module"]
+          }]
+        }],
+        "transform-runtime",
+        "transform-decorators-legacy"
+      ]
+    }
+  }
+}

--- a/packages/vx-clip-path/Makefile
+++ b/packages/vx-clip-path/Makefile
@@ -1,0 +1,1 @@
+include node_modules/react-fatigue-dev/Makefile

--- a/packages/vx-clip-path/package.json
+++ b/packages/vx-clip-path/package.json
@@ -23,7 +23,7 @@
     "charts",
     "svg"
   ],
-  "author": "@hshoff",
+  "author": "Chris Williams @williaster",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/hshoff/vx/issues"

--- a/packages/vx-clip-path/package.json
+++ b/packages/vx-clip-path/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@vx/clip-path",
+  "version": "0.0.0",
+  "description": "vx clip-path",
+  "main": "build/index.js",
+  "scripts": {
+    "build": "make build SRC=./src",
+    "prepublish": "make build SRC=./src",
+    "test": "jest"
+  },
+  "files": [
+    "build"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hshoff/vx.git"
+  },
+  "keywords": [
+    "vx",
+    "react",
+    "d3",
+    "visualizations",
+    "charts",
+    "svg"
+  ],
+  "author": "@hshoff",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/hshoff/vx/issues"
+  },
+  "homepage": "https://github.com/hshoff/vx#readme",
+  "devDependencies": {
+    "babel-jest": "^20.0.3",
+    "enzyme": "^2.8.2",
+    "jest": "^20.0.3",
+    "react-addons-test-utils": "15.4.2",
+    "react-fatigue-dev": "github:tj/react-fatigue-dev",
+    "react-tools": "^0.10.0",
+    "regenerator-runtime": "^0.10.5"
+  },
+  "dependencies": {
+    "react": "15.4.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/vx-clip-path/src/clip-paths/CircleClipPath.js
+++ b/packages/vx-clip-path/src/clip-paths/CircleClipPath.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import ClipPath from './ClipPath';
+
+export default ({
+  id,
+  cx,
+  cy,
+  r,
+  ...restProps,
+}) => (
+  <ClipPath id={id}>
+    <circle
+      cx={cx}
+      cy={cy}
+      r={r}
+      {...restProps}
+    />
+  </ClipPath>
+);
+

--- a/packages/vx-clip-path/src/clip-paths/ClipPath.js
+++ b/packages/vx-clip-path/src/clip-paths/ClipPath.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default ({
+  id,
+  children,
+  ...restProps
+}) => (
+  <defs>
+    <clipPath id={id} {...restProps}>
+      {children}
+    </clipPath>
+  </defs>
+);

--- a/packages/vx-clip-path/src/clip-paths/RectClipPath.js
+++ b/packages/vx-clip-path/src/clip-paths/RectClipPath.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import ClipPath from './ClipPath';
+
+export default ({
+  id,
+  x = 0,
+  y = 0,
+  width = 1,
+  height = 1,
+  ...restProps,
+}) => (
+  <ClipPath id={id}>
+    <rect
+      x={x}
+      y={y}
+      width={width}
+      height={height}
+      {...restProps}
+    />
+  </ClipPath>
+);

--- a/packages/vx-clip-path/src/index.js
+++ b/packages/vx-clip-path/src/index.js
@@ -1,0 +1,3 @@
+export { default as ClipPath } from './clip-paths/ClipPath';
+export { default as CircleClipPath } from './clip-paths/CircleClipPath';
+export { default as RectClipPath } from './clip-paths/RectClipPath';

--- a/packages/vx-clip-path/test/ClipPaths.test.js
+++ b/packages/vx-clip-path/test/ClipPaths.test.js
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import {
+  ClipPath,
+  CircleClipPath,
+  RectClipPath,
+} from '../src';
+
+import { shallow } from 'enzyme';
+
+describe('<ClipPath />', () => {
+  test('it should be defined', () => {
+    expect(ClipPath).toBeDefined();
+  });
+
+  test('it should render defs and clipPath elements', () => {
+    const wrapper = shallow(<ClipPath />);
+    expect(wrapper.type()).toBe('defs');
+    expect(wrapper.find('clipPath').length).toBe(1);
+  });
+
+  test('it should assign the passed id to the clipPath', () => {
+    const wrapper = shallow(<ClipPath id="best_clip"/>);
+    expect(wrapper.find('clipPath#best_clip').length).toBe(1);
+  });
+});
+
+describe('<RectClipPath />', () => {
+  test('it should be defined', () => {
+    expect(RectClipPath).toBeDefined();
+  });
+
+  test('it should render a rect', () => {
+    const wrapper = shallow(<RectClipPath />);
+    expect(wrapper.find('rect').length).toBe(1);
+  });
+});
+
+describe('<CircleClipPath />', () => {
+  test('it should be defined', () => {
+    expect(CircleClipPath).toBeDefined();
+  });
+
+  test('it should render a circle', () => {
+    const wrapper = shallow(<CircleClipPath />);
+    expect(wrapper.find('circle').length).toBe(1);
+  });
+});


### PR DESCRIPTION
Let me know what you think about the utility of something like this. I think it's less useful than the `Gradients` package but on par with the `Group` package esp since it gets around creating the `<defs>` etc.

Before:
![no-clip](https://user-images.githubusercontent.com/4496521/26998155-57213d3e-4d35-11e7-8120-f7d7137b0972.gif)

After with `<RectClipPath id="clip"width={innerWidth} height={innerHeight} />`:
![with-clip](https://user-images.githubusercontent.com/4496521/26998150-4e2667cc-4d35-11e7-92c7-193899f0274a.gif)
