### PR TITLE
[glyph] add remaining d3 symbols

### DIFF
--- a/packages/vx-demo/components/gallery.js
+++ b/packages/vx-demo/components/gallery.js
@@ -140,7 +140,7 @@ export default class Gallery extends React.Component {
                 <div className="details color-yellow">
                   <div className="title">Dots</div>
                   <div className="description">
-                    <pre>{`<Glyph.GlyphDot />`}</pre>
+                    <pre>{`<Glyph.GlyphCircle />`}</pre>
                   </div>
                 </div>
               </div>

--- a/packages/vx-demo/components/tiles/dots.js
+++ b/packages/vx-demo/components/tiles/dots.js
@@ -48,7 +48,7 @@ export default ({ width, height }) => {
               fill={'#f6c431'}
               left={xScale(x(point))}
               top={yScale(y(point))}
-              size={i % 3 === 0 ? 2 : 3}
+              size={i % 3 === 0 ? 12 : 24}
             />
           );
         })}

--- a/packages/vx-demo/components/tiles/dots.js
+++ b/packages/vx-demo/components/tiles/dots.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Group } from '@vx/group';
-import { GlyphDot } from '@vx/glyph';
+import { GlyphCircle } from '@vx/glyph';
 import { GradientPinkRed } from '@vx/gradient';
 import { scaleLinear } from '@vx/scale';
 import { genRandomNormalPoints } from '@vx/mock-data';
 
-const points = genRandomNormalPoints(600).filter((d,i) => {
+const points = genRandomNormalPoints(600).filter((d, i) => {
   return i < 600;
 });
 
@@ -13,10 +13,7 @@ const x = d => d[0];
 const y = d => d[1];
 const z = d => d[2];
 
-export default ({
-  width,
-  height,
-}) => {
+export default ({ width, height }) => {
   const xMax = width;
   const yMax = height - 80;
   if (width < 10) return null;
@@ -27,14 +24,14 @@ export default ({
     clamp: true,
   });
   const yScale = scaleLinear({
-    domain: [.75, 1.6],
+    domain: [0.75, 1.6],
     range: [yMax, 0],
     clamp: true,
   });
 
   return (
     <svg width={width} height={height}>
-      <GradientPinkRed id='pink' />
+      <GradientPinkRed id="pink" />
       <rect
         x={0}
         y={0}
@@ -44,18 +41,18 @@ export default ({
         fill={`url(#pink)`}
       />
       <Group>
-        {points.map((point,i) => {
+        {points.map((point, i) => {
           return (
-            <GlyphDot
+            <GlyphCircle
               key={`point-${point.x}-${i}`}
               fill={'#f6c431'}
-              cx={xScale(x(point))}
-              cy={yScale(y(point))}
-              r={i % 3 === 0 ? 2 : 3}
+              left={xScale(x(point))}
+              top={yScale(y(point))}
+              size={i % 3 === 0 ? 2 : 3}
             />
           );
         })}
       </Group>
     </svg>
   );
-}
+};

--- a/packages/vx-demo/components/tiles/legends.js
+++ b/packages/vx-demo/components/tiles/legends.js
@@ -15,6 +15,13 @@ import {
   scaleThreshold,
 } from '@vx/scale';
 
+import {
+  GlyphStar,
+  GlyphWye,
+  GlyphTriangle,
+  GlyphDiamond,
+} from '@vx/glyph';
+
 const oneDecimalFormat = format('.1f');
 const twoDecimalFormat = format('.2f');
 
@@ -39,29 +46,24 @@ const ordinalColor2 = scaleOrdinal({
 });
 
 const ordinalShape = scaleOrdinal({
-  domain: ['a', 'b', 'c', 'd'],
+  domain: ['a', 'b', 'c', 'd', 'e'],
   range: [
+    <GlyphStar size={50} top={50 / 6} left={50 / 6} fill="#dd59b8" />,
+    <GlyphWye size={50} top={50 / 6} left={50 / 6} fill="#de6a9a" />,
+    <GlyphTriangle
+      size={50}
+      top={50 / 6}
+      left={50 / 6}
+      fill="#de7d7b"
+    />,
+    <GlyphDiamond
+      size={50}
+      top={50 / 6}
+      left={50 / 6}
+      fill="#df905f"
+    />,
     props =>
-      <circle
-        {...{
-          r: props.width / 2,
-          cx: props.width / 2,
-          cy: props.width / 2,
-        }}
-        {...props}
-      />,
-    props => <rect {...props} />,
-    props =>
-      <circle
-        {...{
-          r: props.width / 2,
-          cx: props.width / 2,
-          cy: props.width / 2,
-        }}
-        {...props}
-      />,
-    props =>
-      <text fontSize="12" dy="1em" dx=".33em" {...props}>
+      <text fontSize="12" dy="1em" dx=".33em" fill="#e0a346">
         $
       </text>,
   ],
@@ -195,15 +197,23 @@ export default ({ width, height, margin }) => {
           itemMargin="0 4px 0 0"
           scale={ordinalShape}
           fill={({ datum }) => ordinalColor2(datum)}
+          shapeWidth={15}
           shape={props => {
             return (
               <svg width={props.width} height={props.height}>
-                {React.createElement(
+                {!React.isValidElement(
                   ordinalShape(props.label.datum),
-                  {
-                    ...props,
-                  },
-                )}
+                ) &&
+                  React.createElement(
+                    ordinalShape(props.label.datum),
+                    {
+                      ...props,
+                    },
+                  )}
+                {React.isValidElement(
+                  ordinalShape(props.label.datum),
+                ) &&
+                  React.cloneElement(ordinalShape(props.label.datum))}
               </svg>
             );
           }}

--- a/packages/vx-demo/pages/dots.js
+++ b/packages/vx-demo/pages/dots.js
@@ -5,9 +5,9 @@ import Dots from '../components/tiles/dots';
 export default () => {
   return (
     <Show component={Dots} title="Dots">
-{`import React from 'react';
+      {`import React from 'react';
 import { Group } from '@vx/group';
-import { GlyphDot } from '@vx/glyph';
+import { GlyphCircle } from '@vx/glyph';
 import { GradientPinkRed } from '@vx/gradient';
 import { scaleLinear } from '@vx/scale';
 import { genRandomNormalPoints } from '@vx/mock-data';
@@ -53,12 +53,12 @@ export default ({
       <Group>
         {points.map((point,i) => {
           return (
-            <GlyphDot
+            <GlyphCircle
               key={\`point-\${point.x}-\${i}\`}
-              fill="#f6c431"
-              cx={xScale(x(point))}
-              cy={yScale(y(point))}
-              r={i % 3 === 0 ? 2 : 3}
+              fill={'#f6c431'}
+              left={xScale(x(point))}
+              top={yScale(y(point))}
+              size={i % 3 === 0 ? 2 : 3}
             />
           );
         })}
@@ -68,4 +68,4 @@ export default ({
 }`}
     </Show>
   );
-}
+};

--- a/packages/vx-demo/pages/legends.js
+++ b/packages/vx-demo/pages/legends.js
@@ -32,6 +32,13 @@ import {
   scaleThreshold,
 } from '@vx/scale';
 
+import {
+  GlyphStar,
+  GlyphWye,
+  GlyphTriangle,
+  GlyphDiamond,
+} from '@vx/glyph';
+
 const oneDecimalFormat = format('.1f');
 const twoDecimalFormat = format('.2f');
 
@@ -56,29 +63,24 @@ const ordinalColor2 = scaleOrdinal({
 });
 
 const ordinalShape = scaleOrdinal({
-  domain: ['a', 'b', 'c', 'd'],
+  domain: ['a', 'b', 'c', 'd', 'e'],
   range: [
+    <GlyphStar size={50} top={50 / 6} left={50 / 6} fill="#dd59b8" />,
+    <GlyphWye size={50} top={50 / 6} left={50 / 6} fill="#de6a9a" />,
+    <GlyphTriangle
+      size={50}
+      top={50 / 6}
+      left={50 / 6}
+      fill="#de7d7b"
+    />,
+    <GlyphDiamond
+      size={50}
+      top={50 / 6}
+      left={50 / 6}
+      fill="#df905f"
+    />,
     props =>
-      <circle
-        {...{
-          r: props.width / 2,
-          cx: props.width / 2,
-          cy: props.width / 2,
-        }}
-        {...props}
-      />,
-    props => <rect {...props} />,
-    props =>
-      <circle
-        {...{
-          r: props.width / 2,
-          cx: props.width / 2,
-          cy: props.width / 2,
-        }}
-        {...props}
-      />,
-    props =>
-      <text fontSize="12" dy="1em" dx=".33em" {...props}>
+      <text fontSize="12" dy="1em" dx=".33em" fill="#e0a346">
         $
       </text>,
   ],
@@ -194,15 +196,23 @@ export default ({ width, height, margin }) => {
           itemMargin="0 4px 0 0"
           scale={ordinalShape}
           fill={({ datum }) => ordinalColor2(datum)}
+          shapeWidth={15}
           shape={props => {
             return (
               <svg width={props.width} height={props.height}>
-                {React.createElement(
+                {!React.isValidElement(
                   ordinalShape(props.label.datum),
-                  {
-                    ...props,
-                  },
-                )}
+                ) &&
+                  React.createElement(
+                    ordinalShape(props.label.datum),
+                    {
+                      ...props,
+                    },
+                  )}
+                {React.isValidElement(
+                  ordinalShape(props.label.datum),
+                ) &&
+                  React.cloneElement(ordinalShape(props.label.datum))}
               </svg>
             );
           }}
@@ -211,6 +221,7 @@ export default ({ width, height, margin }) => {
     </div>
   );
 };
+
 `}
     </Show>
   );

--- a/packages/vx-glyph/src/glyphs/Circle.js
+++ b/packages/vx-glyph/src/glyphs/Circle.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import cx from 'classnames';
+import { symbol, symbolCircle } from 'd3-shape';
+import Glyph from './Glyph';
+import additionalProps from '../util/additionalProps';
+
+export default function GlyphCircle({
+  children,
+  className,
+  top,
+  left,
+  size,
+  ...restProps
+}) {
+  const path = symbol();
+  path.type(symbolCircle);
+  if (size) path.size(size);
+  return (
+    <Glyph
+      top={top}
+      left={left}
+      className={cx('vx-glyph-circle', className)}
+    >
+      <path d={path()} {...additionalProps(restProps)} />
+      {children}
+    </Glyph>
+  );
+}

--- a/packages/vx-glyph/src/glyphs/Diamond.js
+++ b/packages/vx-glyph/src/glyphs/Diamond.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import cx from 'classnames';
+import { symbol, symbolDiamond } from 'd3-shape';
+import Glyph from './Glyph';
+import additionalProps from '../util/additionalProps';
+
+export default function GlyphDiamond({
+  children,
+  className,
+  top,
+  left,
+  size,
+  ...restProps
+}) {
+  const path = symbol();
+  path.type(symbolDiamond);
+  if (size) path.size(size);
+  return (
+    <Glyph
+      top={top}
+      left={left}
+      className={cx('vx-glyph-diamond', className)}
+    >
+      <path d={path()} {...additionalProps(restProps)} />
+      {children}
+    </Glyph>
+  );
+}

--- a/packages/vx-glyph/src/glyphs/Square.js
+++ b/packages/vx-glyph/src/glyphs/Square.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import cx from 'classnames';
+import { symbol, symbolSquare } from 'd3-shape';
+import Glyph from './Glyph';
+import additionalProps from '../util/additionalProps';
+
+export default function GlyphSquare({
+  children,
+  className,
+  top,
+  left,
+  size,
+  ...restProps
+}) {
+  const path = symbol();
+  path.type(symbolSquare);
+  if (size) path.size(size);
+  return (
+    <Glyph
+      top={top}
+      left={left}
+      className={cx('vx-glyph-square', className)}
+    >
+      <path d={path()} {...additionalProps(restProps)} />
+      {children}
+    </Glyph>
+  );
+}

--- a/packages/vx-glyph/src/glyphs/Star.js
+++ b/packages/vx-glyph/src/glyphs/Star.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import cx from 'classnames';
+import { symbol, symbolStar } from 'd3-shape';
+import Glyph from './Glyph';
+import additionalProps from '../util/additionalProps';
+
+export default function GlyphStar({
+  children,
+  className,
+  top,
+  left,
+  size,
+  ...restProps
+}) {
+  const path = symbol();
+  path.type(symbolStar);
+  if (size) path.size(size);
+  return (
+    <Glyph
+      top={top}
+      left={left}
+      className={cx('vx-glyph-star', className)}
+    >
+      <path d={path()} {...additionalProps(restProps)} />
+      {children}
+    </Glyph>
+  );
+}

--- a/packages/vx-glyph/src/glyphs/Triangle.js
+++ b/packages/vx-glyph/src/glyphs/Triangle.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import cx from 'classnames';
+import { symbol, symbolTriangle } from 'd3-shape';
+import Glyph from './Glyph';
+import additionalProps from '../util/additionalProps';
+
+export default function GlyphTriangle({
+  children,
+  className,
+  top,
+  left,
+  size,
+  ...restProps
+}) {
+  const path = symbol();
+  path.type(symbolTriangle);
+  if (size) path.size(size);
+  return (
+    <Glyph
+      top={top}
+      left={left}
+      className={cx('vx-glyph-triangle', className)}
+    >
+      <path d={path()} {...additionalProps(restProps)} />
+      {children}
+    </Glyph>
+  );
+}

--- a/packages/vx-glyph/src/glyphs/Wye.js
+++ b/packages/vx-glyph/src/glyphs/Wye.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import cx from 'classnames';
+import { symbol, symbolWye } from 'd3-shape';
+import Glyph from './Glyph';
+import additionalProps from '../util/additionalProps';
+
+export default function GlyphWye({
+  children,
+  className,
+  top,
+  left,
+  size,
+  ...restProps
+}) {
+  const path = symbol();
+  path.type(symbolWye);
+  if (size) path.size(size);
+  return (
+    <Glyph
+      top={top}
+      left={left}
+      className={cx('vx-glyph-wye', className)}
+    >
+      <path d={path()} {...additionalProps(restProps)} />
+      {children}
+    </Glyph>
+  );
+}

--- a/packages/vx-glyph/src/index.js
+++ b/packages/vx-glyph/src/index.js
@@ -1,3 +1,9 @@
 export { default as Glyph } from './glyphs/Glyph';
 export { default as GlyphDot } from './glyphs/Dot';
 export { default as GlyphCross } from './glyphs/Cross';
+export { default as GlyphDiamond } from './glyphs/Diamond';
+export { default as GlyphStar } from './glyphs/Star';
+export { default as GlyphTriangle } from './glyphs/Triangle';
+export { default as GlyphWye } from './glyphs/Wye';
+export { default as GlyphSquare } from './glyphs/Square';
+export { default as GlyphCircle } from './glyphs/Circle';

--- a/packages/vx-glyph/test/Circle.test.js
+++ b/packages/vx-glyph/test/Circle.test.js
@@ -1,0 +1,7 @@
+import { GlyphCircle } from '../src';
+
+describe('<GlyphCircle />', () => {
+  test('it should be defined', () => {
+    expect(GlyphCircle).toBeDefined();
+  });
+});

--- a/packages/vx-glyph/test/Cross.test.js
+++ b/packages/vx-glyph/test/Cross.test.js
@@ -1,0 +1,7 @@
+import { GlyphCross } from '../src';
+
+describe('<GlyphCross />', () => {
+  test('it should be defined', () => {
+    expect(GlyphCross).toBeDefined();
+  });
+});

--- a/packages/vx-glyph/test/Diamond.test.js
+++ b/packages/vx-glyph/test/Diamond.test.js
@@ -1,0 +1,7 @@
+import { GlyphDiamond } from '../src';
+
+describe('<GlyphDiamond />', () => {
+  test('it should be defined', () => {
+    expect(GlyphDiamond).toBeDefined();
+  });
+});

--- a/packages/vx-glyph/test/Square.test.js
+++ b/packages/vx-glyph/test/Square.test.js
@@ -1,0 +1,7 @@
+import { GlyphSquare } from '../src';
+
+describe('<GlyphSquare />', () => {
+  test('it should be defined', () => {
+    expect(GlyphSquare).toBeDefined();
+  });
+});

--- a/packages/vx-glyph/test/Star.test.js
+++ b/packages/vx-glyph/test/Star.test.js
@@ -1,0 +1,7 @@
+import { GlyphStar } from '../src';
+
+describe('<GlyphStar />', () => {
+  test('it should be defined', () => {
+    expect(GlyphStar).toBeDefined();
+  });
+});

--- a/packages/vx-glyph/test/Triangle.test.js
+++ b/packages/vx-glyph/test/Triangle.test.js
@@ -1,0 +1,7 @@
+import { GlyphTriangle } from '../src';
+
+describe('<GlyphTriangle />', () => {
+  test('it should be defined', () => {
+    expect(GlyphTriangle).toBeDefined();
+  });
+});

--- a/packages/vx-glyph/test/Wye.test.js
+++ b/packages/vx-glyph/test/Wye.test.js
@@ -1,0 +1,7 @@
+import { GlyphWye } from '../src';
+
+describe('<GlyphWye />', () => {
+  test('it should be defined', () => {
+    expect(GlyphWye).toBeDefined();
+  });
+});


### PR DESCRIPTION
- adds support for the missing d3 symbols from [d3-shape](https://github.com/d3/d3-shape#symbols)
- `<GlyphDot />` should be considered deprecated in favor of `<GlyphCircle />` for a consistent api across all Glyphs, but I'll keep GlyphDot around just in case folks are already using it as legacy

`<GlyphCircle />`
<img width="174" alt="screen shot 2017-06-30 at 1 58 44 pm" src="https://user-images.githubusercontent.com/339208/27753955-baa9c282-5d9c-11e7-80a3-f4d613506e87.png">

`<GlyphSquare />`
<img width="248" alt="screen shot 2017-06-30 at 1 57 12 pm" src="https://user-images.githubusercontent.com/339208/27753971-c6bc2e2a-5d9c-11e7-9b9c-408e5946d687.png">

`<GlyphWye />`
<img width="224" alt="screen shot 2017-06-30 at 1 53 57 pm" src="https://user-images.githubusercontent.com/339208/27753981-d449b1e8-5d9c-11e7-9d43-31678cb7cf13.png">

`<GlyphTriangle />`
<img width="227" alt="screen shot 2017-06-30 at 1 52 43 pm" src="https://user-images.githubusercontent.com/339208/27753986-de5d406e-5d9c-11e7-96bf-10d0f30909dc.png">

`<GlyphStar />`
<img width="216" alt="screen shot 2017-06-30 at 1 50 55 pm" src="https://user-images.githubusercontent.com/339208/27753998-ec6a6d3a-5d9c-11e7-9c5c-3d6d56b12d4d.png">

`<GlyphCross />`
<img width="158" alt="screen shot 2017-06-30 at 2 07 48 pm" src="https://user-images.githubusercontent.com/339208/27754094-8d3f7c96-5d9d-11e7-8f62-a9600e32fd16.png">





