### PR TITLE
[geo] add graticule

### DIFF
--- a/packages/vx-geo/src/graticule/Graticule.js
+++ b/packages/vx-geo/src/graticule/Graticule.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Group } from '@vx/group';
+import additionalProps from '../util/additionalProps';
+import { geoGraticule } from 'd3-geo';
+
+export default function Graticule({
+  graticule,
+  lines,
+  outline,
+  extent,
+  extentMajor,
+  extentMinor,
+  step,
+  stepMajor,
+  stepMinor,
+  precision,
+  ...restProps
+}) {
+  const currGraticule = geoGraticule();
+
+  if (extent) currGraticule.extent(extent);
+  if (extentMajor) currGraticule.extentMajor(extentMajor);
+  if (extentMinor) currGraticule.extentMinor(extentMinor);
+  if (step) currGraticule.step(step);
+  if (stepMajor) currGraticule.stepMajor(stepMajor);
+  if (stepMinor) currGraticule.stepMinor(stepMinor);
+  if (precision) currGraticule.stepMinor(precision);
+
+  return (
+    <Group className={`vx-geo-graticule`}>
+      {graticule &&
+        <path
+          d={graticule(currGraticule())}
+          fill="none"
+          stroke="black"
+          {...restProps}
+        />}
+      {lines &&
+        currGraticule.lines().map((line, i) =>
+          <g key={i}>
+            <path
+              d={lines(line)}
+              fill="none"
+              stroke="black"
+              {...additionalProps(restProps, {
+                ...line,
+                index: i
+              })}
+            />
+          </g>
+        )}
+      {outline &&
+        <path
+          d={outline(currGraticule.outline())}
+          fill="none"
+          stroke="black"
+          {...restProps}
+        />}
+    </Group>
+  );
+}
+
+Graticule.propTypes = {
+  graticule: PropTypes.func,
+  lines: PropTypes.func,
+  outline: PropTypes.func
+};

--- a/packages/vx-geo/src/projections/Graticule.js
+++ b/packages/vx-geo/src/projections/Graticule.js
@@ -1,1 +1,0 @@
-// TODO: Add graticule component.

--- a/packages/vx-geo/src/projections/Projection.js
+++ b/packages/vx-geo/src/projections/Projection.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Group } from '@vx/group';
 import additionalProps from '../util/additionalProps';
+import Graticule from '../graticule/Graticule';
 import { geoOrthographic, geoAlbers, geoMercator, geoPath } from 'd3-geo';
 
 // TODO: Implement all projections of d3-geo
@@ -29,6 +30,9 @@ export default function Projection({
   fitExtent,
   fitSize,
   centroid,
+  graticule,
+  graticuleLines,
+  graticuleOutline,
   className,
   ...restProps
 }) {
@@ -47,14 +51,24 @@ export default function Projection({
   const path = geoPath().projection(currProjection);
 
   return (
-    <Group className={`vx-${projection}-group`}>
+    <Group className={`vx-geo`}>
+      {graticule &&
+        !graticule.foreGround &&
+        <Graticule graticule={g => path(g)} {...graticule} />}
+      {graticuleLines &&
+        !graticuleLines.foreGround &&
+        <Graticule lines={g => path(g)} {...graticuleLines} />}
+      {graticuleOutline &&
+        !graticuleOutline.foreGround &&
+        <Graticule outline={g => path(g)} {...graticuleOutline} />}
+
       {data.map((feature, i) => {
         let c;
         if (centroid) c = path.centroid(feature);
         return (
           <g key={`${projection}-${i}`}>
             <path
-              className={classnames(`vx-${projection}`, className)}
+              className={`vx-geo-${projection}`}
               d={path(feature)}
               {...additionalProps(restProps, {
                 ...feature,
@@ -68,6 +82,16 @@ export default function Projection({
       })}
       {/* TODO: Maybe find a different way to pass projection function to use for example invert */}
       {projectionFunc && projectionFunc(currProjection)}
+
+      {graticule &&
+        graticule.foreGround &&
+        <Graticule graticule={g => path(g)} {...graticule} />}
+      {graticuleLines &&
+        graticuleLines.foreGround &&
+        <Graticule lines={g => path(g)} {...graticuleLines} />}
+      {graticuleOutline &&
+        graticuleOutline.foreGround &&
+        <Graticule outline={g => path(g)} {...graticuleOutline} />}
     </Group>
   );
 }


### PR DESCRIPTION
Implemented graticule for projection's.

<img width="500" alt="bildschirmfoto 2017-08-02 um 01 13 28" src="https://user-images.githubusercontent.com/3831579/28850973-e0f95ab4-771f-11e7-9244-11c97d7a9192.png">

Draw graticule:
```js
<Mercator
  data={world.features}
  scale={width / 630 * 100}
  translate={[width / 2, height / 2 + 50]}
  fill={() => '#8be4c5'}
  stroke={() => '#5fcfa7'}
  graticule={{
    stroke: 'rgba(85, 189, 213, 0.3)'
  }}
/>
```
Graticule lines in foreground of the map and outline:
```js
<Mercator
  //...
  graticuleLines={{
    foreGround: true,
    stroke: (data) => 'rgba(85, 189, 213, 0.3)'
  }}
  graticuleOutline={{
    stroke: 'rgba(85, 189, 213, 0.3)'
  }}
/>
```

Any other ideas to implement graticule. I think graticule as prop is fine because a graticule without a projection doesn't make sense.