### PR TITLE
[event] add touchEvt support to localPnt, find owner svg. fixes #15

### DIFF
--- a/packages/vx-demo/components/tiles/area.js
+++ b/packages/vx-demo/components/tiles/area.js
@@ -19,6 +19,27 @@ const yStock = d => d.close;
 const bisectDate = bisector(d => new Date(d.date)).left;
 
 class Area extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleTooltip = this.handleTooltip.bind(this);
+  }
+  handleTooltip({ event, data, xStock, xScale, yScale }) {
+    const { showTooltip } = this.props;
+    const { x } = localPoint(event);
+    const x0 = xScale.invert(x);
+    const index = bisectDate(data, x0, 1);
+    const d0 = data[index - 1];
+    const d1 = data[index];
+    let d = d0;
+    if (d1 && d1.date) {
+      d = x0 - xStock(d0.date) > xStock(d1.date) - x0 ? d1 : d0;
+    }
+    showTooltip({
+      tooltipData: d,
+      tooltipLeft: x,
+      tooltipTop: yScale(d.close),
+    });
+  }
   render() {
     const {
       width,
@@ -108,28 +129,33 @@ class Area extends React.Component {
             fill="transparent"
             rx={14}
             data={stock}
+            onTouchStart={data => event =>
+              this.handleTooltip({
+                event,
+                data,
+                xStock,
+                xScale,
+                yScale,
+              })}
+            onTouchMove={data => event =>
+              this.handleTooltip({
+                event,
+                data,
+                xStock,
+                xScale,
+                yScale,
+              })}
+            onMouseMove={data => event =>
+              this.handleTooltip({
+                event,
+                data,
+                xStock,
+                xScale,
+                yScale,
+              })}
             onMouseLeave={data => event => hideTooltip()}
-            onMouseMove={data => event => {
-              const { x } = localPoint(this.svg, event);
-              const x0 = xScale.invert(x);
-              const index = bisectDate(data, x0, 1);
-              const d0 = data[index - 1];
-              const d1 = data[index];
-              let d = d0;
-              if (d1 && d1.date) {
-                d =
-                  x0 - xStock(d0.date) > xStock(d1.date) - x0
-                    ? d1
-                    : d0;
-              }
-              showTooltip({
-                tooltipData: d,
-                tooltipLeft: x,
-                tooltipTop: yScale(d.close),
-              });
-            }}
           />
-          {tooltipData &&
+          {tooltipData && (
             <g>
               <Line
                 from={{ x: tooltipLeft, y: 0 }}
@@ -159,9 +185,10 @@ class Area extends React.Component {
                 strokeWidth={2}
                 style={{ pointerEvents: 'none' }}
               />
-            </g>}
+            </g>
+          )}
         </svg>
-        {tooltipData &&
+        {tooltipData && (
           <div>
             <Tooltip
               top={tooltipTop - 12}
@@ -182,7 +209,8 @@ class Area extends React.Component {
             >
               {formatDate(xStock(tooltipData))}
             </Tooltip>
-          </div>}
+          </div>
+        )}
       </div>
     );
   }

--- a/packages/vx-demo/pages/areas.js
+++ b/packages/vx-demo/pages/areas.js
@@ -35,6 +35,27 @@ const yStock = d => d.close;
 const bisectDate = bisector(d => new Date(d.date)).left;
 
 class Area extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleTooltip = this.handleTooltip.bind(this);
+  }
+  handleTooltip({ event, data, xStock, xScale, yScale }) {
+    const { showTooltip } = this.props;
+    const { x } = localPoint(event);
+    const x0 = xScale.invert(x);
+    const index = bisectDate(data, x0, 1);
+    const d0 = data[index - 1];
+    const d1 = data[index];
+    let d = d0;
+    if (d1 && d1.date) {
+      d = x0 - xStock(d0.date) > xStock(d1.date) - x0 ? d1 : d0;
+    }
+    showTooltip({
+      tooltipData: d,
+      tooltipLeft: x,
+      tooltipTop: yScale(d.close),
+    });
+  }
   render() {
     const {
       width,
@@ -83,7 +104,11 @@ class Area extends React.Component {
               x2="0%"
               y2="100%"
             >
-              <stop offset="0%" stopColor="#FFFFFF" stopOpacity={1} />
+              <stop
+                offset="0%"
+                stopColor="#FFFFFF"
+                stopOpacity={1}
+              />
               <stop
                 offset="100%"
                 stopColor="#FFFFFF"
@@ -124,28 +149,33 @@ class Area extends React.Component {
             fill="transparent"
             rx={14}
             data={stock}
+            onTouchStart={data => event =>
+              this.handleTooltip({
+                event,
+                data,
+                xStock,
+                xScale,
+                yScale,
+              })}
+            onTouchMove={data => event =>
+              this.handleTooltip({
+                event,
+                data,
+                xStock,
+                xScale,
+                yScale,
+              })}
+            onMouseMove={data => event =>
+              this.handleTooltip({
+                event,
+                data,
+                xStock,
+                xScale,
+                yScale,
+              })}
             onMouseLeave={data => event => hideTooltip()}
-            onMouseMove={data => event => {
-              const { x } = localPoint(this.svg, event);
-              const x0 = xScale.invert(x);
-              const index = bisectDate(data, x0, 1);
-              const d0 = data[index - 1];
-              const d1 = data[index];
-              let d = d0;
-              if (d1 && d1.date) {
-                d =
-                  x0 - xStock(d0.date) > xStock(d1.date) - x0
-                    ? d1
-                    : d0;
-              }
-              showTooltip({
-                tooltipData: d,
-                tooltipLeft: x,
-                tooltipTop: yScale(d.close),
-              });
-            }}
           />
-          {tooltipData &&
+          {tooltipData && (
             <g>
               <Line
                 from={{ x: tooltipLeft, y: 0 }}
@@ -175,9 +205,10 @@ class Area extends React.Component {
                 strokeWidth={2}
                 style={{ pointerEvents: 'none' }}
               />
-            </g>}
+            </g>
+          )}
         </svg>
-        {tooltipData &&
+        {tooltipData && (
           <div>
             <Tooltip
               top={tooltipTop - 12}
@@ -187,7 +218,7 @@ class Area extends React.Component {
                 color: 'white',
               }}
             >
-              {\`\$\${yStock(tooltipData)}\`}
+              {\`$\${yStock(tooltipData)}\`}
             </Tooltip>
             <Tooltip
               top={yMax - 14}
@@ -198,7 +229,8 @@ class Area extends React.Component {
             >
               {formatDate(xStock(tooltipData))}
             </Tooltip>
-          </div>}
+          </div>
+        )}
       </div>
     );
   }

--- a/packages/vx-event/src/index.js
+++ b/packages/vx-event/src/index.js
@@ -1,1 +1,2 @@
 export { default as localPoint } from './localPoint';
+export { default as touchPoint } from './touchPoint';

--- a/packages/vx-event/src/localPoint.js
+++ b/packages/vx-event/src/localPoint.js
@@ -1,21 +1,47 @@
 import { Point } from '@vx/point';
 
 export default function localPoint(node, event) {
+  // called with no args
   if (!node) return;
-  const svg = node.ownerSVGElement || node;
-  if (svg.createSVGPoint) {
-    let point = svg.createSVGPoint();
-    point.x = event.clientX;
-    point.y = event.clientY;
+
+  // called with localPoint(event)
+  if (node.target) {
+    event = node;
+
+    // set node to targets owner svg
+    node = event.target.ownerSVGElement;
+
+    // find the outermost svg
+    while (node.ownerSVGElement) {
+      node = node.ownerSVGElement;
+    }
+  }
+
+  // default to mouse event
+  let { clientX, clientY } = event;
+
+  // support touch event
+  if (event.changedTouches) {
+    clientX = event.changedTouches[0].clientX;
+    clientY = event.changedTouches[0].clientY;
+  }
+
+  // calculate coordinates from svg
+  if (node.createSVGPoint) {
+    let point = node.createSVGPoint();
+    point.x = clientX;
+    point.y = clientY;
     point = point.matrixTransform(node.getScreenCTM().inverse());
     return new Point({
       x: point.x,
-      y: point.y
+      y: point.y,
     });
   }
+
+  // fallback to calculating position from non-svg dom node
   let rect = node.getBoundingClientRect();
   return new Point({
-    x: event.clientX - rect.left - node.clientLeft,
-    y: event.clientY - rect.top - node.clientTop
+    x: clientX - rect.left - node.clientLeft,
+    y: clientY - rect.top - node.clientTop,
   });
 }

--- a/packages/vx-event/src/touchPoint.js
+++ b/packages/vx-event/src/touchPoint.js
@@ -9,12 +9,12 @@ export default function touchPoint(node, event) {
     point = point.matrixTransform(node.getScreenCTM().inverse());
     return new Point({
       x: point.x,
-      y: point.y
+      y: point.y,
     });
   }
   const rect = node.getBoundingClientRect();
   return new Point({
     x: event.changedTouches[0].clientX - rect.left - node.clientLeft,
-    y: event.changedTouches[0].clientY - rect.top - node.clientTop
+    y: event.changedTouches[0].clientY - rect.top - node.clientTop,
   });
 }


### PR DESCRIPTION
Fixes: https://github.com/hshoff/vx/issues/15

Adds single arity support to `localPoint(event)` which will find the ownerSVG and loop for the owner on nested SVG. This use case was found by @conglei  when his chart has nested svg icons that had event handlers. Thanks to @conglei for pointing this out.

You can still pass in a reference to a specific svg if you want your local point relative to a specific svg element by using dual arity `localPoint(svgNode, event)` or `localPoint(event.target.ownerSVGElement, event)`.

Lastly, this adds touch event support to `localPoint` so you don't have to use `touchPoint` and `localPoint`. `touchPoint` will still exist to prevent breaking changes for folks. I also added `touchPoint` to the exports on index so you can now do `import { touchPoint } from '@vx/event'` if you want to.

Updated the /areas demo to support touch events and mouse events with the new single arity usage. 

*future* will probably need a `localTouchPoints` that returns an array of local `event.changeTouches` points since `localPoint` returns the the first `event.eventTouches` and ignores the rest.