### PR TITLE
Update hierarchy comps

### DIFF
--- a/packages/vx-hierarchy/src/DefaultLink.js
+++ b/packages/vx-hierarchy/src/DefaultLink.js
@@ -1,0 +1,15 @@
+import React from "react";
+
+export default function DefaultLink({ link }) {
+  return (
+    <line
+      x1={link.source.x}
+      y1={link.source.y}
+      x2={link.target.x}
+      y2={link.target.y}
+      strokeWidth={2}
+      stroke="#999"
+      strokeOpacity={0.6}
+    />
+  );
+}

--- a/packages/vx-hierarchy/src/DefaultNode.js
+++ b/packages/vx-hierarchy/src/DefaultNode.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function DefaultNode({ node }) {
+  return <circle cx={node.x} cy={node.y} r={15} fill="#21D4FD" />;
+}

--- a/packages/vx-hierarchy/src/hierarchies/Cluster.js
+++ b/packages/vx-hierarchy/src/hierarchies/Cluster.js
@@ -25,7 +25,7 @@ export default function Cluster({
   const links = data.links();
   const descendants = root.descendants();
   return (
-    <Group top={top} left={left} className={className}>
+    <Group top={top} left={left} className={cx("vx-cluster", className)}>
       {linkComponent &&
         links.map((link, i) => {
           return (
@@ -37,7 +37,7 @@ export default function Cluster({
       {nodeComponent &&
         descendants.map((node, i) => {
           return (
-            <Group key={`cluster-node-${i}`} className={className}>
+            <Group key={`cluster-node-${i}`}>
               {React.createElement(nodeComponent, { node })}
             </Group>
           );

--- a/packages/vx-hierarchy/src/hierarchies/Cluster.js
+++ b/packages/vx-hierarchy/src/hierarchies/Cluster.js
@@ -1,7 +1,7 @@
-import React from 'react';
-import cx from 'classnames';
-import { Group } from '@vx/group';
-import { cluster as d3cluster } from 'd3-hierarchy';
+import React from "react";
+import cx from "classnames";
+import { Group } from "@vx/group";
+import { cluster as d3cluster } from "d3-hierarchy";
 
 export default function Cluster({
   top,
@@ -23,21 +23,23 @@ export default function Cluster({
   const links = data.links();
   const descendants = root.descendants();
   return (
-    <Group top={top} left={left}>
-      {linkComponent && links.map((link, i) => {
-        return (
-          <Group key={`cluster-link-${i}`}>
-            {React.createElement(linkComponent, { link })}
-          </Group>
-        );
-      })}
-      {nodeComponent && descendants.map((node, i) => {
-        return (
-          <Group key={`cluster-node-${i}`}>
-            {React.createElement(nodeComponent, { node })}
-          </Group>
-        );
-      })}
+    <Group top={top} left={left} className={className}>
+      {linkComponent &&
+        links.map((link, i) => {
+          return (
+            <Group key={`cluster-link-${i}`}>
+              {React.createElement(linkComponent, { link })}
+            </Group>
+          );
+        })}
+      {nodeComponent &&
+        descendants.map((node, i) => {
+          return (
+            <Group key={`cluster-node-${i}`} className={className}>
+              {React.createElement(nodeComponent, { node })}
+            </Group>
+          );
+        })}
     </Group>
   );
 }

--- a/packages/vx-hierarchy/src/hierarchies/Cluster.js
+++ b/packages/vx-hierarchy/src/hierarchies/Cluster.js
@@ -2,6 +2,8 @@ import React from "react";
 import cx from "classnames";
 import { Group } from "@vx/group";
 import { cluster as d3cluster } from "d3-hierarchy";
+import DefaultLink from "../DefaultLink";
+import DefaultNode from "../DefaultNode";
 
 export default function Cluster({
   top,
@@ -11,8 +13,8 @@ export default function Cluster({
   size,
   nodeSize,
   separation,
-  linkComponent,
-  nodeComponent,
+  linkComponent = DefaultLink,
+  nodeComponent = DefaultNode,
   ...restProps
 }) {
   const cluster = d3cluster();

--- a/packages/vx-hierarchy/src/hierarchies/Tree.js
+++ b/packages/vx-hierarchy/src/hierarchies/Tree.js
@@ -2,6 +2,8 @@ import React from "react";
 import cx from "classnames";
 import { Group } from "@vx/group";
 import { tree as d3tree } from "d3-hierarchy";
+import DefaultLink from "../DefaultLink";
+import DefaultNode from "../DefaultNode";
 
 export default function Tree({
   top,
@@ -11,8 +13,8 @@ export default function Tree({
   size,
   nodeSize,
   separation,
-  linkComponent,
-  nodeComponent,
+  linkComponent = DefaultLink,
+  nodeComponent = DefaultNode,
   ...restProps
 }) {
   const tree = d3tree();

--- a/packages/vx-hierarchy/src/hierarchies/Tree.js
+++ b/packages/vx-hierarchy/src/hierarchies/Tree.js
@@ -1,7 +1,7 @@
-import React from 'react';
-import cx from 'classnames';
-import { Group } from '@vx/group';
-import { tree as d3tree } from 'd3-hierarchy';
+import React from "react";
+import cx from "classnames";
+import { Group } from "@vx/group";
+import { tree as d3tree } from "d3-hierarchy";
 
 export default function Tree({
   top,
@@ -23,21 +23,23 @@ export default function Tree({
   const links = data.links();
   const descendants = root.descendants();
   return (
-    <Group top={top} left={left}>
-      {linkComponent && links.map((link, i) => {
-        return (
-          <Group key={`tree-link-${i}`}>
-            {React.createElement(linkComponent, { link })}
-          </Group>
-        );
-      })}
-      {nodeComponent && descendants.map((node, i) => {
-        return (
-          <Group key={`tree-node-${i}`}>
-            {React.createElement(nodeComponent, { node })}
-          </Group>
-        );
-      })}
+    <Group top={top} left={left} className={className}>
+      {linkComponent &&
+        links.map((link, i) => {
+          return (
+            <Group key={`tree-link-${i}`}>
+              {React.createElement(linkComponent, { link })}
+            </Group>
+          );
+        })}
+      {nodeComponent &&
+        descendants.map((node, i) => {
+          return (
+            <Group key={`tree-node-${i}`} className={className}>
+              {React.createElement(nodeComponent, { node })}
+            </Group>
+          );
+        })}
     </Group>
   );
 }

--- a/packages/vx-hierarchy/src/hierarchies/Tree.js
+++ b/packages/vx-hierarchy/src/hierarchies/Tree.js
@@ -25,7 +25,7 @@ export default function Tree({
   const links = data.links();
   const descendants = root.descendants();
   return (
-    <Group top={top} left={left} className={className}>
+    <Group top={top} left={left} className={cx("vx-tree", className)}>
       {linkComponent &&
         links.map((link, i) => {
           return (
@@ -37,7 +37,7 @@ export default function Tree({
       {nodeComponent &&
         descendants.map((node, i) => {
           return (
-            <Group key={`tree-node-${i}`} className={className}>
+            <Group key={`tree-node-${i}`}>
               {React.createElement(nodeComponent, { node })}
             </Group>
           );

--- a/packages/vx-hierarchy/src/index.js
+++ b/packages/vx-hierarchy/src/index.js
@@ -1,2 +1,4 @@
-export { default as Tree } from './hierarchies/Tree';
-export { default as Cluster } from './hierarchies/Cluster';
+export { default as Tree } from "./hierarchies/Tree";
+export { default as Cluster } from "./hierarchies/Cluster";
+export { default as DefaultLink } from "./DefaultLink";
+export { default as DefaultNode } from "./DefaultNode";

--- a/packages/vx-hierarchy/test/Defaults.test.js
+++ b/packages/vx-hierarchy/test/Defaults.test.js
@@ -1,0 +1,13 @@
+import { DefaultLink, DefaultNode } from "../src";
+
+describe("<DefaultLink />", () => {
+  test("it should be defined", () => {
+    expect(DefaultLink).toBeDefined();
+  });
+});
+
+describe("<DefaultNode />", () => {
+  test("it should be defined", () => {
+    expect(DefaultNode).toBeDefined();
+  });
+});


### PR DESCRIPTION
This is related to #139 

This PR does the following (each statement applies to both `<Tree />` and `<Cluster />` components:

1. Adds `className` to each `<Group />` component.
* Is this where the `className` prop should go?  I didn't see any other reasonable place to put it.
2. Adds `<DefaultLink />` and `<DefaultNode />` components to each component, along with basic tests for each.
* These render just fine--let me know if there are issues with them.
* I don't know much about testing components, so let me know if we need more comprehensive tests right now 🃏 

This PR **does not**

3. Add defaults to the `size`, `nodeSize`, and `separation` props.
* The defaults are set in the corresponding d3 functions.   The questions is, are we setting defaults at the highest or lowest level they're called at?  
  * For example, there is no default for the `top` prop in either component--the prop gets passed to `<Group />` which **does** have a default for `top`.  So the default is set there (that's what I mean by "lowest level". I think this is the best way to do it.
4. Update the Readme.  
* I can do this once the above points are addressed (let me know and I can add them before you merge 👍)

This is my first contribution to the codebase outside of documentation, so let me know if there's something I missed.  For example, it doesn't have today's commits to master (I probably need to do that, right? 😬).