### PR TITLE
Get min range for area chart baseline

### DIFF
--- a/packages/vx-shape/src/shapes/AreaClosed.js
+++ b/packages/vx-shape/src/shapes/AreaClosed.js
@@ -19,7 +19,7 @@ export default function AreaClosed({
 }) {
   const path = area()
     .x(d => xScale(x(d)))
-    .y0(yScale(yScale.domain()[0]))
+    .y0(yScale.range()[0])
     .y1(d => yScale(y(d)))
     .defined(defined || (d => y(d) && x(d)));
   if (curve) path.curve(curve);

--- a/packages/vx-shape/src/shapes/AreaClosed.js
+++ b/packages/vx-shape/src/shapes/AreaClosed.js
@@ -19,7 +19,7 @@ export default function AreaClosed({
 }) {
   const path = area()
     .x(d => xScale(x(d)))
-    .y0(yScale(0))
+    .y0(yScale(yScale.domain()[0]))
     .y1(d => yScale(y(d)))
     .defined(defined || (d => y(d) && x(d)));
   if (curve) path.curve(curve);


### PR DESCRIPTION
If range of scale does not start at 0, chart would extend beyond bounds of the scale when yScale(0) is used. This fixes it by taking first element of scales range (which should be the lowest y point on screen)

I was not able to test the code, trying to run tests resulted in lots of errors across all packages. Also even if technically correct I am not sure if this does not brake something outside of my usecase.