### PR TITLE
added Glyph support for BoxPlot

### DIFF
--- a/packages/vx-demo/components/gallery.js
+++ b/packages/vx-demo/components/gallery.js
@@ -24,6 +24,7 @@ import Trees from '../components/tiles/tree';
 import Cluster from '../components/tiles/dendrogram';
 import Voronoi from '../components/tiles/voronoi';
 import Legends from '../components/tiles/legends';
+import BoxPlot from '../components/tiles/boxplot';
 
 const items = [
   '#242424',
@@ -85,6 +86,7 @@ export default class Gallery extends React.Component {
     const t14 = this.state.dimensions[13] || [8, 300];
     const t15 = this.state.dimensions[14] || [8, 300];
     const t16 = this.state.dimensions[15] || [8, 300];
+    const t17 = this.state.dimensions[16] || [8, 300];
 
     return (
       <div>
@@ -490,6 +492,27 @@ export default class Gallery extends React.Component {
               </div>
             </Link>
           </Tilt>
+
+          <Tilt className="tilt" options={{ max: 8, scale: 1 }}>
+            <Link prefetch href="/boxplot">
+              <div
+                className="gallery-item"
+                ref={d => this.nodes.add(d)}
+                style={{background:"#fd7e14"}}
+              >
+                <div className="image">
+                  <BoxPlot width={t17[0]} height={t17[1]} />
+                </div>
+                <div className="details" style={{ color: '#FFFFFF' }}>
+                  <div className="title">BoxPlot</div>
+                  <div className="description">
+                    <pre>{`<Glyph.GlyphBoxPlot /> `}</pre>
+                  </div>
+                </div>
+              </div>
+            </Link>
+          </Tilt>
+          <div className="gallery-item placeholder" />
           <div className="gallery-item placeholder" />
         </div>
 

--- a/packages/vx-demo/components/tiles/boxplot.js
+++ b/packages/vx-demo/components/tiles/boxplot.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Group } from '@vx/group';
+import { GlyphBoxPlot } from '@vx/glyph'
+import { GradientTealBlue } from '@vx/gradient'
+import { scaleBand, scaleLinear } from '@vx/scale';
+import { extent } from 'd3-array';
+
+const BoxPlotData = (number) => {
+  const data = [];
+  let i;
+  for (i = 0; i < number; i += 1) {
+    const points = [];
+    let j;
+    for (j = 0; j < 5; j += 1) {
+      points.push(Math.random() * 100);
+    }
+    points.sort((a, b) => (a - b));
+    data.push({
+      x: `Statistics ${i}`,
+      min: points[0],
+      firstQuartile: points[1],
+      median: points[2],
+      thirdQuartile: points[3],
+      max: points[4],
+    });
+  }
+  return data;
+};
+
+const data = BoxPlotData(5);
+
+// accessors
+const x = d => d.x;
+const min = d => d.min;
+const max = d => d.max;
+const median = d => d.median;
+const firstQuartile = d => d.firstQuartile;
+const thirdQuartile = d => d.thirdQuartile;
+
+
+export default ({
+  width,
+  height,
+  events = false,
+}) => {
+  if (width < 10) return null;
+
+  // bounds
+  const xMax = width;
+  const yMax = height - 120;
+
+  // scales
+  const xScale = scaleBand({
+    rangeRound: [0, xMax],
+    domain: data.map(x),
+    padding: 0.4,
+  });
+
+  const values = data.reduce((r, e) => r.push(e.min, e.max) && r, []);
+  const minYValue = Math.min(...values);
+  const maxYValue = Math.max(...values);
+  const yDomain = [minYValue - (0.1 * Math.abs(minYValue)),
+    maxYValue + (0.1 * Math.abs(minYValue))];
+
+  const yScale = scaleLinear({
+    rangeRound: [yMax, 0],
+    domain: [minYValue, maxYValue]
+  });
+
+  const boxWidth = xScale.bandwidth();
+  const actualyWidth = Math.min(40, boxWidth);
+
+  return (
+    <svg width={width} height={height}>
+      <GradientTealBlue id="TealBlue" vertical/>
+      <rect
+        x={0}
+        y={0}
+        width={width}
+        height={height}
+        fill={`url(#TealBlue)`}
+        rx={14}
+      />
+      <Group top={40}>
+      {data.map((d, i) => (
+        <GlyphBoxPlot
+            key={i}
+            min={yScale(min(d))}
+            max={yScale(max(d))}
+            left={xScale(x(d))}
+            firstQuartile={yScale(firstQuartile(d))}
+            thirdQuartile={yScale(thirdQuartile(d))}
+            median={yScale(median(d))}
+            boxWidth={actualyWidth}
+            fill="rgba(255,255,255,0.4)"
+            stroke="#FFFFFF"
+            strokeWidth={2}
+        />
+      ))
+    }
+    </Group>
+    </svg>
+  );
+}

--- a/packages/vx-demo/pages/boxplot.js
+++ b/packages/vx-demo/pages/boxplot.js
@@ -1,0 +1,117 @@
+import React from 'react';
+import Show from '../components/show';
+import BoxPlot from '../components/tiles/boxplot';
+
+export default () => {
+  return (
+    <Show
+      events={true}
+      margin={{top: 80}}
+      component={BoxPlot}
+      title="Box Plot">
+{`import React from 'react';
+import { Group } from '@vx/group';
+import { GlyphBoxPlot } from '@vx/glyph'
+import { GradientTealBlue } from '@vx/gradient'
+import { scaleBand, scaleLinear } from '@vx/scale';
+import { extent } from 'd3-array';
+
+const BoxPlotData = (number) => {
+  const data = [];
+  let i;
+  for (i = 0; i < number; i += 1) {
+    const points = [];
+    let j;
+    for (j = 0; j < 5; j += 1) {
+      points.push(Math.random() * 100);
+    }
+    points.sort((a, b) => (a - b));
+    data.push({
+      x: \`Statistics $\{i\}\`,
+      min: points[0],
+      firstQuartile: points[1],
+      median: points[2],
+      thirdQuartile: points[3],
+      max: points[4],
+    });
+  }
+  return data;
+};
+
+const data = BoxPlotData(5);
+
+// accessors
+const x = d => d.x;
+const min = d => d.min;
+const max = d => d.max;
+const median = d => d.median;
+const firstQuartile = d => d.firstQuartile;
+const thirdQuartile = d => d.thirdQuartile;
+
+
+export default ({
+  width,
+  height,
+  events = false,
+}) => {
+  if (width < 10) return null;
+
+  // bounds
+  const xMax = width;
+  const yMax = height - 120;
+
+  // scales
+  const xScale = scaleBand({
+    rangeRound: [0, xMax],
+    domain: data.map(x),
+    padding: 0.4,
+  });
+
+  const values = data.reduce((r, e) => r.push(e.min, e.max) && r, []);
+  const minYValue = Math.min(...values);
+  const maxYValue = Math.max(...values);
+  const yDomain = [minYValue - (0.1 * Math.abs(minYValue)),
+    maxYValue + (0.1 * Math.abs(minYValue))];
+
+  const yScale = scaleLinear({
+    rangeRound: [yMax, 0],
+    domain: [minYValue, maxYValue]
+  });
+
+  const boxWidth = xScale.bandwidth();
+  const actualyWidth = Math.min(40, boxWidth);
+
+  return (
+    <svg width={width} height={height}>
+      <GradientTealBlue id="TealBlue" vertical/>
+      <rect
+        x={0}
+        y={0}
+        width={width}
+        height={height}
+        fill={\`url(#TealBlue)\`}
+        rx={14}
+      />
+      <Group top={40}>
+      {data.map((d, i) => (
+        <GlyphBoxPlot
+            key={i}
+            min={yScale(min(d))}
+            max={yScale(max(d))}
+            left={xScale(x(d))}
+            firstQuartile={yScale(firstQuartile(d))}
+            thirdQuartile={yScale(thirdQuartile(d))}
+            median={yScale(median(d))}
+            boxWidth={actualyWidth}
+            fill="rgba(255,255,255,0.4)"
+            stroke="#FFFFFF"
+            strokeWidth={2}
+        />
+      ))
+    }
+    </Group>
+    </svg>
+  );`}
+    </Show>
+  );
+}

--- a/packages/vx-glyph/src/glyphs/statistics/BoxPlot.js
+++ b/packages/vx-glyph/src/glyphs/statistics/BoxPlot.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import classnames from 'classnames';
+import Glyph from '../Glyph';
+
+export default function GlyphBoxPlot({
+  left = 0,
+  className,
+  max,
+  min,
+  firstQuartile,
+  thirdQuartile,
+  median,
+  boxWidth,
+  fill,
+  stroke,
+  strokeWidth,
+}) {
+  const centerX = left + boxWidth/2;
+  return (
+    <Glyph
+      className={classnames('vx-glyph-boxplot', className)}
+    >
+      <line
+        x1={centerX - boxWidth/4}
+        y1={max}
+        x2={centerX + boxWidth/4}
+        y2={max}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+      />
+      <line
+        x1={centerX}
+        y1={max}
+        x2={centerX}
+        y2={thirdQuartile}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+      />
+      <rect
+        x={left}
+        y={thirdQuartile}
+        width={boxWidth}
+        height={firstQuartile - thirdQuartile}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        fill={fill}
+        rx={2}
+        ry={2}
+      />
+      <line
+        x1={left}
+        y1={median}
+        x2={left + boxWidth}
+        y2={median}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+      />
+      <line
+        x1={centerX}
+        y1={firstQuartile}
+        x2={centerX}
+        y2={min}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+      />
+      <line
+        x1={centerX - boxWidth/4}
+        y1={min}
+        x2={centerX + boxWidth/4}
+        y2={min}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+      />
+    </Glyph>
+  );
+}

--- a/packages/vx-glyph/src/index.js
+++ b/packages/vx-glyph/src/index.js
@@ -7,3 +7,4 @@ export { default as GlyphTriangle } from './glyphs/Triangle';
 export { default as GlyphWye } from './glyphs/Wye';
 export { default as GlyphSquare } from './glyphs/Square';
 export { default as GlyphCircle } from './glyphs/Circle';
+export { default as GlyphBoxPlot } from './glyphs/statistics/BoxPlot';

--- a/packages/vx-glyph/test/BoxPlot.test.js
+++ b/packages/vx-glyph/test/BoxPlot.test.js
@@ -1,0 +1,7 @@
+import { GlyphBoxPlot } from '../src';
+
+describe('<GlyphBoxPlot />', () => {
+  test('it should be defined', () => {
+    expect(GlyphBoxPlot).toBeDefined();
+  });
+});


### PR DESCRIPTION
As per request, a simple version of  Box Plot is added here as a glyph. 

http://www.physics.csbsju.edu/stats/box2.html 

<img width="872" alt="screen shot 2017-07-01 at 9 54 46 pm" src="https://user-images.githubusercontent.com/2024960/27767301-0aa0bf3c-5ea8-11e7-9bb4-8b326049e3ca.png">

Or it is too high level for vx? since it is actually not a basic visual component. @williaster 