### PR TITLE
ES6 Module Support Proposal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 build
+module
 bundle.js
 test/tmp
 *.log

--- a/packages/vx-axis/.babelrc
+++ b/packages/vx-axis/.babelrc
@@ -1,19 +1,4 @@
 {
-  "presets": ["es2015", "react", "stage-0"],
-  "plugins": [],
-  "env": {
-    "development": {
-      "plugins": [
-        ["react-transform", {
-          "transforms": [{
-            "transform": "react-transform-hmr",
-            "imports": ["react"],
-            "locals": ["module"]
-          }]
-        }],
-        "transform-runtime",
-        "transform-decorators-legacy"
-      ]
-    }
-  }
+  "presets": ["./babelrc.js"]
 }
+

--- a/packages/vx-axis/babelrc.js
+++ b/packages/vx-axis/babelrc.js
@@ -1,0 +1,23 @@
+module.exports = {
+  presets: [
+    ['es2015', { 'modules': process.env.BABEL_ENV === 'es6' ? false : 'commonjs' }],
+    'react',
+    'stage-0'
+  ],
+  plugins: [],
+  env: {
+    development: {
+      plugins: [
+        ['react-transform', {
+          transforms: [{
+            transform: 'react-transform-hmr',
+            imports: ['react'],
+            locals: ['module']
+          }]
+        }],
+        'transform-runtime',
+        'transform-decorators-legacy'
+      ]
+    }
+  }
+}

--- a/packages/vx-axis/package.json
+++ b/packages/vx-axis/package.json
@@ -3,9 +3,10 @@
   "version": "0.0.136",
   "description": "vx axis",
   "main": "build/index.js",
+  "module": "module/index.js",
   "scripts": {
-    "build": "make build SRC=./src",
-    "prepublish": "make build SRC=./src",
+    "build": "make build SRC=./src && BABEL_ENV=es6 node_modules/.bin/babel -d module ./src",
+    "prepublish": "npm run build",
     "test": "jest"
   },
   "files": [


### PR DESCRIPTION
Relates to https://github.com/hshoff/vx/issues/143

One way of doing it. I couldn't find a simpler way of changing the `modules: false` field for two different builds. The idea would be that this format would be applied across all the libraries