### PR TITLE
add strokeDashoffset prop to LinePath

### DIFF
--- a/packages/vx-shape/src/shapes/LinePath.js
+++ b/packages/vx-shape/src/shapes/LinePath.js
@@ -14,6 +14,7 @@ export default function LinePath({
   stroke = 'steelblue',
   strokeWidth = 2,
   strokeDasharray = '',
+  strokeDashoffset = 0,
   fill = 'none',
   curve = curveLinear,
   glyph,
@@ -31,6 +32,7 @@ export default function LinePath({
         stroke={stroke}
         strokeWidth={strokeWidth}
         strokeDasharray={strokeDasharray}
+        strokeDashoffset={strokeDashoffset}
         fill={fill}
       />
       {glyph &&


### PR DESCRIPTION
This PR adds `strokeDashoffset` prop to `LinePath` component which is helpful for transitions.