### PR TITLE
[bounds] move react-dom to peerDeps

### DIFF
--- a/packages/vx-bounds/package.json
+++ b/packages/vx-bounds/package.json
@@ -8,19 +8,12 @@
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "visualizations", "charts"],
   "author": "Chris Williams @williaster",
   "license": "MIT",
   "bugs": {
@@ -35,16 +28,17 @@
     "enzyme": "^2.8.2",
     "jest": "^20.0.3",
     "react": "^15.0.0 || 15.x",
+    "react-dom": "^15.0.0 || 15.x",
     "react-addons-test-utils": "^15.4.2",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
   "dependencies": {
-    "prop-types": "^15.5.10",
-    "react-dom": "^15.0.0 || 15.x"
+    "prop-types": "^15.5.10"
   },
   "peerDependencies": {
-    "react": "^15.0.0 || 15.x"
+    "react": "^15.0.0 || 15.x",
+    "react-dom": "^15.0.0 || 15.x"
   }
 }


### PR DESCRIPTION
Moving `react-dom` to peerDeps. Fixes https://github.com/hshoff/vx/issues/130

cc @williaster 