### PR TITLE
[gradient] add horizontal linear gradients, make more flexible. fixes #68

### DIFF
--- a/packages/vx-demo/components/gallery.js
+++ b/packages/vx-demo/components/gallery.js
@@ -468,6 +468,9 @@ export default class Gallery extends React.Component {
               <div
                 className="gallery-item"
                 ref={d => this.nodes.add(d)}
+                style={{
+                  boxShadow: 'rgba(0, 0, 0, 0.1) 0px 1px 6px',
+                }}
               >
                 <div
                   className="image"

--- a/packages/vx-demo/components/tiles/axis.js
+++ b/packages/vx-demo/components/tiles/axis.js
@@ -9,7 +9,6 @@ import { AreaClosed, LinePath } from '@vx/shape';
 import { scaleTime, scaleLinear } from '@vx/scale';
 import { extent, max } from 'd3-array';
 
-
 const data = genDateValue(20);
 
 // accessors
@@ -29,11 +28,7 @@ function numTicksForWidth(width) {
   return 10;
 }
 
-export default ({
-  width,
-  height,
-  margin,
-}) => {
+export default ({ width, height, margin }) => {
   if (width < 10) return null;
 
   // bounds
@@ -57,7 +52,7 @@ export default ({
 
   return (
     <svg width={width} height={height}>
-      <GradientOrangeRed id="linear" />
+      <GradientOrangeRed id="linear" vertical={false} />
       <rect
         x={0}
         y={0}
@@ -71,7 +66,7 @@ export default ({
         left={margin.left}
         xScale={xScale}
         yScale={yScale}
-        stroke='rgba(142, 32, 95, 0.9)'
+        stroke="rgba(142, 32, 95, 0.9)"
         width={xMax}
         height={yMax}
         numTicksRows={numTicksForHeight(height)}
@@ -87,7 +82,7 @@ export default ({
           strokeWidth={2}
           stroke={'transparent'}
           fill={'url(#linear)'}
-          fillOpacity='0.9'
+          fillOpacity="0.9"
           curve={curveBasis}
         />
         <LinePath
@@ -158,4 +153,4 @@ export default ({
       />
     </svg>
   );
-}
+};

--- a/packages/vx-demo/components/tiles/axis.js
+++ b/packages/vx-demo/components/tiles/axis.js
@@ -52,7 +52,12 @@ export default ({ width, height, margin }) => {
 
   return (
     <svg width={width} height={height}>
-      <GradientOrangeRed id="linear" vertical={false} />
+      <GradientOrangeRed
+        id="linear"
+        vertical={false}
+        fromOpacity={0.8}
+        toOpacity={0.3}
+      />
       <rect
         x={0}
         y={0}
@@ -82,7 +87,6 @@ export default ({ width, height, margin }) => {
           strokeWidth={2}
           stroke={'transparent'}
           fill={'url(#linear)'}
-          fillOpacity="0.9"
           curve={curveBasis}
         />
         <LinePath

--- a/packages/vx-demo/components/tiles/bars.js
+++ b/packages/vx-demo/components/tiles/bars.js
@@ -17,11 +17,7 @@ function round(value, precision) {
 const x = d => d.letter;
 const y = d => +d.frequency * 100;
 
-export default ({
-  width,
-  height,
-  events = false,
-}) => {
+export default ({ width, height, events = false }) => {
   if (width < 10) return null;
 
   // bounds
@@ -62,9 +58,9 @@ export default ({
                 y={yMax - barHeight}
                 fill="rgba(23, 233, 217, .5)"
                 data={{ x: x(d), y: y(d) }}
-                onClick={(data) => (event) => {
+                onClick={data => event => {
                   if (!events) return;
-                  alert(`clicked: ${JSON.stringify(data)}`)
+                  alert(`clicked: ${JSON.stringify(data)}`);
                 }}
               />
             </Group>
@@ -73,4 +69,4 @@ export default ({
       </Group>
     </svg>
   );
-}
+};

--- a/packages/vx-demo/components/tiles/gradients.js
+++ b/packages/vx-demo/components/tiles/gradients.js
@@ -10,7 +10,7 @@ import {
   GradientPurpleRed,
   GradientPurpleTeal,
   GradientSteelPurple,
-  GradientTealBlue
+  GradientTealBlue,
 } from '@vx/gradient';
 
 export default ({
@@ -20,8 +20,8 @@ export default ({
     top: 0,
     left: 0,
     right: 0,
-    bottom: 80
-  }
+    bottom: 80,
+  },
 }) => {
   const w = width / 4;
   const h = (height - margin.bottom) / 2;
@@ -31,19 +31,19 @@ export default ({
       <GradientLightgreenGreen id="LightgreenGreen" />
       <GradientOrangeRed id="OrangeRed" />
       <GradientPinkBlue id="PinkBlue" />
-      <GradientPinkRed id="PinkRed" />
-      <GradientPurpleOrange id="PurpleOrange" />
-      <GradientPurpleRed id="PurpleRed" />
-      <GradientPurpleTeal id="PurpleTeal" />
-      <GradientSteelPurple id="SteelPurple" />
-      <GradientTealBlue id="TealBlue" />
+      <GradientPinkRed id="PinkRed" vertical={false} />
+      <GradientPurpleOrange id="PurpleOrange" vertical={false} />
+      <GradientPurpleRed id="PurpleRed" vertical={false} />
+      <GradientPurpleTeal id="PurpleTeal" vertical={false} />
+      <GradientSteelPurple id="SteelPurple" vertical={false} />
+      <GradientTealBlue id="TealBlue" vertical={false} />
       <Bar
         x={0}
         y={0}
         width={w}
         height={h}
         fill={`url(#LightgreenGreen)`}
-        stroke='#ffffff'
+        stroke="#ffffff"
         strokeWidth={8}
         rx={14}
       />
@@ -54,7 +54,7 @@ export default ({
         height={h}
         fill={`url(#OrangeRed)`}
         rx={14}
-        stroke='#ffffff'
+        stroke="#ffffff"
         strokeWidth={8}
       />
       <Bar
@@ -64,7 +64,7 @@ export default ({
         height={h}
         fill={`url(#PinkBlue)`}
         rx={14}
-        stroke='#ffffff'
+        stroke="#ffffff"
         strokeWidth={8}
       />
       <Bar
@@ -74,7 +74,7 @@ export default ({
         height={h}
         fill={`url(#DarkgreenGreen)`}
         rx={14}
-        stroke='#ffffff'
+        stroke="#ffffff"
         strokeWidth={8}
       />
       <Bar
@@ -84,7 +84,7 @@ export default ({
         height={h}
         fill={`url(#PinkRed)`}
         rx={14}
-        stroke='#ffffff'
+        stroke="#ffffff"
         strokeWidth={8}
       />
       <Bar
@@ -94,7 +94,7 @@ export default ({
         height={h}
         fill={`url(#TealBlue)`}
         rx={14}
-        stroke='#ffffff'
+        stroke="#ffffff"
         strokeWidth={8}
       />
       <Bar
@@ -104,7 +104,7 @@ export default ({
         height={h}
         fill={`url(#PurpleOrange)`}
         rx={14}
-        stroke='#ffffff'
+        stroke="#ffffff"
         strokeWidth={8}
       />
       <Bar
@@ -114,9 +114,9 @@ export default ({
         height={h}
         fill={`url(#PurpleTeal)`}
         rx={14}
-        stroke='#ffffff'
+        stroke="#ffffff"
         strokeWidth={8}
       />
     </svg>
   );
-}
+};

--- a/packages/vx-demo/components/tiles/voronoi.js
+++ b/packages/vx-demo/components/tiles/voronoi.js
@@ -12,7 +12,7 @@ export default ({
     top: 0,
     left: 0,
     right: 0,
-    bottom: 70,
+    bottom: 76,
   },
 }) => {
   if (width < 10) return <div />;

--- a/packages/vx-demo/pages/axis.js
+++ b/packages/vx-demo/pages/axis.js
@@ -4,13 +4,17 @@ import Axis from '../components/tiles/axis';
 
 export default () => {
   return (
-    <Show component={Axis} title="Axis" margin={{
-      top: 20,
-      left: 60,
-      right: 40,
-      bottom: 60,
-    }}>
-{`import React from 'react';
+    <Show
+      component={Axis}
+      title="Axis"
+      margin={{
+        top: 20,
+        left: 60,
+        right: 40,
+        bottom: 60,
+      }}
+    >
+      {`import React from 'react';
 import { Grid } from '@vx/grid';
 import { Group } from '@vx/group';
 import { curveBasis } from '@vx/curve';
@@ -66,7 +70,7 @@ export default ({
 
   return (
     <svg width={width} height={height}>
-      <GradientOrangeRed id="linear" />
+      <GradientOrangeRed id="linear" vertical={false} />
       <Grid
         top={margin.top}
         left={margin.left}
@@ -162,4 +166,4 @@ export default ({
 }`}
     </Show>
   );
-}
+};

--- a/packages/vx-demo/pages/axis.js
+++ b/packages/vx-demo/pages/axis.js
@@ -70,7 +70,12 @@ export default ({
 
   return (
     <svg width={width} height={height}>
-      <GradientOrangeRed id="linear" vertical={false} />
+      <GradientOrangeRed
+        id="linear"
+        vertical={false}
+        fromOpacity={0.8}
+        toOpacity={0.3}
+      />
       <Grid
         top={margin.top}
         left={margin.left}
@@ -92,7 +97,6 @@ export default ({
           strokeWidth={2}
           stroke='transparent'
           fill="url('#linear')"
-          fillOpacity='0.9'
           curve={curveBasis}
         />
         <LinePath

--- a/packages/vx-demo/pages/gradients.js
+++ b/packages/vx-demo/pages/gradients.js
@@ -4,10 +4,15 @@ import Gradients from '../components/tiles/gradients';
 
 export default () => {
   return (
-    <Show component={Gradients} title="Gradients" shadow margin={{
-      bottom: 0,
-    }}>
-{`import React from 'react';
+    <Show
+      component={Gradients}
+      title="Gradients"
+      shadow
+      margin={{
+        bottom: 0,
+      }}
+    >
+      {`import React from 'react';
 import { Bar } from '@vx/shape';
 import {
   GradientDarkgreenGreen,
@@ -34,12 +39,12 @@ export default ({
       <LightgreenGreen id="LightgreenGreen" />
       <OrangeRed id="OrangeRed" />
       <PinkBlue id="PinkBlue" />
-      <PinkRed id="PinkRed" />
-      <PurpleOrange id="PurpleOrange" />
-      <PurpleRed id="PurpleRed" />
-      <PurpleTeal id="PurpleTeal" />
-      <SteelPurple id="SteelPurple" />
-      <TealBlue id="TealBlue" />
+      <PinkRed id="PinkRed" vertical={false} />
+      <PurpleOrange id="PurpleOrange" vertical={false} />
+      <PurpleRed id="PurpleRed" vertical={false} />
+      <PurpleTeal id="PurpleTeal" vertical={false} />
+      <SteelPurple id="SteelPurple" vertical={false} />
+      <TealBlue id="TealBlue" vertical={false} />
       <Bar
         x={0}
         y={0}
@@ -125,4 +130,4 @@ export default ({
 }`}
     </Show>
   );
-}
+};

--- a/packages/vx-gradient/package.json
+++ b/packages/vx-gradient/package.json
@@ -29,7 +29,8 @@
   },
   "homepage": "https://github.com/hshoff/vx#readme",
   "dependencies": {
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "prop-types": "^15.5.7"
   },
   "devDependencies": {
     "babel-jest": "^20.0.3",

--- a/packages/vx-gradient/src/gradients/LinearGradient.js
+++ b/packages/vx-gradient/src/gradients/LinearGradient.js
@@ -1,18 +1,69 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-export default ({
+LinearGradient.propTypes = {
+  id: PropTypes.string.isRequired,
+  from: PropTypes.string,
+  to: PropTypes.string,
+  x1: PropTypes.string,
+  y1: PropTypes.string,
+  y2: PropTypes.string,
+  fromOffset: PropTypes.string,
+  fromOpacity: PropTypes.number,
+  toOffset: PropTypes.string,
+  toOpacity: PropTypes.number,
+  rotate: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  transform: PropTypes.string,
+};
+
+export default function LinearGradient({
+  children,
   id,
   from,
   to,
-  fromOffset = "0%",
-  toOffset = "100%",
+  x1,
+  y1,
+  x2,
+  y2,
+  fromOffset = '0%',
+  fromOpacity = 1,
+  toOffset = '100%',
+  toOpacity = 1,
+  rotate,
+  transform,
+  vertical = true,
   ...restProps
-}) => {
+}) {
+  if (vertical && !x1 && !x2 && !y1 && !y2) {
+    x1 = '0';
+    x2 = '0';
+    y1 = '0';
+    y2 = '1';
+  }
   return (
     <defs>
-      <linearGradient id={id} x1="0%" y1="0%" x2="0%" y2="100%" {...restProps}>
-        <stop offset={fromOffset} stopColor={from} />
-        <stop offset={toOffset} stopColor={to} />
+      <linearGradient
+        id={id}
+        x1={x1}
+        y1={y1}
+        x2={x2}
+        y2={y2}
+        gradientTransform={rotate ? `rotate(${rotate})` : transform}
+        {...restProps}
+      >
+        {!!children && children}
+        {!children &&
+          <stop
+            offset={fromOffset}
+            stopColor={from}
+            stopOpacity={fromOpacity}
+          />}
+        {!children &&
+          <stop
+            offset={toOffset}
+            stopColor={to}
+            stopOpacity={toOpacity}
+          />}
       </linearGradient>
     </defs>
   );

--- a/packages/vx-legend/src/legends/Legend.js
+++ b/packages/vx-legend/src/legends/Legend.js
@@ -25,7 +25,7 @@ Legend.propTypes = {
   direction: PropTypes.string,
   itemDirection: PropTypes.string,
   fill: PropTypes.func,
-  shape: PropTypes.func,
+  shape: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   labelFormat: PropTypes.func,
   labelTransform: PropTypes.func,
 };


### PR DESCRIPTION
`@vx/gradient`

- add horizontal gradients with `vertical={false}` - defaults to `true`
- add support for children so you can pass in your own `<stop />`s
- add `rotate` shortcut prop
- add `transform` prop to set your own transform - rotate takes precedence over transform, so if you're adding your own transform remove the rotate prop and include `rotate(270)` or whatever value in your transform string
- add `fromOpacity` and `toOpacity` props
- remove hardcoded `x1, y1, x2, y2`, can set your own - defaults to vertical, set `vertical={false}` to get horizontal or set your own
- add proptypes

<img width="467" alt="screen shot 2017-06-30 at 1 09 00 pm" src="https://user-images.githubusercontent.com/339208/27752432-cb5861c6-5d95-11e7-9c4d-36ef57156070.png">

`@vx/legend`

- fix shape proptype to add oneOfType string as well as func
