### PR TITLE
make `@vx/axis` api more sane, update docs

### DIFF
--- a/packages/vx-axis/Readme.md
+++ b/packages/vx-axis/Readme.md
@@ -189,7 +189,7 @@ function MyChart() {
 | labelProps         | `{ textAnchor: 'middle', fontFamily: 'Arial', fontSize: 10, fill: 'black' }` | object | Props applied to the axis label component              |
 | left               | `0`             | number   | A left pixel offset applied to the entire axis.                                                                 |
 | numTicks           | `10`            | number   | The number of ticks wanted for the axis (note this is approximate)                                              |
-| orientation        | REQUIRED        | 'top', 'right', 'bottom', or 'left' | Specifies the orientation of the axis.                                               |
+| orientation        | `bottom`        | 'top', 'right', 'bottom', or 'left' | Specifies the orientation of the axis.                                               |
 | rangePadding       | `0`             | number   | Px padding to apply to both sides of the axis                                                                   |
 | scale              | REQUIRED        | function | A d3 [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale).                              |
 | stroke             | `black`         | string   | The color for the stroke of the lines.                                                                          |

--- a/packages/vx-axis/Readme.md
+++ b/packages/vx-axis/Readme.md
@@ -4,197 +4,207 @@
 npm install --save @vx/axis
 ```
 
-An axis is a line with ticks that helps you label your graphs.
+An axis component consists of a line with ticks, tick labels, and an axis label that helps viewers interpret your graph.
 
-You can use one of the 4 pre-made axes or you can create your own based on the `<Axis />` element.
+You can use one of the 4 pre-made axes, or you can create your own based on the `<Axis />` element.
 
 ## Example
 
 ![Axis Example](http://i.imgur.com/uNIgPsg.png)
 
-``` js
+```javascript
 import { AxisBottom, AxisLeft } from '@vx/axis';
 // or
 // import * as Axis from '@vx/axis';
 // <Axis.AxisBottom />
+// or
+// import AxisBottom from '@vx/axis/build/Axis/AxisBottom';
 
-const axis = (
-  <AxisBottom
-    scale={xScale}
-    top={yMax + margin.top}
-    left={margin.left}
-    label={'My string label'}
-    stroke={'#1b1a1e'}
-    tickTextFill={'#1b1a1e'}
-  />
-  <AxisLeft
-    scale={yScale}
-    top={margin.top}
-    left={margin.left}
-    label={<text {...labelStyles}>My component label</text>}
-    stroke={'#1b1a1e'}
-    tickTextFill={'#1b1a1e'}
-  />
-);
+
+function MyChart() {
+  // ...
+  return (
+    <svg>
+      // ...
+      <AxisBottom
+        scale={xScale}
+        top={yMax + margin.top}
+        left={margin.left}
+        axisClassName="axis-class"
+        labelClassName="axis-label-class"
+        tickClassName="tick-label-class"
+        label="Bottom axis label"
+        stroke="#333333"
+        tickStroke="#333333"
+      />
+      <AxisLeft
+        scale={yScale}
+        top={margin.top}
+        left={margin.left}
+        label="Left axis label"
+        labelProps={{ fontSize: 12, fill: 'black' }}
+        tickFormat={(value, index) => `$${value}`}
+        tickProps={(value, index) => ({
+          dx: "0.33em",
+          fill: "black",
+          fontSize: 8,
+          opacity: index % 2 === 0 ? 0.5 : 0.9,
+        })}
+      />
+    </svg>
+  );
+}
 ```
 
-## `<AxisTop/>`
+## `<AxisBottom />`
 
-|        Name        | Default  |   Type   |                                                   Description                                                   |
-|:------------------ |:-------- |:-------- |:--------------------------------------------------------------------------------------------------------------- |
-| scale              |          | function | A d3 [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale).                              |
-| top                |          | number   | A pixel value for the top margin.                                                                               |
-| left               |          | number   | A pixel value for the top margin.                                                                               |
-| stroke             |          | string   | The color for the stroke of the lines.                                                                          |
-| strokeWidth        |          | number   | The pixel value for the width of the lines.                                                                     |
-| strokeDasharray    |          | array    | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
-| label              |          | string or node | The text for the axis label, or a label component                                                         |
-| numTicks           | 10       | number   | The number of ticks wanted for the axis.                                                                        |
-| tickFormat         |          | function | A [d3 formatter](https://github.com/d3/d3-scale/blob/master/README.md#continuous_tickFormat) for the tick text. |
-| tickStroke         | black    | string   | The color for the tick's stroke value.                                                                          |
-| tickValues         |          | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
-| tickK              | -1       | number   | A value that determines an offset in the tick position.                                                         |
-| tickOffset         |          | number   | A value that determines the y offset in the tick position.                                                      |
-| tickTransform      |          | string   | A custom SVG transform value to be applied to the ticks.                                                        |
-| tickLength         | 8        | number   | The length of the tick lines.                                                                                   |
-| tickPadding        | 2        | number   | The padding between the ticks and their labels.                                                                 |
-| tickTextAnchor     | "middle" | string   | The textAnchor value for the tick's text.                                                                       |
-| tickTextFontFamily | "Arial"  | string   | The font for the ticks.                                                                                         |
-| tickTextFontSize   | 10       | number   | The font size for the ticks.                                                                                    |
-| tickTextFill       | black    | string   | The text fill color for the tick's text.                                                                        |
-| tickTextDy         |          | number   | The y offset to the tick's text.                                                                                |
-| tickTextDx         |          | number   | The x offset to the tick's text.                                                                                |
-| hideAxisLine       | false    | bool     | If true, will hide the axis line.                                                                               |
-| hideTicks          | false    | bool     | If true, will hide the ticks.                                                                                   |
-| hideZero           | false    | bool     | If true, will hide '0' values.                                                                                  |
-| className          |          | string   | The class name applied to the axis group element.                                                               |
+|        Name        |     Default     |   Type   |                                                   Description                                                   |
+|:------------------ |:--------------- |:-------- |:--------------------------------------------------------------------------------------------------------------- |
+| axisClassName      |                 | string   | The class name applied to the outermost axis group element.                                                     |
+| axisLineClassName  |                 | string   | The class name applied to the axis line element.                                                                |
+| hideAxisLine       | `false`         | bool     | If true, will hide the axis line.                                                                               |
+| hideTicks          | `false`         | bool     | If true, will hide the ticks (but not the tick labels).                                                         |
+| hideZero           | `false`         | bool     | If true, will hide the '0' value tick and tick label.                                                           |
+| label              | `""`            | string   | The text for the axis label.                                                                                    |
+| labelClassName     |                 | string   | The class name applied to the axis label text element.                                                          |
+| labelOffset        | `8`             | number   | Px offset of the axis label (does not include tick label font size, which is accounted for automatically)       |
+| labelProps         | `{ textAnchor: 'middle', fontFamily: 'Arial', fontSize: 10, fill: 'black' }` | object | Props applied to the axis label component.           |
+| left               | `0`             | number   | A left pixel offset applied to the entire axis.                                                                 |
+| numTicks           | `10`            | number   | The number of ticks wanted for the axis (note this is approximate)                                              |
+| rangePadding       | `0`             | number   | Px padding to apply to both sides of the axis                                                                   |
+| scale              | REQUIRED        | function | A d3 [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale).                              |
+| stroke             | `black`         | string   | The color for the stroke of the lines.                                                                          |
+| strokeWidth        | `1`             | number   | The pixel value for the width of the lines.                                                                     |
+| strokeDasharray    |                 | string   | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
+| tickClassName      |                 | string   | The class name applied to each tick group.                                                                      |
+| tickFormat         | `(val, i) => val` | function | A [d3 formatter](https://github.com/d3/d3-scale/blob/master/README.md#continuous_tickFormat) for the tick text. |
+| tickLabelProps     | `(val, i) => ({ dy: '0.25em', textAnchor: 'middle', fontFamily: 'Arial', fontSize: 10, fill: 'black' })` | function | function that returns props for a given tick label. |
+| tickLength         | `8`             | number   | The length of the tick lines.                                                                                   |
+| tickStroke         | `black`         | string   | The color for the tick's stroke value.                                                                          |
+| tickTransform      |                 | string   | A custom SVG transform value to be applied to each tick group.                                                  |
+| tickValues         |                 | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
+| top                | `0`             | number   | A top pixel offset applied to the entire axis.                                                                  |
 
-## `<AxisBottom/>`
 
-|        Name        | Default  |   Type   |                                                   Description                                                   |
-|:------------------ |:-------- |:-------- |:--------------------------------------------------------------------------------------------------------------- |
-| scale              |          | function | A d3 [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale).                              |
-| top                |          | number   | A pixel value for the top margin.                                                                               |
-| left               |          | number   | A pixel value for the top margin.                                                                               |
-| stroke             |          | string   | The color for the stroke of the lines.                                                                          |
-| strokeWidth        |          | number   | The pixel value for the width of the lines.                                                                     |
-| strokeDasharray    |          | array    | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
-| label              |          | string   | The text for the axis label.                                                                                    |
-| numTicks           | 10       | number   | The number of ticks wanted for the axis.                                                                        |
-| tickFormat         |          | function | A [d3 formatter](https://github.com/d3/d3-scale/blob/master/README.md#continuous_tickFormat) for the tick text. |
-| tickStroke         | black    | string   | The color for the tick's stroke value.                                                                          |
-| tickValues         |          | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
-| tickK              | 1        | number   | A value that determines an offset in the tick position.                                                         |
-| tickOffset         |          | number   | A value that determines the y offset in the tick position.                                                      |
-| tickTransform      |          | string   | A custom SVG transform value to be applied to the ticks.                                                        |
-| tickLength         | 8        | number   | The length of the tick lines.                                                                                   |
-| tickPadding        | 2        | number   | The padding between the ticks and their labels.                                                                 |
-| tickTextAnchor     | "middle" | string   | The textAnchor value for the tick's text.                                                                       |
-| tickTextFontFamily | "Arial"  | string   | The font for the ticks.                                                                                         |
-| tickTextFontSize   | 10       | number   | The font size for the ticks.                                                                                    |
-| tickTextFill       | black    | string   | The text fill color for the tick's text.                                                                        |
-| tickTextDy         |          | number   | The y offset to the tick's text.                                                                                |
-| tickTextDx         |          | number   | The x offset to the tick's text.                                                                                |
-| hideAxisLine       | false    | bool     | If true, will hide the axis line.                                                                               |
-| hideTicks          | false    | bool     | If true, will hide the ticks.                                                                                   |
-| hideZero           | false    | bool     | If true, will hide '0' values.                                                                                  |
-| className          |          | string   | The class name applied to the axis group element.                                                               |
+## `<AxisLeft />`
 
-## `<AxisLeft/>`
+|        Name        |     Default     |   Type   |                                                   Description                                                   |
+|:------------------ |:--------------- |:-------- |:--------------------------------------------------------------------------------------------------------------- |
+| axisClassName      |                 | string   | The class name applied to the outermost axis group element.                                                     |
+| axisLineClassName  |                 | string   | The class name applied to the axis line element.                                                                |
+| hideAxisLine       | `false`         | bool     | If true, will hide the axis line.                                                                               |
+| hideTicks          | `false`         | bool     | If true, will hide the ticks (but not the tick labels).                                                         |
+| hideZero           | `false`         | bool     | If true, will hide the '0' value tick and tick label.                                                           |
+| label              | `""`            | string   | The text for the axis label.                                                                                    |
+| labelClassName     |                 | string   | The class name applied to the axis label text element.                                                          |
+| labelOffset        | `36`            | number   | Px offset of the axis label (does not include tick label font size, which is accounted for automatically)       |
+| labelProps         | `{ textAnchor: 'middle', fontFamily: 'Arial', fontSize: 10, fill: 'black' }` | object | Props applied to the axis label component.           |
+| left               | `0`             | number   | A left pixel offset applied to the entire axis.                                                                 |
+| numTicks           | `10`            | number   | The number of ticks wanted for the axis (note this is approximate)                                              |
+| rangePadding       | `0`             | number   | Px padding to apply to both sides of the axis                                                                   |
+| scale              | REQUIRED        | function | A d3 [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale).                              |
+| stroke             | `black`         | string   | The color for the stroke of the lines.                                                                          |
+| strokeWidth        | `1`             | number   | The pixel value for the width of the lines.                                                                     |
+| strokeDasharray    |                 | string   | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
+| tickClassName      |                 | string   | The class name applied to each tick group.                                                                      |
+| tickFormat         | `(val, i) => val` | function | A [d3 formatter](https://github.com/d3/d3-scale/blob/master/README.md#continuous_tickFormat) for the tick text. |
+| tickLabelProps     | `(val, i) => ({ dx: '-0.25em', dy: '0.25em', textAnchor: 'end', fontFamily: 'Arial', fontSize: 10, fill: 'black' })` | function | function that returns props for a given tick label. |
+| tickLength         | `8`             | number   | The length of the tick lines.                                                                                   |
+| tickStroke         | `black`         | string   | The color for the tick's stroke value.                                                                          |
+| tickTransform      |                 | string   | A custom SVG transform value to be applied to each tick group.                                                  |
+| tickValues         |                 | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
+| top                | `0`             | number   | A top pixel offset applied to the entire axis.                                                                  |
 
-|        Name        | Default |   Type   |                                                   Description                                                   |
-|:------------------ |:------- |:-------- |:--------------------------------------------------------------------------------------------------------------- |
-| scale              |         | function | A d3 [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale).                              |
-| top                |         | number   | A pixel value for the top margin.                                                                               |
-| left               |         | number   | A pixel value for the top margin.                                                                               |
-| stroke             |         | string   | The color for the stroke of the lines.                                                                          |
-| strokeWidth        |         | number   | The pixel value for the width of the lines.                                                                     |
-| strokeDasharray    |         | array    | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
-| label              |         | string   | The text for the axis label.                                                                                    |
-| numTicks           | 10      | number   | The number of ticks wanted for the axis.                                                                        |
-| tickFormat         |         | function | A [d3 formatter](https://github.com/d3/d3-scale/blob/master/README.md#continuous_tickFormat) for the tick text. |
-| tickStroke         | black   | string   | The color for the tick's stroke value.                                                                          |
-| tickValues         |         | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
-| tickK              | -1      | number   | A value that determines an offset in the tick position.                                                         |
-| tickOffset         |         | number   | A value that determines the y offset in the tick position.                                                      |
-| tickTransform      |         | string   | A custom SVG transform value to be applied to the ticks.                                                        |
-| tickLength         | 8       | number   | The length of the tick lines.                                                                                   |
-| tickPadding        | 2       | number   | The padding between the ticks and their labels.                                                                 |
-| tickTextAnchor     | "end"   | string   | The textAnchor value for the tick's text.                                                                       |
-| tickTextFontFamily | "Arial" | string   | The font for the ticks.                                                                                         |
-| tickTextFontSize   | 10      | number   | The font size for the ticks.                                                                                    |
-| tickTextFill       | black   | string   | The text fill color for the tick's text.                                                                        |
-| tickTextDy         |         | number   | The y offset to the tick's text.                                                                                |
-| tickTextDx         |         | number   | The x offset to the tick's text.                                                                                |
-| hideAxisLine       | false   | bool     | If true, will hide the axis line.                                                                               |
-| hideTicks          | false   | bool     | If true, will hide the ticks.                                                                                   |
-| hideZero           | false   | bool     | If true, will hide '0' values.                                                                                  |
-| className          |         | string   | The class name applied to the axis group element.                                                               |
+## `<AxisRight />`
 
-## `<AxisRight/>`
+|        Name        |     Default     |   Type   |                                                   Description                                                   |
+|:------------------ |:--------------- |:-------- |:--------------------------------------------------------------------------------------------------------------- |
+| axisClassName      |                 | string   | The class name applied to the outermost axis group element.                                                     |
+| axisLineClassName  |                 | string   | The class name applied to the axis line element.                                                                |
+| hideAxisLine       | `false`         | bool     | If true, will hide the axis line.                                                                               |
+| hideTicks          | `false`         | bool     | If true, will hide the ticks (but not the tick labels).                                                         |
+| hideZero           | `false`         | bool     | If true, will hide the '0' value tick and tick label.                                                           |
+| label              | `""`            | string   | The text for the axis label.                                                                                    |
+| labelClassName     |                 | string   | The class name applied to the axis label text element.                                                          |
+| labelOffset        | `36`            | number   | Px offset of the axis label (does not include tick label font size, which is accounted for automatically)       |
+| labelProps         | `{ textAnchor: 'middle', fontFamily: 'Arial', fontSize: 10, fill: 'black' }` | object | Props applied to the axis label component.           |
+| left               | `0`             | number   | A left pixel offset applied to the entire axis.                                                                 |
+| numTicks           | `10`            | number   | The number of ticks wanted for the axis (note this is approximate)                                              |
+| rangePadding       | `0`             | number   | Px padding to apply to both sides of the axis                                                                   |
+| scale              | REQUIRED        | function | A d3 [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale).                              |
+| stroke             | `black`         | string   | The color for the stroke of the lines.                                                                          |
+| strokeWidth        | `1`             | number   | The pixel value for the width of the lines.                                                                     |
+| strokeDasharray    |                 | string   | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
+| tickClassName      |                 | string   | The class name applied to each tick group.                                                                      |
+| tickFormat         | `(val, i) => val` | function | A [d3 formatter](https://github.com/d3/d3-scale/blob/master/README.md#continuous_tickFormat) for the tick text. |
+| tickLabelProps     | `(val, i) => ({ dx: '0.25em', dy: '0.25em', textAnchor: 'start', fontFamily: 'Arial', fontSize: 10, fill: 'black' })` | function | function that returns props for a given tick label. |
+| tickLength         | `8`             | number   | The length of the tick lines.                                                                                   |
+| tickStroke         | `black`         | string   | The color for the tick's stroke value.                                                                          |
+| tickTransform      |                 | string   | A custom SVG transform value to be applied to each tick group.                                                  |
+| tickValues         |                 | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
+| top                | `0`             | number   | A top pixel offset applied to the entire axis.                                                                  |
 
-|        Name        | Default |   Type   |                                                   Description                                                   |
-|:------------------ |:------- |:-------- |:--------------------------------------------------------------------------------------------------------------- |
-| scale              |         | function | A d3 [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale).                              |
-| top                |         | number   | A pixel value for the top margin.                                                                               |
-| left               |         | number   | A pixel value for the top margin.                                                                               |
-| stroke             |         | string   | The color for the stroke of the lines.                                                                          |
-| strokeWidth        |         | number   | The pixel value for the width of the lines.                                                                     |
-| strokeDasharray    |         | array    | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
-| label              |         | string   | The text for the axis label.                                                                                    |
-| numTicks           | 10      | number   | The number of ticks wanted for the axis.                                                                        |
-| tickFormat         |         | function | A [d3 formatter](https://github.com/d3/d3-scale/blob/master/README.md#continuous_tickFormat) for the tick text. |
-| tickStroke         | black   | string   | The color for the tick's stroke value.                                                                          |
-| tickValues         |         | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
-| tickK              | 1       | number   | A value that determines an offset in the tick position.                                                         |
-| tickOffset         |         | number   | A value that determines the y offset in the tick position.                                                      |
-| tickTransform      |         | string   | A custom SVG transform value to be applied to the ticks.                                                        |
-| tickLength         | 8       | number   | The length of the tick lines.                                                                                   |
-| tickPadding        | 2       | number   | The padding between the ticks and their labels.                                                                 |
-| tickTextAnchor     | "start" | string   | The textAnchor value for the tick's text.                                                                       |
-| tickTextFontFamily | "Arial" | string   | The font for the ticks.                                                                                         |
-| tickTextFontSize   | 10      | number   | The font size for the ticks.                                                                                    |
-| tickTextFill       | black   | string   | The text fill color for the tick's text.                                                                        |
-| tickTextDy         |         | number   | The y offset to the tick's text.                                                                                |
-| tickTextDx         |         | number   | The x offset to the tick's text.                                                                                |
-| hideAxisLine       | false   | bool     | If true, will hide the axis line.                                                                               |
-| hideTicks          | false   | bool     | If true, will hide the ticks.                                                                                   |
-| hideZero           | false   | bool     | If true, will hide '0' values.                                                                                  |
-| className          |         | string   | The class name applied to the axis group element.                                                               |
+## `<AxisTop />`
+
+|        Name        |     Default     |   Type   |                                                   Description                                                   |
+|:------------------ |:--------------- |:-------- |:--------------------------------------------------------------------------------------------------------------- |
+| axisClassName      |                 | string   | The class name applied to the outermost axis group element.                                                     |
+| axisLineClassName  |                 | string   | The class name applied to the axis line element.                                                                |
+| hideAxisLine       | `false`         | bool     | If true, will hide the axis line.                                                                               |
+| hideTicks          | `false`         | bool     | If true, will hide the ticks (but not the tick labels).                                                         |
+| hideZero           | `false`         | bool     | If true, will hide the '0' value tick and tick label.                                                           |
+| label              | `""`            | string   | The text for the axis label.                                                                                    |
+| labelClassName     |                 | string   | The class name applied to the axis label text element.                                                          |
+| labelOffset        | `8`             | number   | Px offset of the axis label (does not include tick label font size, which is accounted for automatically)       |
+| labelProps         | `{ textAnchor: 'middle', fontFamily: 'Arial', fontSize: 10, fill: 'black' }` | object | Props applied to the axis label component.           |
+| left               | `0`             | number   | A left pixel offset applied to the entire axis.                                                                 |
+| numTicks           | `10`            | number   | The number of ticks wanted for the axis (note this is approximate)                                              |
+| rangePadding       | `0`             | number   | Px padding to apply to both sides of the axis                                                                   |
+| scale              | REQUIRED        | function | A d3 [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale).                              |
+| stroke             | `black`         | string   | The color for the stroke of the lines.                                                                          |
+| strokeWidth        | `1`             | number   | The pixel value for the width of the lines.                                                                     |
+| strokeDasharray    |                 | string   | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
+| tickClassName      |                 | string   | The class name applied to each tick group.                                                                      |
+| tickFormat         | `(val, i) => val` | function | A [d3 formatter](https://github.com/d3/d3-scale/blob/master/README.md#continuous_tickFormat) for the tick text. |
+| tickLabelProps     | `(val, i) => ({ dy: '-0.25em', textAnchor: 'middle', fontFamily: 'Arial', fontSize: 10, fill: 'black' })` | function | function that returns props for a given tick label. |
+| tickLength         | `8`             | number   | The length of the tick lines.                                                                                   |
+| tickStroke         | `black`         | string   | The color for the tick's stroke value.                                                                          |
+| tickTransform      |                 | string   | A custom SVG transform value to be applied to each tick group.                                                  |
+| tickValues         |                 | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
+| top                | `0`             | number   | A top pixel offset applied to the entire axis.                                                                  |
+
 
 ## `<Axis />`
 
 |        Name        |     Default     |   Type   |                                                   Description                                                   |
 |:------------------ |:--------------- |:-------- |:--------------------------------------------------------------------------------------------------------------- |
-| scale              |                 | function | A d3 [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale).                              |
-| orient             |                 | string   | An orientation defined as 'top', 'bottom', 'left', or 'right'.                                                  |
-| top                |                 | number   | A pixel value for the top margin.                                                                               |
-| left               |                 | number   | A pixel value for the top margin.                                                                               |
-| stroke             |                 | string   | The color for the stroke of the lines.                                                                          |
-| strokeWidth        |                 | number   | The pixel value for the width of the lines.                                                                     |
-| strokeDasharray    |                 | array    | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
-| label              | "default label" | string   | The text for the axis label.                                                                                    |
-| numTicks           | 10              | number   | The number of ticks wanted for the axis.                                                                        |
-| tickFormat         |                 | function | A [d3 formatter](https://github.com/d3/d3-scale/blob/master/README.md#continuous_tickFormat) for the tick text. |
-| tickStroke         | black           | string   | The color for the tick's stroke value.                                                                          
+| axisClassName      |                 | string   | The class name applied to the outermost axis group element.                                                     |
+| axisLineClassName  |                 | string   | The class name applied to the axis line element.                                                                |
+| hideAxisLine       | `false`         | bool     | If true, will hide the axis line.                                                                               |
+| hideTicks          | `false`         | bool     | If true, will hide the ticks (but not the tick labels).                                                         |
+| hideZero           | `false`         | bool     | If true, will hide the '0' value tick and tick label.                                                           |
+| label              | `""`            | string   | The text for the axis label.                                                                                    |
+| labelClassName     |                 | string   | The class name applied to the axis label text element.                                                          |
+| labelOffset        | `14`            | number   | Px offset of the axis label (does not include tick label font size, which is accounted for automatically)       |
+| labelProps         | `{ textAnchor: 'middle', fontFamily: 'Arial', fontSize: 10, fill: 'black' }` | object | Props applied to the axis label component              |
+| left               | `0`             | number   | A left pixel offset applied to the entire axis.                                                                 |
+| numTicks           | `10`            | number   | The number of ticks wanted for the axis (note this is approximate)                                              |
+| orientation        | REQUIRED        | 'top', 'right', 'bottom', or 'left' | Specifies the orientation of the axis.                                               |
+| rangePadding       | `0`             | number   | Px padding to apply to both sides of the axis                                                                   |
+| scale              | REQUIRED        | function | A d3 [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale).                              |
+| stroke             | `black`         | string   | The color for the stroke of the lines.                                                                          |
+| strokeWidth        | `1`             | number   | The pixel value for the width of the lines.                                                                     |
+| strokeDasharray    |                 | string   | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
+| tickClassName      |                 | string   | The class name applied to each tick group.                                                                      |
+| tickFormat         | `(val, i) => val` | function | A [d3 formatter](https://github.com/d3/d3-scale/blob/master/README.md#continuous_tickFormat) for the tick text. |
+| tickLabelProps     | `(val, i) => ({ textAnchor: 'middle', fontFamily: 'Arial', fontSize: 10, fill: 'black' })` | function | function that returns props for a given tick label. |
+| tickLength         | `8`             | number   | The length of the tick lines.                                                                                   |
+| tickStroke         | `black`         | string   | The color for the tick's stroke value.                                                                          |
+| tickTransform      |                 | string   | A custom SVG transform value to be applied to each tick group.                                                  |
 | tickValues         |                 | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
-| tickK              | 1               | number   | A value that determines an offset in the tick position.                                                         |
-| tickOffset         |                 | number   | A value that determines the y offset in the tick position.                                                      |
-| tickTransform      |                 | string   | A custom SVG transform value to be applied to the ticks.                                                        |
-| tickLength         | 8               | number   | The length of the tick lines.                                                                                   |
-| tickPadding        | 2               | number   | The padding between the ticks and their labels.                                                                 |
-| tickTextAnchor     | "start"         | string   | The textAnchor value for the tick's text.                                                                       |
-| tickTextFontFamily | "Arial"         | string   | The font for the ticks.                                                                                         |
-| tickTextFontSize   | 10              | number   | The font size for the ticks.                                                                                    |
-| tickTextFill       | black           | string   | The text fill color for the tick's text.                                                                        |
-| tickTextDy         |                 | number   | The y offset to the tick's text.                                                                                |
-| tickTextDx         |                 | number   | The x offset to the tick's text.                                                                                |
-| hideAxisLine       | false           | bool     | If true, will hide the axis line.                                                                               |
-| hideTicks          | false           | bool     | If true, will hide the ticks.                                                                                   |
-| hideZero           | false           | bool     | If true, will hide '0' values.                                                                                  |
-| className          |                 | string   | The class name applied to the axis group element.                                                               |
+| top                | `0`             | number   | A top pixel offset applied to the entire axis.                                                                  |
 
-
+## Source code
 + [`<Axis />`](https://github.com/hshoff/vx/blob/master/packages/vx-axis/src/axis/Axis.js)
 + [`<AxisLeft />`](https://github.com/hshoff/vx/blob/master/packages/vx-axis/src/axis/AxisLeft.js)
 + [`<AxisBottom />`](https://github.com/hshoff/vx/blob/master/packages/vx-axis/src/axis/AxisBottom.js)

--- a/packages/vx-axis/package.json
+++ b/packages/vx-axis/package.json
@@ -33,7 +33,7 @@
     "@vx/point": "0.0.136",
     "@vx/shape": "0.0.136",
     "classnames": "^2.2.5",
-    "prop-types": "^15.5.10"
+    "prop-types": "15.5.10"
   },
   "devDependencies": {
     "babel-jest": "^20.0.3",

--- a/packages/vx-axis/package.json
+++ b/packages/vx-axis/package.json
@@ -32,7 +32,8 @@
     "@vx/group": "0.0.136",
     "@vx/point": "0.0.136",
     "@vx/shape": "0.0.136",
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "prop-types": "^15.5.10"
   },
   "devDependencies": {
     "babel-jest": "^20.0.3",

--- a/packages/vx-axis/src/axis/Axis.js
+++ b/packages/vx-axis/src/axis/Axis.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Line } from '@vx/shape';
 import { Point } from '@vx/point';
@@ -20,7 +21,7 @@ const propTypes = {
   labelProps: PropTypes.object,
   left: PropTypes.number,
   numTicks: PropTypes.number,
-  orientation: PropTypes.oneOf([ORIENT.top, ORIENT.right, ORIENT.bottom, ORIENT.left]).isRequired,
+  orientation: PropTypes.oneOf([ORIENT.top, ORIENT.right, ORIENT.bottom, ORIENT.left]),
   rangePadding: PropTypes.number,
   scale: PropTypes.func.isRequired,
   stroke: PropTypes.string,
@@ -53,6 +54,7 @@ export default function Axis({
   },
   left = 0,
   numTicks = 10,
+  orientation = ORIENT.bottom,
   rangePadding = 0,
   scale,
   stroke = 'black',
@@ -60,7 +62,7 @@ export default function Axis({
   strokeDasharray,
   tickClassName,
   tickFormat,
-  tickLabelProps = ({ tick, index }) => ({
+  tickLabelProps = (tickValue, index) => ({
     textAnchor: 'middle',
     fontFamily: 'Arial',
     fontSize: 10,

--- a/packages/vx-axis/src/axis/Axis.js
+++ b/packages/vx-axis/src/axis/Axis.js
@@ -148,7 +148,7 @@ export default function Axis({
 
         {!hideAxisLine &&
           <Line
-            className={axisLineClassName}
+            className={cx('vx-axis-line', axisLineClassName)}
             from={axisFromPoint}
             to={axisToPoint}
             stroke={stroke}

--- a/packages/vx-axis/src/axis/AxisBottom.js
+++ b/packages/vx-axis/src/axis/AxisBottom.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Axis from './Axis';
 import ORIENT from '../constants/orientation';
@@ -56,7 +57,7 @@ export default function AxisBottom({
     fontSize: 10,
     textAnchor: 'middle',
   }),
-  tickLength,
+  tickLength = 8,
   tickStroke,
   tickTransform,
   tickValues,

--- a/packages/vx-axis/src/axis/AxisBottom.js
+++ b/packages/vx-axis/src/axis/AxisBottom.js
@@ -3,70 +3,94 @@ import cx from 'classnames';
 import Axis from './Axis';
 import ORIENT from '../constants/orientation';
 
+const propTypes = {
+  axisClassName: PropTypes.string,
+  axisLineClassName: PropTypes.string,
+  hideAxisLine: PropTypes.bool,
+  hideTicks: PropTypes.bool,
+  hideZero: PropTypes.bool,
+  label: PropTypes.string,
+  labelClassName: PropTypes.string,
+  labelOffset: PropTypes.number,
+  labelProps: PropTypes.object,
+  left: PropTypes.number,
+  numTicks: PropTypes.number,
+  rangePadding: PropTypes.number,
+  scale: PropTypes.func.isRequired,
+  stroke: PropTypes.string,
+  strokeWidth: PropTypes.number,
+  strokeDasharray: PropTypes.string,
+  tickClassName: PropTypes.string,
+  tickFormat: PropTypes.func,
+  tickLabelProps: PropTypes.func,
+  tickLength: PropTypes.number,
+  tickStroke: PropTypes.string,
+  tickTransform: PropTypes.string,
+  tickValues: PropTypes.arrayOf(PropTypes.number),
+  top: PropTypes.number,
+};
+
 export default function AxisBottom({
-  scale,
-  top,
-  left,
-  stroke,
-  strokeWidth,
-  strokeDasharray,
-  rangePadding,
-  label,
-  labelOffset = 8,
-  numTicks,
-  tickFormat,
-  tickStroke,
-  tickTransform,
-  tickValues,
-  tickLength = 8,
-  tickLabelComponent = (
-    <text
-      textAnchor="middle"
-      fontFamily="Arial"
-      fontSize={10}
-      fill="black"
-      dy="0.25em"
-    />
-  ),
+  axisClassName,
+  axisLineClassName,
   hideAxisLine,
   hideTicks,
   hideZero,
-  className,
+  label,
+  labelClassName,
+  labelOffset = 8,
+  labelProps,
+  left,
+  numTicks,
+  rangePadding,
+  scale,
+  stroke,
+  strokeWidth,
+  strokeDasharray,
+  tickClassName,
+  tickFormat,
+  tickLabelProps = ({ tick, index }) => ({
+    dy: '0.25em',
+    fill: 'black',
+    fontFamily: 'Arial',
+    fontSize: 10,
+    textAnchor: 'middle',
+  }),
+  tickLength,
+  tickStroke,
+  tickTransform,
+  tickValues,
+  top,
 }) {
   return (
     <Axis
-      className={cx('vx-axis-bottom', className)}
-      orientation={ORIENT.bottom}
-      top={top}
+      axisClassName={cx('vx-axis-bottom', axisClassName)}
+      axisLineClassName={axisLineClassName}
+      hideAxisLine={hideAxisLine}
+      hideTicks={hideTicks}
+      hideZero={hideZero}
+      label={label}
+      labelClassName={labelClassName}
+      labelOffset={labelOffset}
+      labelProps={labelProps}
       left={left}
+      numTicks={numTicks}
+      orientation={ORIENT.bottom}
+      rangePadding={rangePadding}
       scale={scale}
       stroke={stroke}
       strokeWidth={strokeWidth}
       strokeDasharray={strokeDasharray}
-      rangePadding={rangePadding}
-      labelComponent={
-        typeof label === 'string' ?
-        <text
-          textAnchor="middle"
-          fontFamily="Arial"
-          fontSize={10}
-          fill="black"
-        >
-          {label}
-        </text>
-        : label
-      }
-      numTicks={numTicks}
+      tickClassName={tickClassName}
       tickFormat={tickFormat}
+      tickLabelProps={tickLabelProps}
       tickLength={tickLength}
-      tickTransform={tickTransform}
       tickStroke={tickStroke}
+      tickTransform={tickTransform}
       tickValues={tickValues}
-      labelOffset={labelOffset}
-      tickLabelComponent={tickLabelComponent}
-      hideAxisLine={hideAxisLine}
-      hideTicks={hideTicks}
-      hideZero={hideZero}
+      top={top}
     />
   );
 }
+
+AxisBottom.propTypes = propTypes;

--- a/packages/vx-axis/src/axis/AxisLeft.js
+++ b/packages/vx-axis/src/axis/AxisLeft.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Axis from './Axis';
 import ORIENT from '../constants/orientation';
@@ -57,7 +58,7 @@ export default function AxisLeft({
     fontSize: 10,
     textAnchor: 'end',
   }),
-  tickLength,
+  tickLength = 8,
   tickStroke,
   tickTransform,
   tickValues,

--- a/packages/vx-axis/src/axis/AxisLeft.js
+++ b/packages/vx-axis/src/axis/AxisLeft.js
@@ -3,71 +3,95 @@ import cx from 'classnames';
 import Axis from './Axis';
 import ORIENT from '../constants/orientation';
 
+const propTypes = {
+  axisClassName: PropTypes.string,
+  axisLineClassName: PropTypes.string,
+  hideAxisLine: PropTypes.bool,
+  hideTicks: PropTypes.bool,
+  hideZero: PropTypes.bool,
+  label: PropTypes.string,
+  labelClassName: PropTypes.string,
+  labelOffset: PropTypes.number,
+  labelProps: PropTypes.object,
+  left: PropTypes.number,
+  numTicks: PropTypes.number,
+  rangePadding: PropTypes.number,
+  scale: PropTypes.func.isRequired,
+  stroke: PropTypes.string,
+  strokeWidth: PropTypes.number,
+  strokeDasharray: PropTypes.string,
+  tickClassName: PropTypes.string,
+  tickFormat: PropTypes.func,
+  tickLabelProps: PropTypes.func,
+  tickLength: PropTypes.number,
+  tickStroke: PropTypes.string,
+  tickTransform: PropTypes.string,
+  tickValues: PropTypes.arrayOf(PropTypes.number),
+  top: PropTypes.number,
+};
+
 export default function AxisLeft({
-  scale,
-  top,
-  left,
-  stroke,
-  strokeWidth,
-  strokeDasharray,
-  rangePadding,
-  label,
-  labelOffset = 36,
-  numTicks,
-  tickFormat,
-  tickStroke,
-  tickTransform,
-  tickValues,
-  tickLength = 8,
-  tickLabelComponent = (
-    <text
-      textAnchor="end"
-      fontFamily="Arial"
-      fontSize={10}
-      fill="black"
-      dx="-0.25em"
-      dy="0.25em"
-    />
-  ),
+  axisClassName,
+  axisLineClassName,
   hideAxisLine,
   hideTicks,
   hideZero,
-  className,
+  label,
+  labelClassName,
+  labelOffset = 36,
+  labelProps,
+  left,
+  numTicks,
+  rangePadding,
+  scale,
+  stroke,
+  strokeWidth,
+  strokeDasharray,
+  tickClassName,
+  tickFormat,
+  tickLabelProps = ({ tick, index }) => ({
+    dx: '-0.25em',
+    dy: '0.25em',
+    fill: 'black',
+    fontFamily: 'Arial',
+    fontSize: 10,
+    textAnchor: 'end',
+  }),
+  tickLength,
+  tickStroke,
+  tickTransform,
+  tickValues,
+  top,
 }) {
   return (
     <Axis
-      className={cx('vx-axis-left', className)}
-      orientation={ORIENT.left}
-      top={top}
+      axisClassName={cx('vx-axis-left', axisClassName)}
+      axisLineClassName={axisLineClassName}
+      hideAxisLine={hideAxisLine}
+      hideTicks={hideTicks}
+      hideZero={hideZero}
+      label={label}
+      labelClassName={labelClassName}
+      labelOffset={labelOffset}
+      labelProps={labelProps}
       left={left}
+      numTicks={numTicks}
+      orientation={ORIENT.left}
+      rangePadding={rangePadding}
       scale={scale}
       stroke={stroke}
       strokeWidth={strokeWidth}
       strokeDasharray={strokeDasharray}
-      rangePadding={rangePadding}
-      labelComponent={
-        typeof label === 'string' ?
-        <text
-          textAnchor="middle"
-          fontFamily="Arial"
-          fontSize={10}
-          fill="black"
-        >
-          {label}
-        </text>
-        : label
-      }
-      numTicks={numTicks}
+      tickClassName={tickClassName}
       tickFormat={tickFormat}
+      tickLabelProps={tickLabelProps}
       tickLength={tickLength}
-      tickTransform={tickTransform}
       tickStroke={tickStroke}
+      tickTransform={tickTransform}
       tickValues={tickValues}
-      labelOffset={labelOffset}
-      tickLabelComponent={tickLabelComponent}
-      hideAxisLine={hideAxisLine}
-      hideTicks={hideTicks}
-      hideZero={hideZero}
+      top={top}
     />
   );
 }
+
+AxisLeft.propTypes = propTypes;

--- a/packages/vx-axis/src/axis/AxisRight.js
+++ b/packages/vx-axis/src/axis/AxisRight.js
@@ -3,71 +3,95 @@ import cx from 'classnames';
 import Axis from './Axis';
 import ORIENT from '../constants/orientation';
 
+const propTypes = {
+  axisClassName: PropTypes.string,
+  axisLineClassName: PropTypes.string,
+  hideAxisLine: PropTypes.bool,
+  hideTicks: PropTypes.bool,
+  hideZero: PropTypes.bool,
+  label: PropTypes.string,
+  labelClassName: PropTypes.string,
+  labelOffset: PropTypes.number,
+  labelProps: PropTypes.object,
+  left: PropTypes.number,
+  numTicks: PropTypes.number,
+  rangePadding: PropTypes.number,
+  scale: PropTypes.func.isRequired,
+  stroke: PropTypes.string,
+  strokeWidth: PropTypes.number,
+  strokeDasharray: PropTypes.string,
+  tickClassName: PropTypes.string,
+  tickFormat: PropTypes.func,
+  tickLabelProps: PropTypes.func,
+  tickLength: PropTypes.number,
+  tickStroke: PropTypes.string,
+  tickTransform: PropTypes.string,
+  tickValues: PropTypes.arrayOf(PropTypes.number),
+  top: PropTypes.number,
+};
+
 export default function AxisRight({
-  scale,
-  top,
-  left,
-  stroke,
-  strokeWidth,
-  strokeDasharray,
-  rangePadding,
-  label,
-  labelOffset = 36,
-  numTicks,
-  tickFormat,
-  tickStroke,
-  tickTransform,
-  tickValues,
-  tickLength = 8,
-  tickLabelComponent = (
-    <text
-      textAnchor="start"
-      fontFamily="Arial"
-      fontSize={10}
-      fill="black"
-      dx="0.25em"
-      dy="0.25em"
-    />
-  ),
+  axisClassName,
+  axisLineClassName,
   hideAxisLine,
   hideTicks,
   hideZero,
-  className,
+  label,
+  labelClassName,
+  labelOffset = 36,
+  labelProps,
+  left,
+  numTicks,
+  rangePadding,
+  scale,
+  stroke,
+  strokeWidth,
+  strokeDasharray,
+  tickClassName,
+  tickFormat,
+  tickLabelProps = ({ tick, index }) => ({
+    dx: '0.25em',
+    dy: '0.25em',
+    fill: 'black',
+    fontFamily: 'Arial',
+    fontSize: 10,
+    textAnchor: 'start',
+  }),
+  tickLength,
+  tickStroke,
+  tickTransform,
+  tickValues,
+  top,
 }) {
   return (
     <Axis
-      className={cx('vx-axis-right', className)}
-      orientation={ORIENT.right}
-      top={top}
+      axisClassName={cx('vx-axis-right', axisClassName)}
+      axisLineClassName={axisLineClassName}
+      hideAxisLine={hideAxisLine}
+      hideTicks={hideTicks}
+      hideZero={hideZero}
+      label={label}
+      labelClassName={labelClassName}
+      labelOffset={labelOffset}
+      labelProps={labelProps}
       left={left}
+      numTicks={numTicks}
+      orientation={ORIENT.right}
+      rangePadding={rangePadding}
       scale={scale}
       stroke={stroke}
       strokeWidth={strokeWidth}
       strokeDasharray={strokeDasharray}
-      rangePadding={rangePadding}
-      labelComponent={
-        typeof label === 'string' ?
-        <text
-          textAnchor="middle"
-          fontFamily="Arial"
-          fontSize={10}
-          fill="black"
-        >
-          {label}
-        </text>
-        : label
-      }
-      numTicks={numTicks}
+      tickClassName={tickClassName}
       tickFormat={tickFormat}
+      tickLabelProps={tickLabelProps}
       tickLength={tickLength}
-      tickTransform={tickTransform}
       tickStroke={tickStroke}
+      tickTransform={tickTransform}
       tickValues={tickValues}
-      labelOffset={labelOffset}
-      tickLabelComponent={tickLabelComponent}
-      hideAxisLine={hideAxisLine}
-      hideTicks={hideTicks}
-      hideZero={hideZero}
+      top={top}
     />
   );
 }
+
+AxisRight.propTypes = propTypes;

--- a/packages/vx-axis/src/axis/AxisRight.js
+++ b/packages/vx-axis/src/axis/AxisRight.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Axis from './Axis';
 import ORIENT from '../constants/orientation';
@@ -57,7 +58,7 @@ export default function AxisRight({
     fontSize: 10,
     textAnchor: 'start',
   }),
-  tickLength,
+  tickLength = 8,
   tickStroke,
   tickTransform,
   tickValues,

--- a/packages/vx-axis/src/axis/AxisTop.js
+++ b/packages/vx-axis/src/axis/AxisTop.js
@@ -3,70 +3,94 @@ import cx from 'classnames';
 import Axis from './Axis';
 import ORIENT from '../constants/orientation';
 
+const propTypes = {
+  axisClassName: PropTypes.string,
+  axisLineClassName: PropTypes.string,
+  hideAxisLine: PropTypes.bool,
+  hideTicks: PropTypes.bool,
+  hideZero: PropTypes.bool,
+  label: PropTypes.string,
+  labelClassName: PropTypes.string,
+  labelOffset: PropTypes.number,
+  labelProps: PropTypes.object,
+  left: PropTypes.number,
+  numTicks: PropTypes.number,
+  rangePadding: PropTypes.number,
+  scale: PropTypes.func.isRequired,
+  stroke: PropTypes.string,
+  strokeWidth: PropTypes.number,
+  strokeDasharray: PropTypes.string,
+  tickClassName: PropTypes.string,
+  tickFormat: PropTypes.func,
+  tickLabelProps: PropTypes.func,
+  tickLength: PropTypes.number,
+  tickStroke: PropTypes.string,
+  tickTransform: PropTypes.string,
+  tickValues: PropTypes.arrayOf(PropTypes.number),
+  top: PropTypes.number,
+};
+
 export default function AxisTop({
-  scale,
-  top,
-  left,
-  stroke,
-  strokeWidth,
-  strokeDasharray,
-  rangePadding,
-  label,
-  labelOffset = 8,
-  numTicks,
-  tickFormat,
-  tickStroke,
-  tickTransform,
-  tickValues,
-  tickLength = 8,
-  tickLabelComponent = (
-    <text
-      textAnchor="middle"
-      fontFamily="Arial"
-      fontSize={10}
-      fill="black"
-      dy="-0.25em"
-    />
-  ),
+  axisClassName,
+  axisLineClassName,
   hideAxisLine,
   hideTicks,
   hideZero,
-  className,
+  label,
+  labelClassName,
+  labelOffset = 8,
+  labelProps,
+  left,
+  numTicks,
+  rangePadding,
+  scale,
+  stroke,
+  strokeWidth,
+  strokeDasharray,
+  tickClassName,
+  tickFormat,
+  tickLabelProps = ({ tick, index }) => ({
+    dy: '-0.25em',
+    fill: 'black',
+    fontFamily: 'Arial',
+    fontSize: 10,
+    textAnchor: 'middle',
+  }),
+  tickLength,
+  tickStroke,
+  tickTransform,
+  tickValues,
+  top,
 }) {
   return (
     <Axis
-      className={cx('vx-axis-top', className)}
-      orientation={ORIENT.top}
-      top={top}
+      axisClassName={cx('vx-axis-top', axisClassName)}
+      axisLineClassName={axisLineClassName}
+      hideAxisLine={hideAxisLine}
+      hideTicks={hideTicks}
+      hideZero={hideZero}
+      label={label}
+      labelClassName={labelClassName}
+      labelOffset={labelOffset}
+      labelProps={labelProps}
       left={left}
+      numTicks={numTicks}
+      orientation={ORIENT.top}
+      rangePadding={rangePadding}
       scale={scale}
       stroke={stroke}
       strokeWidth={strokeWidth}
       strokeDasharray={strokeDasharray}
-      rangePadding={rangePadding}
-      labelComponent={
-        typeof label === 'string' ?
-        <text
-          textAnchor="middle"
-          fontFamily="Arial"
-          fontSize={10}
-          fill="black"
-        >
-          {label}
-        </text>
-        : label
-      }
-      numTicks={numTicks}
+      tickClassName={tickClassName}
       tickFormat={tickFormat}
+      tickLabelProps={tickLabelProps}
       tickLength={tickLength}
-      tickTransform={tickTransform}
       tickStroke={tickStroke}
+      tickTransform={tickTransform}
       tickValues={tickValues}
-      labelOffset={labelOffset}
-      tickLabelComponent={tickLabelComponent}
-      hideAxisLine={hideAxisLine}
-      hideTicks={hideTicks}
-      hideZero={hideZero}
+      top={top}
     />
   );
 }
+
+AxisTop.propTypes = propTypes;

--- a/packages/vx-axis/src/axis/AxisTop.js
+++ b/packages/vx-axis/src/axis/AxisTop.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Axis from './Axis';
 import ORIENT from '../constants/orientation';
@@ -56,7 +57,7 @@ export default function AxisTop({
     fontSize: 10,
     textAnchor: 'middle',
   }),
-  tickLength,
+  tickLength = 8,
   tickStroke,
   tickTransform,
   tickValues,

--- a/packages/vx-axis/src/utils/labelTransform.js
+++ b/packages/vx-axis/src/utils/labelTransform.js
@@ -14,7 +14,7 @@ export default function labelTransform({
   if (orientation === ORIENT.top || orientation === ORIENT.bottom) {
     x = Math.max(...range) / 2;
     y = sign * (tickLength + labelOffset + tickLabelFontSize +
-      (orientation === ORIENT.bottom ? fontSize : 0));
+      (orientation === ORIENT.bottom ? labelProps.fontSize : 0));
   } else {
     x = sign * (Math.max(...range) / 2);
     y = -(tickLength + labelOffset);

--- a/packages/vx-axis/src/utils/labelTransform.js
+++ b/packages/vx-axis/src/utils/labelTransform.js
@@ -1,16 +1,14 @@
 import ORIENT from '../constants/orientation';
 
 export default function labelTransform({
-  tickLength,
   labelOffset,
-  tickLabelFontSize,
-  labelComponent,
+  labelProps,
   orientation,
   range,
+  tickLabelFontSize,
+  tickLength,
 }) {
-  if (!labelComponent || !labelComponent.props) return {};
   const sign = orientation === ORIENT.left || orientation === ORIENT.top ? -1 : 1;
-  const { fontSize = 10 } = labelComponent.props;
 
   let x, y, transform = null;
   if (orientation === ORIENT.top || orientation === ORIENT.bottom) {

--- a/packages/vx-axis/test/Axis.test.js
+++ b/packages/vx-axis/test/Axis.test.js
@@ -3,10 +3,14 @@ import { Axis } from '../src';
 import { shallow } from 'enzyme';
 import { scaleLinear } from '../../vx-scale';
 
-const fakeScale = scaleLinear({
-  rangeRound: [10, 0],
-  domain: [0, 10],
-});
+const axisProps = {
+  orientation: 'left',
+  scale: scaleLinear({
+    rangeRound: [10, 0],
+    domain: [0, 10],
+  }),
+  label: 'test axis',
+};
 
 describe('<Axis />', () => {
   test('it should be defined', () => {
@@ -14,74 +18,122 @@ describe('<Axis />', () => {
   });
 
   test('it should render with class .vx-axis', () => {
-    const wrapper = shallow(<Axis scale={fakeScale} />);
+    const wrapper = shallow(<Axis {...axisProps} />);
     expect(wrapper.prop('className')).toEqual('vx-axis');
   });
 
-  test('it should pass users class down to element', () => {
-    const fakeClass = "test-class";
-    const wrapper = shallow(<Axis scale={fakeScale} className={fakeClass} />);
-    expect(wrapper.prop('className')).toEqual(`vx-axis ${fakeClass}`);
+  test('it should set user-specified axisClassName, axisLineClassName, labelClassName, and tickClassName', () => {
+    const axisClassName = 'axis-test-class';
+    const axisLineClassName = 'axisline-test-class';
+    const labelClassName = 'label-test-class';
+    const tickClassName = 'tick-test-class';
+
+    const wrapper = shallow(
+      <Axis
+        {...axisProps}
+        axisClassName={axisClassName}
+        axisLineClassName={axisLineClassName}
+        labelClassName={labelClassName}
+        tickClassName={tickClassName}
+      />
+    ).dive();
+
+    expect(wrapper.find(`.${axisClassName}`).length).toBe(1);
+    expect(wrapper.find(`.${axisLineClassName}`).length).toBe(1);
+    expect(wrapper.find(`.${labelClassName}`).length).toBe(1);
+    expect(wrapper.find(`.${tickClassName}`).length).toBeGreaterThan(0);
   });
 
-  test('it should render the 0th element if hideZero is false', () => {
-    // Note that we're explicitly passing in false so that we're testing
-    // the rendering, NOT wether or not this is a default value.
-    const wrapper = shallow(<Axis scale={fakeScale} hideZero={false} />);
-    expect(wrapper.find('.vx-axis-ticks').at(0).key()).toBe('vx-tick-0-0');
+  test('it should pass the output of tickLabelProps to tick labels', () => {
+    const tickProps = { fontSize: 50, fill: 'magenta' };
+    const wrapper = shallow(
+      <Axis {...axisProps} tickLabelProps={() => tickProps} />
+    );
+
+    const ticks = wrapper.find('.vx-axis-tick');
+    ticks.forEach((tick) => {
+      expect(tick.find('text').props()).toEqual(expect.objectContaining(tickProps));
+    });
+
+    expect.hasAssertions();
+  });
+
+  test('it should call the tickLabelProps func with the signature (tickValue, index)', () => {
+    const wrapper = shallow(
+      <Axis {...axisProps}
+        tickLabelProps={(value, index) => {
+          expect(value).toEqual(expect.any(Number));
+          expect(index).toBeGreaterThan(-1);
+          return {};
+        }}
+      />
+    );
+
+    expect.hasAssertions();
+  });
+
+  test('it should pass labelProps to the axis label', () => {
+    const labelProps = { fontSize: 50, fill: 'magenta' };
+    const wrapper = shallow(
+      <Axis {...axisProps} labelProps={labelProps} />
+    );
+
+    const label = wrapper.find('.vx-axis-label');
+    expect(label.find('text').props()).toEqual(expect.objectContaining(labelProps));
+  });
+
+  test('it should render the 0th tick if hideZero is false', () => {
+    const wrapper = shallow(<Axis {...axisProps} hideZero={false} />);
+    expect(wrapper.find('.vx-axis-tick').at(0).key()).toBe('vx-tick-0-0');
   });
 
   test('it should not show 0th tick if hideZero is true', () => {
-    const wrapper = shallow(<Axis scale={fakeScale} hideZero />);
-    expect(wrapper.find('.vx-axis-ticks').at(0).key()).toBe('vx-tick-1-1');
+    const wrapper = shallow(<Axis {...axisProps} hideZero />);
+    expect(wrapper.find('.vx-axis-tick').at(0).key()).toBe('vx-tick-1-1');
   });
 
   test('it should SHOW an axis line if hideAxisLine is false', () => {
-    // Again, we're explicitly passing in false so we're testing
-    // the rendering, NOT the default value.
-    const wrapper = shallow(<Axis scale={fakeScale} hideAxisLine={false} />);
-    expect(wrapper.children().not(".vx-axis-ticks").find("Line").length).toBe(1);
+    const wrapper = shallow(<Axis {...axisProps} hideAxisLine={false} />);
+    expect(wrapper.children().not(".vx-axis-tick").find("Line").length).toBe(1);
   });
 
   test('it should HIDE an axis line if hideAxisLine is true', () => {
-    const wrapper = shallow(<Axis scale={fakeScale} hideAxisLine />);
-    expect(wrapper.children().not(".vx-axis-ticks").find("Line").length).toBe(0);
+    const wrapper = shallow(<Axis {...axisProps} hideAxisLine />);
+    expect(wrapper.children().not(".vx-axis-tick").find("Line").length).toBe(0);
   });
 
   test('it should SHOW ticks if hideTicks is false', () => {
-    // Again, we're explicitly passing in false so we're testing
-    // the rendering, NOT the default value.
-    const wrapper = shallow(<Axis scale={fakeScale} hideTicks={false} />);
-    expect(wrapper.children().find(".vx-axis-ticks").find("Line").length).toBeGreaterThan(0);
+    const wrapper = shallow(<Axis {...axisProps} hideTicks={false} />);
+    expect(wrapper.children().find(".vx-axis-tick").find("Line").length).toBeGreaterThan(0);
   });
 
   test('it should HIDE ticks if hideTicks is true', () => {
-    const wrapper = shallow(<Axis scale={fakeScale} hideTicks />);
-    expect(wrapper.children().find(".vx-axis-ticks").find("Line").length).toBe(0);
+    const wrapper = shallow(<Axis {...axisProps} hideTicks />);
+    expect(wrapper.children().find(".vx-axis-tick").find("Line").length).toBe(0);
   });
 
   test('it should render one tick for each value specified in tickValues', () => {
-    let wrapper = shallow(<Axis scale={fakeScale} tickValues={[]} />);
-    expect(wrapper.children().find(".vx-axis-ticks").find("Line").length).toBe(0);
+    let wrapper = shallow(<Axis {...axisProps} tickValues={[]} />);
+    expect(wrapper.children().find(".vx-axis-tick").find("Line").length).toBe(0);
 
-    wrapper = shallow(<Axis scale={fakeScale} tickValues={[0]} />);
-    expect(wrapper.children().find(".vx-axis-ticks").find("Line").length).toBe(1);
+    wrapper = shallow(<Axis {...axisProps} tickValues={[0]} />);
+    expect(wrapper.children().find(".vx-axis-tick").find("Line").length).toBe(1);
 
-    wrapper = shallow(<Axis scale={fakeScale} tickValues={[0, 1, 2, 3, 4, 5, 6]} />);
-    expect(wrapper.children().find(".vx-axis-ticks").find("Line").length).toBe(7);
+    wrapper = shallow(<Axis {...axisProps} tickValues={[0, 1, 2, 3, 4, 5, 6]} />);
+    expect(wrapper.children().find(".vx-axis-tick").find("Line").length).toBe(7);
   });
 
   test('it should use tickFormat to format ticks if passed', () => {
     const wrapper = shallow(
-      <Axis scale={fakeScale} tickValues={[0]} tickFormat={(val, i) => 'test!!!'} />
+      <Axis {...axisProps} tickValues={[0]} tickFormat={(val, i) => 'test!!!'} />
     );
-    expect(wrapper.children().find(".vx-axis-ticks").find("text").text()).toBe('test!!!');
+    expect(wrapper.children().find(".vx-axis-tick").find("text").text()).toBe('test!!!');
   });
 
   test('tickFormat should have access to tick index', () => {
     const wrapper = shallow(
-      <Axis scale={fakeScale} tickValues={[9]} tickFormat={(val, i) => i} />
+      <Axis {...axisProps} tickValues={[9]} tickFormat={(val, i) => i} />
     );
-    expect(wrapper.children().find(".vx-axis-ticks").find("text").text()).toBe('0');
+    expect(wrapper.children().find(".vx-axis-tick").find("text").text()).toBe('0');
   });
 })

--- a/packages/vx-axis/test/AxisBottom.test.js
+++ b/packages/vx-axis/test/AxisBottom.test.js
@@ -1,57 +1,74 @@
 import React from 'react';
-import { AxisBottom } from '../src';
 import { shallow } from 'enzyme';
+import { Axis, AxisBottom } from '../src';
+import { scaleLinear } from '../../vx-scale';
+
+const axisProps = {
+  scale: scaleLinear({
+    rangeRound: [10, 0],
+    domain: [0, 10],
+  }),
+};
 
 describe('<AxisBottom />', () => {
   test('it should be defined', () => {
-    expect(AxisBottom).toBeDefined()
-  })
+    expect(AxisBottom).toBeDefined();
+  });
 
   test('it should render with class .vx-axis-bottom', () => {
-    const wrapper = shallow(<AxisBottom />)
-    expect(wrapper.prop('className')).toEqual('vx-axis-bottom')
-  })
+    const wrapper = shallow(<AxisBottom {...axisProps} />);
+    expect(wrapper.prop('axisClassName')).toEqual('vx-axis-bottom');
+  });
 
-  test('it should set className', () => {
-    const wrapper = shallow(<AxisBottom className='test' />)
-    expect(wrapper.prop('className')).toEqual('vx-axis-bottom test')
-  })
+  test('it should set user-specified axisClassName, axisLineClassName, labelClassName, and tickClassName', () => {
+    const axisClassName = 'axis-test-class';
+    const axisLineClassName = 'axisline-test-class';
+    const labelClassName = 'label-test-class';
+    const tickClassName = 'tick-test-class';
+
+    const wrapper = shallow(
+      <AxisBottom
+        {...axisProps}
+        axisClassName={axisClassName}
+        axisLineClassName={axisLineClassName}
+        labelClassName={labelClassName}
+        tickClassName={tickClassName}
+      />
+    );
+
+    const axis = wrapper.find(Axis);
+    expect(axis.prop('axisClassName')).toMatch(axisClassName);
+    expect(axis.prop('axisLineClassName')).toBe(axisLineClassName);
+    expect(axis.prop('labelClassName')).toBe(labelClassName);
+    expect(axis.prop('tickClassName')).toBe(tickClassName);
+  });
 
   test('it should default labelOffset prop to 8', () => {
-    const wrapper = shallow(<AxisBottom />)
-    expect(wrapper.prop('labelOffset')).toEqual(8)
-  })
+    const wrapper = shallow(<AxisBottom {...axisProps} />);
+    expect(wrapper.prop('labelOffset')).toEqual(8);
+  });
 
   test('it should set labelOffset prop', () => {
-    const labelOffset = 3
-    const wrapper = shallow(<AxisBottom labelOffset={labelOffset} />)
-    expect(wrapper.prop('labelOffset')).toEqual(labelOffset)
-  })
+    const labelOffset = 3;
+    const wrapper = shallow(<AxisBottom {...axisProps} labelOffset={labelOffset} />);
+    expect(wrapper.prop('labelOffset')).toEqual(labelOffset);
+  });
 
   test('it should default tickLength prop to 8', () => {
-    const wrapper = shallow(<AxisBottom />)
-    expect(wrapper.prop('tickLength')).toEqual(8)
-  })
+    const wrapper = shallow(<AxisBottom {...axisProps} />);
+    expect(wrapper.prop('tickLength')).toEqual(8);
+  });
 
   test('it should set tickLength prop', () => {
-    const tickLength = 15
-    const wrapper = shallow(<AxisBottom tickLength={tickLength} />)
-    expect(wrapper.prop('tickLength')).toEqual(tickLength)
-  })
+    const tickLength = 15;
+    const wrapper = shallow(<AxisBottom {...axisProps} tickLength={tickLength} />);
+    expect(wrapper.prop('tickLength')).toEqual(tickLength);
+  });
 
-  test('it should set labelComponent prop if label prop is string', () => {
-    const label = 'test'
-    const wrapper = shallow(<AxisBottom label={label} />)
-    const labelComponent = shallow(wrapper.prop('labelComponent'))
-    expect(labelComponent.prop('children')).toEqual(label)
-  })
-
-  test('it should set labelComponent prop if label is a component', () => {
-    const labelText = 'test'
-    const label = (<text>{labelText}</text>)
-    const wrapper = shallow(<AxisBottom label={label} />)
-    const labelComponent = shallow(wrapper.prop('labelComponent'))
-    expect(labelComponent.node.type).toEqual('text')
-    expect(labelComponent.prop('children')).toEqual(labelText)
-  })
-})
+  test('it should set label prop', () => {
+    const label = 'test';
+    const wrapper = shallow(<AxisBottom {...axisProps} label={label} />).dive();
+    const text = wrapper.find('.vx-axis-label');
+    expect(text.text()).toEqual(label);
+  });
+});

--- a/packages/vx-axis/test/AxisLeft.test.js
+++ b/packages/vx-axis/test/AxisLeft.test.js
@@ -1,57 +1,74 @@
 import React from 'react';
-import { AxisLeft } from '../src';
 import { shallow } from 'enzyme';
+import { Axis, AxisLeft } from '../src';
+import { scaleLinear } from '../../vx-scale';
+
+const axisProps = {
+  scale: scaleLinear({
+    rangeRound: [10, 0],
+    domain: [0, 10],
+  }),
+};
 
 describe('<AxisLeft />', () => {
   test('it should be defined', () => {
-    expect(AxisLeft).toBeDefined()
-  })
+    expect(AxisLeft).toBeDefined();
+  });
 
   test('it should render with class .vx-axis-left', () => {
-    const wrapper = shallow(<AxisLeft />)
-    expect(wrapper.prop('className')).toEqual('vx-axis-left')
-  })
+    const wrapper = shallow(<AxisLeft {...axisProps} />);
+    expect(wrapper.prop('axisClassName')).toEqual('vx-axis-left');
+  });
 
-  test('it should set className', () => {
-    const wrapper = shallow(<AxisLeft className='test' />)
-    expect(wrapper.prop('className')).toEqual('vx-axis-left test')
-  })
+  test('it should set user-specified axisClassName, axisLineClassName, labelClassName, and tickClassName', () => {
+    const axisClassName = 'axis-test-class';
+    const axisLineClassName = 'axisline-test-class';
+    const labelClassName = 'label-test-class';
+    const tickClassName = 'tick-test-class';
+
+    const wrapper = shallow(
+      <AxisLeft
+        {...axisProps}
+        axisClassName={axisClassName}
+        axisLineClassName={axisLineClassName}
+        labelClassName={labelClassName}
+        tickClassName={tickClassName}
+      />
+    );
+
+    const axis = wrapper.find(Axis);
+    expect(axis.prop('axisClassName')).toMatch(axisClassName);
+    expect(axis.prop('axisLineClassName')).toBe(axisLineClassName);
+    expect(axis.prop('labelClassName')).toBe(labelClassName);
+    expect(axis.prop('tickClassName')).toBe(tickClassName);
+  });
 
   test('it should default labelOffset prop to 36', () => {
-    const wrapper = shallow(<AxisLeft />)
-    expect(wrapper.prop('labelOffset')).toEqual(36)
-  })
+    const wrapper = shallow(<AxisLeft {...axisProps} />);
+    expect(wrapper.prop('labelOffset')).toEqual(36);
+  });
 
   test('it should set labelOffset prop', () => {
-    const labelOffset = 3
-    const wrapper = shallow(<AxisLeft labelOffset={labelOffset} />)
-    expect(wrapper.prop('labelOffset')).toEqual(labelOffset)
-  })
+    const labelOffset = 3;
+    const wrapper = shallow(<AxisLeft {...axisProps} labelOffset={labelOffset} />);
+    expect(wrapper.prop('labelOffset')).toEqual(labelOffset);
+  });
 
   test('it should default tickLength prop to 8', () => {
-    const wrapper = shallow(<AxisLeft />)
-    expect(wrapper.prop('tickLength')).toEqual(8)
-  })
+    const wrapper = shallow(<AxisLeft {...axisProps} />);
+    expect(wrapper.prop('tickLength')).toEqual(8);
+  });
 
   test('it should set tickLength prop', () => {
-    const tickLength = 15
-    const wrapper = shallow(<AxisLeft tickLength={tickLength} />)
-    expect(wrapper.prop('tickLength')).toEqual(tickLength)
-  })
+    const tickLength = 15;
+    const wrapper = shallow(<AxisLeft {...axisProps} tickLength={tickLength} />);
+    expect(wrapper.prop('tickLength')).toEqual(tickLength);
+  });
 
-  test('it should set labelComponent prop if label prop is string', () => {
-    const label = 'test'
-    const wrapper = shallow(<AxisLeft label={label} />)
-    const labelComponent = shallow(wrapper.prop('labelComponent'))
-    expect(labelComponent.prop('children')).toEqual(label)
-  })
-
-  test('it should set labelComponent prop if label is a component', () => {
-    const labelText = 'test'
-    const label = (<text>{labelText}</text>)
-    const wrapper = shallow(<AxisLeft label={label} />)
-    const labelComponent = shallow(wrapper.prop('labelComponent'))
-    expect(labelComponent.node.type).toEqual('text')
-    expect(labelComponent.prop('children')).toEqual(labelText)
-  })
-})
+  test('it should set label prop', () => {
+    const label = 'test';
+    const wrapper = shallow(<AxisLeft {...axisProps} label={label} />).dive();
+    const text = wrapper.find('.vx-axis-label');
+    expect(text.text()).toEqual(label);
+  });
+});

--- a/packages/vx-axis/test/AxisRight.test.js
+++ b/packages/vx-axis/test/AxisRight.test.js
@@ -1,57 +1,74 @@
 import React from 'react';
-import { AxisRight } from '../src';
 import { shallow } from 'enzyme';
+import { Axis, AxisRight } from '../src';
+import { scaleLinear } from '../../vx-scale';
+
+const axisProps = {
+  scale: scaleLinear({
+    rangeRound: [10, 0],
+    domain: [0, 10],
+  }),
+};
 
 describe('<AxisRight />', () => {
   test('it should be defined', () => {
-    expect(AxisRight).toBeDefined()
-  })
+    expect(AxisRight).toBeDefined();
+  });
 
   test('it should render with class .vx-axis-right', () => {
-    const wrapper = shallow(<AxisRight />)
-    expect(wrapper.prop('className')).toEqual('vx-axis-right')
-  })
+    const wrapper = shallow(<AxisRight {...axisProps} />);
+    expect(wrapper.prop('axisClassName')).toEqual('vx-axis-right');
+  });
 
-  test('it should set className', () => {
-    const wrapper = shallow(<AxisRight className='test' />)
-    expect(wrapper.prop('className')).toEqual('vx-axis-right test')
-  })
+  test('it should set user-specified axisClassName, axisLineClassName, labelClassName, and tickClassName', () => {
+    const axisClassName = 'axis-test-class';
+    const axisLineClassName = 'axisline-test-class';
+    const labelClassName = 'label-test-class';
+    const tickClassName = 'tick-test-class';
+
+    const wrapper = shallow(
+      <AxisRight
+        {...axisProps}
+        axisClassName={axisClassName}
+        axisLineClassName={axisLineClassName}
+        labelClassName={labelClassName}
+        tickClassName={tickClassName}
+      />
+    );
+
+    const axis = wrapper.find(Axis);
+    expect(axis.prop('axisClassName')).toMatch(axisClassName);
+    expect(axis.prop('axisLineClassName')).toBe(axisLineClassName);
+    expect(axis.prop('labelClassName')).toBe(labelClassName);
+    expect(axis.prop('tickClassName')).toBe(tickClassName);
+  });
 
   test('it should default labelOffset prop to 36', () => {
-    const wrapper = shallow(<AxisRight />)
-    expect(wrapper.prop('labelOffset')).toEqual(36)
-  })
+    const wrapper = shallow(<AxisRight {...axisProps} />);
+    expect(wrapper.prop('labelOffset')).toEqual(36);
+  });
 
   test('it should set labelOffset prop', () => {
-    const labelOffset = 3
-    const wrapper = shallow(<AxisRight labelOffset={labelOffset} />)
-    expect(wrapper.prop('labelOffset')).toEqual(labelOffset)
-  })
+    const labelOffset = 3;
+    const wrapper = shallow(<AxisRight {...axisProps} labelOffset={labelOffset} />);
+    expect(wrapper.prop('labelOffset')).toEqual(labelOffset);
+  });
 
   test('it should default tickLength prop to 8', () => {
-    const wrapper = shallow(<AxisRight />)
-    expect(wrapper.prop('tickLength')).toEqual(8)
-  })
+    const wrapper = shallow(<AxisRight {...axisProps} />);
+    expect(wrapper.prop('tickLength')).toEqual(8);
+  });
 
   test('it should set tickLength prop', () => {
-    const tickLength = 15
-    const wrapper = shallow(<AxisRight tickLength={tickLength} />)
-    expect(wrapper.prop('tickLength')).toEqual(tickLength)
-  })
+    const tickLength = 15;
+    const wrapper = shallow(<AxisRight {...axisProps} tickLength={tickLength} />);
+    expect(wrapper.prop('tickLength')).toEqual(tickLength);
+  });
 
-  test('it should set labelComponent prop if label prop is string', () => {
-    const label = 'test'
-    const wrapper = shallow(<AxisRight label={label} />)
-    const labelComponent = shallow(wrapper.prop('labelComponent'))
-    expect(labelComponent.prop('children')).toEqual(label)
-  })
-
-  test('it should set labelComponent prop if label is a component', () => {
-    const labelText = 'test'
-    const label = (<text>{labelText}</text>)
-    const wrapper = shallow(<AxisRight label={label} />)
-    const labelComponent = shallow(wrapper.prop('labelComponent'))
-    expect(labelComponent.node.type).toEqual('text')
-    expect(labelComponent.prop('children')).toEqual(labelText)
-  })
-})
+  test('it should set label prop', () => {
+    const label = 'test';
+    const wrapper = shallow(<AxisRight {...axisProps} label={label} />).dive();
+    const text = wrapper.find('.vx-axis-label');
+    expect(text.text()).toEqual(label);
+  });
+});

--- a/packages/vx-axis/test/AxisTop.test.js
+++ b/packages/vx-axis/test/AxisTop.test.js
@@ -1,57 +1,74 @@
 import React from 'react';
-import { AxisTop } from '../src';
 import { shallow } from 'enzyme';
+import { Axis, AxisTop } from '../src';
+import { scaleLinear } from '../../vx-scale';
+
+const axisProps = {
+  scale: scaleLinear({
+    rangeRound: [10, 0],
+    domain: [0, 10],
+  }),
+};
 
 describe('<AxisTop />', () => {
   test('it should be defined', () => {
-    expect(AxisTop).toBeDefined()
-  })
+    expect(AxisTop).toBeDefined();
+  });
 
   test('it should render with class .vx-axis-top', () => {
-    const wrapper = shallow(<AxisTop />)
-    expect(wrapper.prop('className')).toEqual('vx-axis-top')
-  })
+    const wrapper = shallow(<AxisTop {...axisProps} />);
+    expect(wrapper.prop('axisClassName')).toEqual('vx-axis-top');
+  });
 
-  test('it should set className', () => {
-    const wrapper = shallow(<AxisTop className='test' />)
-    expect(wrapper.prop('className')).toEqual('vx-axis-top test')
-  })
+  test('it should set user-specified axisClassName, axisLineClassName, labelClassName, and tickClassName', () => {
+    const axisClassName = 'axis-test-class';
+    const axisLineClassName = 'axisline-test-class';
+    const labelClassName = 'label-test-class';
+    const tickClassName = 'tick-test-class';
+
+    const wrapper = shallow(
+      <AxisTop
+        {...axisProps}
+        axisClassName={axisClassName}
+        axisLineClassName={axisLineClassName}
+        labelClassName={labelClassName}
+        tickClassName={tickClassName}
+      />
+    );
+
+    const axis = wrapper.find(Axis);
+    expect(axis.prop('axisClassName')).toMatch(axisClassName);
+    expect(axis.prop('axisLineClassName')).toBe(axisLineClassName);
+    expect(axis.prop('labelClassName')).toBe(labelClassName);
+    expect(axis.prop('tickClassName')).toBe(tickClassName);
+  });
 
   test('it should default labelOffset prop to 8', () => {
-    const wrapper = shallow(<AxisTop />)
-    expect(wrapper.prop('labelOffset')).toEqual(8)
-  })
+    const wrapper = shallow(<AxisTop {...axisProps} />);
+    expect(wrapper.prop('labelOffset')).toEqual(8);
+  });
 
   test('it should set labelOffset prop', () => {
-    const labelOffset = 3
-    const wrapper = shallow(<AxisTop labelOffset={labelOffset} />)
-    expect(wrapper.prop('labelOffset')).toEqual(labelOffset)
-  })
+    const labelOffset = 3;
+    const wrapper = shallow(<AxisTop {...axisProps} labelOffset={labelOffset} />);
+    expect(wrapper.prop('labelOffset')).toEqual(labelOffset);
+  });
 
   test('it should default tickLength prop to 8', () => {
-    const wrapper = shallow(<AxisTop />)
-    expect(wrapper.prop('tickLength')).toEqual(8)
-  })
+    const wrapper = shallow(<AxisTop {...axisProps} />);
+    expect(wrapper.prop('tickLength')).toEqual(8);
+  });
 
   test('it should set tickLength prop', () => {
-    const tickLength = 15
-    const wrapper = shallow(<AxisTop tickLength={tickLength} />)
-    expect(wrapper.prop('tickLength')).toEqual(tickLength)
-  })
+    const tickLength = 15;
+    const wrapper = shallow(<AxisTop {...axisProps} tickLength={tickLength} />);
+    expect(wrapper.prop('tickLength')).toEqual(tickLength);
+  });
 
-  test('it should set labelComponent prop if label prop is string', () => {
-    const label = 'test'
-    const wrapper = shallow(<AxisTop label={label} />)
-    const labelComponent = shallow(wrapper.prop('labelComponent'))
-    expect(labelComponent.prop('children')).toEqual(label)
-  })
-
-  test('it should set labelComponent prop if label is a component', () => {
-    const labelText = 'test'
-    const label = (<text>{labelText}</text>)
-    const wrapper = shallow(<AxisTop label={label} />)
-    const labelComponent = shallow(wrapper.prop('labelComponent'))
-    expect(labelComponent.node.type).toEqual('text')
-    expect(labelComponent.prop('children')).toEqual(labelText)
-  })
+  test('it should set label prop', () => {
+    const label = 'test';
+    const wrapper = shallow(<AxisTop {...axisProps} label={label} />).dive();
+    const text = wrapper.find('.vx-axis-label');
+    expect(text.text()).toEqual(label);
+  });
 })

--- a/packages/vx-demo/components/tiles/axis.js
+++ b/packages/vx-demo/components/tiles/axis.js
@@ -106,54 +106,45 @@ export default ({ width, height, margin }) => {
         scale={yScale}
         hideZero
         numTicks={numTicksForHeight(height)}
-        label={
-          <text
-            fill="#8e205f"
-            textAnchor="middle"
-            fontSize={10}
-            fontFamily="Arial"
-          >
-            value
-          </text>
-        }
+        label="value"
+        labelProps={{
+          fill: '#8e205f',
+          textAnchor: 'middle',
+          fontSize: 12,
+          fontFamily: 'Arial',
+        }}
         stroke="#1b1a1e"
-        tickLabelComponent={
-          <text
-            fill="#8e205f"
-            textAnchor="end"
-            fontSize={10}
-            fontFamily="Arial"
-            dx="-0.25em"
-            dy="0.25em"
-          />
-        }
+        tickStroke="#8e205f"
+        tickLabelProps={(value, index) => ({
+          fill: '#8e205f',
+          textAnchor: 'end',
+          fontSize: 10,
+          fontFamily: 'Arial',
+          dx: '-0.25em',
+          dy: '0.25em',
+        })}
       />
       <AxisBottom
         top={height - margin.bottom}
         left={margin.left}
         scale={xScale}
         numTicks={numTicksForWidth(width)}
-        label={
-          <text
-            fill="#8e205f"
-            textAnchor="middle"
-            fontSize={10}
-            fontFamily="Arial"
-          >
-            time
-          </text>
-        }
-        stroke={'#1b1a1e'}
-        tickStroke={'#1b1a1e'}
-        tickLabelComponent={
-          <text
-            fill="#8e205f"
-            textAnchor="middle"
-            fontSize={10}
-            fontFamily="Arial"
-            dy="0.25em"
-          />
-        }
+        label="time"
+        labelProps={{
+          fill: '#8e205f',
+          textAnchor: 'middle',
+          fontSize: 12,
+          fontFamily: 'Arial',
+        }}
+        stroke="#1b1a1e"
+        tickStroke="#8e205f"
+        tickLabelProps={(value, index) => ({
+          fill: '#8e205f',
+          textAnchor: 'middle',
+          fontSize: 10,
+          fontFamily: 'Arial',
+          dy: '0.25em',
+        })}
       />
     </svg>
   );

--- a/packages/vx-demo/components/tiles/bargroup.js
+++ b/packages/vx-demo/components/tiles/bargroup.js
@@ -86,13 +86,11 @@ export default ({
         stroke='#e5fd3d'
         tickStroke='#e5fd3d'
         hideAxisLine
-        tickLabelComponent={(
-          <text
-            fill='#e5fd3d'
-            fontSize={11}
-            textAnchor="middle"
-          />
-        )}
+        tickLabelProps={(value, index) => ({
+          fill: '#e5fd3d',
+          fontSize: 11,
+          textAnchor: 'middle',
+        })}
       />
     </svg>
   );

--- a/packages/vx-demo/components/tiles/barstack.js
+++ b/packages/vx-demo/components/tiles/barstack.js
@@ -115,9 +115,11 @@ export default withTooltip(
             top={yMax + margin.top}
             stroke="#a44afe"
             tickStroke="#a44afe"
-            tickLabelComponent={
-              <text fill="#a44afe" fontSize={11} textAnchor="middle" />
-            }
+            tickLabelProps={(value, index) => ({
+              fill: '#a44afe',
+              fontSize: 11,
+              textAnchor: 'middle',
+            })}
           />
         </svg>
         <div

--- a/packages/vx-demo/pages/axis.js
+++ b/packages/vx-demo/pages/axis.js
@@ -116,54 +116,45 @@ export default ({
         scale={yScale}
         hideZero
         numTicks={numTicksForHeight(height)}
-        label={
-          <text
-            fill="#8e205f"
-            textAnchor="middle"
-            fontSize={10}
-            fontFamily="Arial"
-          >
-            value
-          </text>
-        }
+        label="value"
+        labelProps={{
+          fill: '#8e205f',
+          textAnchor: 'middle',
+          fontSize: 12,
+          fontFamily: 'Arial',
+        }}
         stroke="#1b1a1e"
-        tickLabelComponent={
-          <text
-            fill="#8e205f"
-            textAnchor="end"
-            fontSize={10}
-            fontFamily="Arial"
-            dx="-0.25em"
-            dy="0.25em"
-          />
-        }
+        tickStroke="#8e205f"
+        tickLabelProps={(value, index) => ({
+          fill: '#8e205f',
+          textAnchor: 'end',
+          fontSize: 10,
+          fontFamily: 'Arial',
+          dx: '-0.25em',
+          dy: '0.25em',
+        })}
       />
       <AxisBottom
         top={height - margin.bottom}
         left={margin.left}
         scale={xScale}
         numTicks={numTicksForWidth(width)}
-        label={
-          <text
-            fill="#8e205f"
-            textAnchor="middle"
-            fontSize={10}
-            fontFamily="Arial"
-          >
-            time
-          </text>
-        }
-        stroke={'#1b1a1e'}
-        tickStroke={'#1b1a1e'}
-        tickLabelComponent={
-          <text
-            fill="#8e205f"
-            textAnchor="middle"
-            fontSize={10}
-            fontFamily="Arial"
-            dy="0.25em"
-          />
-        }
+        label="time"
+        labelProps={{
+          fill: '#8e205f',
+          textAnchor: 'middle',
+          fontSize: 12,
+          fontFamily: 'Arial',
+        }}
+        stroke="#1b1a1e"
+        tickStroke="#8e205f"
+        tickLabelProps={(value, index) => ({
+          fill: '#8e205f',
+          textAnchor: 'middle',
+          fontSize: 10,
+          fontFamily: 'Arial',
+          dy: '0.25em',
+        })}
       />
     </svg>
   );

--- a/packages/vx-demo/pages/bargroup.js
+++ b/packages/vx-demo/pages/bargroup.js
@@ -96,13 +96,11 @@ export default ({
         stroke='#e5fd3d'
         tickStroke='#e5fd3d'
         hideAxisLine
-        tickLabelComponent={(
-          <text
-            fill='#e5fd3d'
-            fontSize={11}
-            textAnchor="middle"
-          />
-        )}
+        tickLabelProps={(value, index) => ({
+          fill: '#e5fd3d',
+          fontSize: 11,
+          textAnchor: 'middle',
+        })}
       />
     </svg>
   );

--- a/packages/vx-demo/pages/barstack.js
+++ b/packages/vx-demo/pages/barstack.js
@@ -122,9 +122,11 @@ export default withTooltip(
             top={yMax + margin.top}
             stroke="#a44afe"
             tickStroke="#a44afe"
-            tickLabelComponent={
-              <text fill="#a44afe" fontSize={11} textAnchor="middle" />
-            }
+            tickLabelProps={(value, index) => ({
+              fill: '#a44afe',
+              fontSize: 11,
+              textAnchor: 'middle',
+            })}
           />
         </svg>
         <div


### PR DESCRIPTION
This PR makes some (**breaking**❗️) changes to the `@vx/axis` package to address several issues highlighted in #138. It also updates relevant `@vx/axis` tests, the demo pages, and the Readme for the package (I couldn't successfully get the docs script to run locally, though 🤔 ).

**Removed**
The following props were removed to make the API more consistent by getting rid of component wrappers:
- `labelComponent`
- `tickLabelComponent`

The generic `className` prop was also removed for more _granular_ control (see below).

**Added**
To replace the above functionality the following props were added:
- `label` (a string label)
- `labelProps` (`obj`, styles applied to the label `text` element)
- `tickLabelProps` (`(tickValue, index) => obj`, called for each tick, returned styles are applied to tick label `text` elements)

Additionally, `className` hooks were made more granular as suggested by @Fxlr8:
- `axisClassName` (replaces `className`, class for entire `Axis` group)
- `axisLineClassName` (class for the axis `Line` component)
-  `labelClassName` (class for the axis label [`text`] component)
- `tickClassName` (class for each tick group, you can style text and lines specifically with e.g., `.my-tick-class text` or `.my-tick-class line`)

Note these components also always have the following classes in addition to those specified by the user: `vx-axis`, `vx-axis-label`,`vx-axis-line`, and `vx-axis-tick`.

**Tests**
I updated jest tests in `@vx/axis` and added some new ones for all axis components that reflect the new API and functionality. Also tested functionally via the demo pages:

**Default styles**:
![default](https://user-images.githubusercontent.com/4496521/30190292-2dc3be26-93ee-11e7-8e82-899acd72b93f.png)

**Custom styles** (note the per-tick alignment on top and bottom 🎉 ):
![styled](https://user-images.githubusercontent.com/4496521/30190287-2ac76290-93ee-11e7-8b94-745fdb441f74.png)

**Example usage**
```javascript
<Axis 
  {...}
  axisClassName="axis-klass"
  axisLineClassName="axis-line-klass"
  labelClassName="axis-label-klass"
  tickClassName="axis-tick-klass"
  label="axis label" 
  labelProps={{ fill: 'magenta' }}
  tickLabelProps={(val, i) => ({
    textAnchor: i === 0 ? 'start' : (i === lastIndex ? 'end' : 'middle'),
  })
/>
```