### PR TITLE
[tooltip] add `<TooltipWithBounds />` and PropTypes to `@vx/tooltip` exports

### DIFF
--- a/packages/vx-tooltip/package.json
+++ b/packages/vx-tooltip/package.json
@@ -26,9 +26,9 @@
   },
   "homepage": "https://github.com/hshoff/vx#readme",
   "dependencies": {
+    "@vx/bounds": "0.0.129",
     "classnames": "^2.2.5",
-    "prop-types": "^15.5.10",
-    "recompose": "^0.23.5"
+    "prop-types": "^15.5.10"
   },
   "devDependencies": {
     "babel-jest": "^20.0.3",

--- a/packages/vx-tooltip/src/enhancers/withTooltip.js
+++ b/packages/vx-tooltip/src/enhancers/withTooltip.js
@@ -1,4 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+
+export const withTooltipPropTypes = {
+  tooltipOpen: PropTypes.bool,
+  tooltipLeft: PropTypes.number,
+  tooltipTop: PropTypes.number,
+  tooltipData: PropTypes.object,
+  updateTooltip: PropTypes.func,
+  showTooltip: PropTypes.func,
+  hideTooltip: PropTypes.func,
+};
 
 export default function withTooltip(BaseComponent) {
   class WrappedComponent extends React.PureComponent {

--- a/packages/vx-tooltip/src/index.js
+++ b/packages/vx-tooltip/src/index.js
@@ -1,2 +1,3 @@
 export { default as withTooltip } from './enhancers/withTooltip';
 export { default as Tooltip } from './tooltips/Tooltip';
+export { default as TooltipWithBounds } from './tooltips/TooltipWithBounds';

--- a/packages/vx-tooltip/src/tooltips/Tooltip.js
+++ b/packages/vx-tooltip/src/tooltips/Tooltip.js
@@ -1,8 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import cx from 'classnames';
 
-export default function Tooltip(props) {
-  const { className, top, left, style, ...restProps } = props;
+export default function Tooltip({ className, top, left, style, children, ...restProps }) {
   return (
     <div
       className={cx('vx-tooltip-portal', className)}
@@ -22,7 +22,15 @@ export default function Tooltip(props) {
       }}
       {...restProps}
     >
-      {props.children}
+      {children}
     </div>
   );
 }
+
+Tooltip.propTypes = {
+  left: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  top: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  className: PropTypes.string,
+  style: PropTypes.object,
+  children: PropTypes.any,
+};

--- a/packages/vx-tooltip/src/tooltips/TooltipWithBounds.js
+++ b/packages/vx-tooltip/src/tooltips/TooltipWithBounds.js
@@ -1,0 +1,41 @@
+/* eslint react/forbid-prop-types: 0 */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { withBoundingRects, withBoundingRectsProps } from '@vx/bounds';
+
+import Tooltip from './Tooltip';
+
+const propTypes = {
+  ...withBoundingRectsProps,
+  ...Tooltip.propTypes,
+};
+
+const defaultProps = {};
+
+function TooltipWithBounds({
+  left: initialLeft,
+  top: initialTop,
+  rect,
+  parentRect,
+  children,
+  style,
+}) {
+  let left = initialLeft;
+  let top = initialTop;
+
+  if (rect && parentRect) {
+    left = rect.right > parentRect.right ? (left - rect.width) : left;
+    top = rect.bottom > parentRect.bottom ? (top - rect.height) : top;
+  }
+
+  return (
+    <Tooltip style={{ top, left, ...style }}>
+      {children}
+    </Tooltip>
+  );
+}
+
+TooltipWithBounds.propTypes = propTypes;
+TooltipWithBounds.defaultProps = defaultProps;
+
+export default withBoundingRects(TooltipWithBounds);

--- a/packages/vx-tooltip/test/TooltipWithBounds.test.js
+++ b/packages/vx-tooltip/test/TooltipWithBounds.test.js
@@ -1,0 +1,7 @@
+import { TooltipWithBounds } from '../src';
+
+describe('<TooltipWithBounds />', () => {
+  test('it should be defined', () => {
+    expect(TooltipWithBounds).toBeDefined();
+  });
+});


### PR DESCRIPTION
This PR adds a`<TooltipWithBounds />` component that wraps the current `<Tooltip />` and is aware of its bounds via the `@vx/bounds` HOC. It also adds some more `PropTypes` to the package.

I found myself wanting a tooltip with this functionality and thought it'd be a useful add here but let me know if you think it's too specialized.

Tested functionally in a linked `@data-ui`

![tooltip-with-bounds](https://user-images.githubusercontent.com/4496521/28608936-60d37b2c-7197-11e7-88ef-800c8c57fbeb.gif)
