### PR TITLE
[axis] make ticks more customizable

### DIFF
--- a/packages/vx-axis/Readme.md
+++ b/packages/vx-axis/Readme.md
@@ -13,7 +13,7 @@ You can use one of the 4 pre-made axes or you can create your own based on the `
 ![Axis Example](http://i.imgur.com/uNIgPsg.png)
 
 ``` js
-import {AxisBottom, AxisLeft} from '@vx/axis';
+import { AxisBottom, AxisLeft } from '@vx/axis';
 // or
 // import * as Axis from '@vx/axis';
 // <Axis.AxisBottom />
@@ -23,7 +23,7 @@ const axis = (
     scale={xScale}
     top={yMax + margin.top}
     left={margin.left}
-    label={''}
+    label={'My string label'}
     stroke={'#1b1a1e'}
     tickTextFill={'#1b1a1e'}
   />
@@ -31,7 +31,7 @@ const axis = (
     scale={yScale}
     top={margin.top}
     left={margin.left}
-    label={''}
+    label={<text {...labelStyles}>My component label</text>}
     stroke={'#1b1a1e'}
     tickTextFill={'#1b1a1e'}
   />
@@ -48,11 +48,12 @@ const axis = (
 | stroke             |          | string   | The color for the stroke of the lines.                                                                          |
 | strokeWidth        |          | number   | The pixel value for the width of the lines.                                                                     |
 | strokeDasharray    |          | array    | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
-| label              |          | string   | The text for the axis label.                                                                                    |
+| label              |          | string or node | The text for the axis label, or a label component                                                         |
 | numTicks           | 10       | number   | The number of ticks wanted for the axis.                                                                        |
 | tickFormat         |          | function | A [d3 formatter](https://github.com/d3/d3-scale/blob/master/README.md#continuous_tickFormat) for the tick text. |
 | tickStroke         | black    | string   | The color for the tick's stroke value.                                                                          |
-| tickK              | -1        | number   | A value that determines an offset in the tick position.                                                         |
+| tickValues         |          | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
+| tickK              | -1       | number   | A value that determines an offset in the tick position.                                                         |
 | tickOffset         |          | number   | A value that determines the y offset in the tick position.                                                      |
 | tickTransform      |          | string   | A custom SVG transform value to be applied to the ticks.                                                        |
 | tickLength         | 8        | number   | The length of the tick lines.                                                                                   |
@@ -82,6 +83,7 @@ const axis = (
 | numTicks           | 10       | number   | The number of ticks wanted for the axis.                                                                        |
 | tickFormat         |          | function | A [d3 formatter](https://github.com/d3/d3-scale/blob/master/README.md#continuous_tickFormat) for the tick text. |
 | tickStroke         | black    | string   | The color for the tick's stroke value.                                                                          |
+| tickValues         |          | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
 | tickK              | 1        | number   | A value that determines an offset in the tick position.                                                         |
 | tickOffset         |          | number   | A value that determines the y offset in the tick position.                                                      |
 | tickTransform      |          | string   | A custom SVG transform value to be applied to the ticks.                                                        |
@@ -112,6 +114,7 @@ const axis = (
 | numTicks           | 10      | number   | The number of ticks wanted for the axis.                                                                        |
 | tickFormat         |         | function | A [d3 formatter](https://github.com/d3/d3-scale/blob/master/README.md#continuous_tickFormat) for the tick text. |
 | tickStroke         | black   | string   | The color for the tick's stroke value.                                                                          |
+| tickValues         |         | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
 | tickK              | -1      | number   | A value that determines an offset in the tick position.                                                         |
 | tickOffset         |         | number   | A value that determines the y offset in the tick position.                                                      |
 | tickTransform      |         | string   | A custom SVG transform value to be applied to the ticks.                                                        |
@@ -142,6 +145,7 @@ const axis = (
 | numTicks           | 10      | number   | The number of ticks wanted for the axis.                                                                        |
 | tickFormat         |         | function | A [d3 formatter](https://github.com/d3/d3-scale/blob/master/README.md#continuous_tickFormat) for the tick text. |
 | tickStroke         | black   | string   | The color for the tick's stroke value.                                                                          |
+| tickValues         |         | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
 | tickK              | 1       | number   | A value that determines an offset in the tick position.                                                         |
 | tickOffset         |         | number   | A value that determines the y offset in the tick position.                                                      |
 | tickTransform      |         | string   | A custom SVG transform value to be applied to the ticks.                                                        |
@@ -172,7 +176,8 @@ const axis = (
 | label              | "default label" | string   | The text for the axis label.                                                                                    |
 | numTicks           | 10              | number   | The number of ticks wanted for the axis.                                                                        |
 | tickFormat         |                 | function | A [d3 formatter](https://github.com/d3/d3-scale/blob/master/README.md#continuous_tickFormat) for the tick text. |
-| tickStroke         | black           | string   | The color for the tick's stroke value.                                                                          |
+| tickStroke         | black           | string   | The color for the tick's stroke value.                                                                          
+| tickValues         |                 | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
 | tickK              | 1               | number   | A value that determines an offset in the tick position.                                                         |
 | tickOffset         |                 | number   | A value that determines the y offset in the tick position.                                                      |
 | tickTransform      |                 | string   | A custom SVG transform value to be applied to the ticks.                                                        |

--- a/packages/vx-axis/src/axis/Axis.js
+++ b/packages/vx-axis/src/axis/Axis.js
@@ -108,7 +108,7 @@ export default function Axis({
                   stroke={tickStroke || stroke}
                 />
               }
-              {React.cloneElement(tickLabelComponent, tickLabelProps, format(val))}
+              {React.cloneElement(tickLabelComponent, tickLabelProps, format(val, i))}
             </Group>
           );
         })}

--- a/packages/vx-axis/src/axis/Axis.js
+++ b/packages/vx-axis/src/axis/Axis.js
@@ -22,6 +22,7 @@ export default function Axis({
   tickStroke = 'black',
   tickLength = 8,
   tickTransform,
+  tickValues,
   hideAxisLine = false,
   hideTicks = false,
   hideZero = false,
@@ -37,7 +38,8 @@ export default function Axis({
   ),
   className,
 }) {
-    const values = scale.ticks ? scale.ticks(numTicks) : scale.domain();
+    let values = scale.ticks ? scale.ticks(numTicks) : scale.domain();
+    if (tickValues) values = tickValues;
     let format = scale.tickFormat ? scale.tickFormat() : identity;
     if (tickFormat) format = tickFormat;
 

--- a/packages/vx-axis/src/axis/AxisBottom.js
+++ b/packages/vx-axis/src/axis/AxisBottom.js
@@ -17,6 +17,7 @@ export default function AxisBottom({
   tickFormat,
   tickStroke,
   tickTransform,
+  tickValues,
   tickLength = 8,
   tickLabelComponent = (
     <text
@@ -60,6 +61,7 @@ export default function AxisBottom({
       tickLength={tickLength}
       tickTransform={tickTransform}
       tickStroke={tickStroke}
+      tickValues={tickValues}
       labelOffset={labelOffset}
       tickLabelComponent={tickLabelComponent}
       hideAxisLine={hideAxisLine}

--- a/packages/vx-axis/src/axis/AxisLeft.js
+++ b/packages/vx-axis/src/axis/AxisLeft.js
@@ -17,6 +17,7 @@ export default function AxisLeft({
   tickFormat,
   tickStroke,
   tickTransform,
+  tickValues,
   tickLength = 8,
   tickLabelComponent = (
     <text
@@ -61,6 +62,7 @@ export default function AxisLeft({
       tickLength={tickLength}
       tickTransform={tickTransform}
       tickStroke={tickStroke}
+      tickValues={tickValues}
       labelOffset={labelOffset}
       tickLabelComponent={tickLabelComponent}
       hideAxisLine={hideAxisLine}

--- a/packages/vx-axis/src/axis/AxisRight.js
+++ b/packages/vx-axis/src/axis/AxisRight.js
@@ -17,6 +17,7 @@ export default function AxisRight({
   tickFormat,
   tickStroke,
   tickTransform,
+  tickValues,
   tickLength = 8,
   tickLabelComponent = (
     <text
@@ -61,6 +62,7 @@ export default function AxisRight({
       tickLength={tickLength}
       tickTransform={tickTransform}
       tickStroke={tickStroke}
+      tickValues={tickValues}
       labelOffset={labelOffset}
       tickLabelComponent={tickLabelComponent}
       hideAxisLine={hideAxisLine}

--- a/packages/vx-axis/src/axis/AxisTop.js
+++ b/packages/vx-axis/src/axis/AxisTop.js
@@ -17,6 +17,7 @@ export default function AxisTop({
   tickFormat,
   tickStroke,
   tickTransform,
+  tickValues,
   tickLength = 8,
   tickLabelComponent = (
     <text
@@ -60,6 +61,7 @@ export default function AxisTop({
       tickLength={tickLength}
       tickTransform={tickTransform}
       tickStroke={tickStroke}
+      tickValues={tickValues}
       labelOffset={labelOffset}
       tickLabelComponent={tickLabelComponent}
       hideAxisLine={hideAxisLine}

--- a/packages/vx-axis/test/Axis.test.js
+++ b/packages/vx-axis/test/Axis.test.js
@@ -10,53 +10,78 @@ const fakeScale = scaleLinear({
 
 describe('<Axis />', () => {
   test('it should be defined', () => {
-    expect(Axis).toBeDefined()
-  })
+    expect(Axis).toBeDefined();
+  });
 
   test('it should render with class .vx-axis', () => {
-    const wrapper = shallow(<Axis scale={fakeScale} />)
-    expect(wrapper.prop('className')).toEqual('vx-axis')
-  })
+    const wrapper = shallow(<Axis scale={fakeScale} />);
+    expect(wrapper.prop('className')).toEqual('vx-axis');
+  });
 
   test('it should pass users class down to element', () => {
-    const fakeClass = "test-class"
-    const wrapper = shallow(<Axis scale={fakeScale} className={fakeClass} />)
+    const fakeClass = "test-class";
+    const wrapper = shallow(<Axis scale={fakeScale} className={fakeClass} />);
     expect(wrapper.prop('className')).toEqual(`vx-axis ${fakeClass}`);
-  })
+  });
 
-  test('it should render the 0th element if the user so declares', () => {
+  test('it should render the 0th element if hideZero is false', () => {
     // Note that we're explicitly passing in false so that we're testing
     // the rendering, NOT wether or not this is a default value.
-    const wrapper = shallow(<Axis scale={fakeScale} hideZero={false} />)
+    const wrapper = shallow(<Axis scale={fakeScale} hideZero={false} />);
     expect(wrapper.find('.vx-axis-ticks').at(0).key()).toBe('vx-tick-0-0');
-  })
+  });
 
-  test('it should not show 0th tick if the user so declares', () => {
-    const wrapper = shallow(<Axis scale={fakeScale} hideZero />)
+  test('it should not show 0th tick if hideZero is true', () => {
+    const wrapper = shallow(<Axis scale={fakeScale} hideZero />);
     expect(wrapper.find('.vx-axis-ticks').at(0).key()).toBe('vx-tick-1-1');
-  })
+  });
 
-  test('it should SHOW an axis line if the user so declares', () => {
-    // Again, we're explicitly passing in false so we're testing 
+  test('it should SHOW an axis line if hideAxisLine is false', () => {
+    // Again, we're explicitly passing in false so we're testing
     // the rendering, NOT the default value.
-    const wrapper = shallow(<Axis scale={fakeScale} hideAxisLine={false} />)
+    const wrapper = shallow(<Axis scale={fakeScale} hideAxisLine={false} />);
     expect(wrapper.children().not(".vx-axis-ticks").find("Line").length).toBe(1);
-  })
+  });
 
-  test('it should HIDE an axis line if the user so declares', () => {
-    const wrapper = shallow(<Axis scale={fakeScale} hideAxisLine />)
+  test('it should HIDE an axis line if hideAxisLine is true', () => {
+    const wrapper = shallow(<Axis scale={fakeScale} hideAxisLine />);
     expect(wrapper.children().not(".vx-axis-ticks").find("Line").length).toBe(0);
-  })
+  });
 
-  test('it should SHOW ticks if the user', () => {
-    // Again, we're explicitly passing in false so we're testing 
+  test('it should SHOW ticks if hideTicks is false', () => {
+    // Again, we're explicitly passing in false so we're testing
     // the rendering, NOT the default value.
-    const wrapper = shallow(<Axis scale={fakeScale} hideTicks={false} />)
+    const wrapper = shallow(<Axis scale={fakeScale} hideTicks={false} />);
     expect(wrapper.children().find(".vx-axis-ticks").find("Line").length).toBeGreaterThan(0);
-  })
+  });
 
-  test('it should HIDE ticks if the user', () => {
-    const wrapper = shallow(<Axis scale={fakeScale} hideTicks />)
+  test('it should HIDE ticks if hideTicks is true', () => {
+    const wrapper = shallow(<Axis scale={fakeScale} hideTicks />);
     expect(wrapper.children().find(".vx-axis-ticks").find("Line").length).toBe(0);
-  })
+  });
+
+  test('it should render one tick for each value specified in tickValues', () => {
+    let wrapper = shallow(<Axis scale={fakeScale} tickValues={[]} />);
+    expect(wrapper.children().find(".vx-axis-ticks").find("Line").length).toBe(0);
+
+    wrapper = shallow(<Axis scale={fakeScale} tickValues={[0]} />);
+    expect(wrapper.children().find(".vx-axis-ticks").find("Line").length).toBe(1);
+
+    wrapper = shallow(<Axis scale={fakeScale} tickValues={[0, 1, 2, 3, 4, 5, 6]} />);
+    expect(wrapper.children().find(".vx-axis-ticks").find("Line").length).toBe(7);
+  });
+
+  test('it should use tickFormat to format ticks if passed', () => {
+    const wrapper = shallow(
+      <Axis scale={fakeScale} tickValues={[0]} tickFormat={(val, i) => 'test!!!'} />
+    );
+    expect(wrapper.children().find(".vx-axis-ticks").find("text").text()).toBe('test!!!');
+  });
+
+  test('tickFormat should have access to tick index', () => {
+    const wrapper = shallow(
+      <Axis scale={fakeScale} tickValues={[9]} tickFormat={(val, i) => i} />
+    );
+    expect(wrapper.children().find(".vx-axis-ticks").find("text").text()).toBe('0');
+  });
 })


### PR DESCRIPTION
This PR does the following with the goal of making the `Axis` ticks more customizable:

1) passes tick index as a second argument to the `tickFormat` function for more customizability options. 
2) adds a `tickValues` prop to all `Axis*` components that lets you specify exactly which tick values to show.
3) updates the readme to address #107 
4) adds `Axis` tests for the new functionality

New jest tests pass and tested`tickValues` and access to tick index in `tickFormat` functionally across all orientations in a linked [`@data-ui`](https://github.com/williaster/data-ui) repo:

<img width="547" alt="screen shot 2017-07-26 at 12 44 31 am" src="https://user-images.githubusercontent.com/4496521/28610732-2b8c4ac8-719e-11e7-93c0-c9814efc9402.png">
