### PR TITLE
Add Pack, Partition, and Treemap hierarchical layouts.  Closes #172

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,18 +6,30 @@
   "scripts": {
     "test": "lerna exec npm install && jest",
     "docs": "node ./scripts/docs/index.js",
-    "prepare-release":
-      "git checkout master && git pull --rebase origin master && npm run docs && lerna updated",
+    "prepare-release": "git checkout master && git pull --rebase origin master && npm run docs && lerna updated",
     "release": "npm run prepare-release && lerna publish --exact"
   },
   "jest": {
-    "projects": ["<rootDir>/packages/*"],
+    "projects": [
+      "<rootDir>/packages/*"
+    ],
     "collectCoverage": true,
     "coverageDirectory": "<rootDir>/coverage",
-    "coveragePathIgnorePatterns": ["/node_modules/"],
-    "coverageReporters": ["text", "lcov"]
+    "coveragePathIgnorePatterns": [
+      "/node_modules/"
+    ],
+    "coverageReporters": [
+      "text",
+      "lcov"
+    ]
   },
-  "keywords": ["react", "d3", "visualization", "vx", "charts"],
+  "keywords": [
+    "react",
+    "d3",
+    "visualization",
+    "vx",
+    "charts"
+  ],
   "author": "@hshoff",
   "license": "MIT",
   "devDependencies": {

--- a/packages/vx-hierarchy/src/hierarchies/Cluster.js
+++ b/packages/vx-hierarchy/src/hierarchies/Cluster.js
@@ -7,7 +7,7 @@ import DefaultLink from '../HierarchyDefaultLink';
 import DefaultNode from '../HierarchyDefaultNode';
 
 Cluster.propTypes = {
-  root: PropTypes.object.isRequired,
+  data: PropTypes.object.isRequired,
   children: PropTypes.func,
 };
 
@@ -15,7 +15,7 @@ export default function Cluster({
   top,
   left,
   className,
-  root,
+  data,
   size,
   nodeSize,
   separation,
@@ -28,9 +28,8 @@ export default function Cluster({
   if (size) cluster.size(size);
   if (nodeSize) cluster.nodeSize(nodeSize);
   if (separation) cluster.separation(separation);
-  const data = cluster(root);
-  const links = data.links();
-  const descendants = root.descendants();
+
+  const root = cluster(data);
 
   if (!!children) {
     return (
@@ -39,7 +38,7 @@ export default function Cluster({
         left={left}
         className={cx('vx-cluster', className)}
       >
-        {children({ data, links, root, descendants })}
+        {children({ root })}
       </Group>
     );
   }
@@ -51,7 +50,7 @@ export default function Cluster({
       className={cx('vx-cluster', className)}
     >
       {linkComponent &&
-        links.map((link, i) => {
+        root.links().map((link, i) => {
           return (
             <Group key={`cluster-link-${i}`}>
               {React.createElement(linkComponent, { link })}
@@ -59,7 +58,7 @@ export default function Cluster({
           );
         })}
       {nodeComponent &&
-        descendants.map((node, i) => {
+        root.descendants().map((node, i) => {
           return (
             <Group key={`cluster-node-${i}`}>
               {React.createElement(nodeComponent, { node })}

--- a/packages/vx-hierarchy/src/hierarchies/Cluster.js
+++ b/packages/vx-hierarchy/src/hierarchies/Cluster.js
@@ -7,7 +7,7 @@ import DefaultLink from '../HierarchyDefaultLink';
 import DefaultNode from '../HierarchyDefaultNode';
 
 Cluster.propTypes = {
-  data: PropTypes.object.isRequired,
+  root: PropTypes.object.isRequired,
   children: PropTypes.func,
 };
 
@@ -15,7 +15,7 @@ export default function Cluster({
   top,
   left,
   className,
-  data,
+  root,
   size,
   nodeSize,
   separation,
@@ -29,7 +29,7 @@ export default function Cluster({
   if (nodeSize) cluster.nodeSize(nodeSize);
   if (separation) cluster.separation(separation);
 
-  const root = cluster(data);
+  const data = cluster(root);
 
   if (!!children) {
     return (
@@ -38,7 +38,7 @@ export default function Cluster({
         left={left}
         className={cx('vx-cluster', className)}
       >
-        {children({ root })}
+        {children({ data })}
       </Group>
     );
   }
@@ -50,7 +50,7 @@ export default function Cluster({
       className={cx('vx-cluster', className)}
     >
       {linkComponent &&
-        root.links().map((link, i) => {
+        data.links().map((link, i) => {
           return (
             <Group key={`cluster-link-${i}`}>
               {React.createElement(linkComponent, { link })}
@@ -58,7 +58,7 @@ export default function Cluster({
           );
         })}
       {nodeComponent &&
-        root.descendants().map((node, i) => {
+        data.descendants().map((node, i) => {
           return (
             <Group key={`cluster-node-${i}`}>
               {React.createElement(nodeComponent, { node })}

--- a/packages/vx-hierarchy/src/hierarchies/Pack.js
+++ b/packages/vx-hierarchy/src/hierarchies/Pack.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { Group } from '@vx/group';
+import { pack as d3pack } from 'd3-hierarchy';
+import DefaultNode from '../HierarchyDefaultNode';
+
+Pack.propTypes = {
+  data: PropTypes.object.isRequired,
+  children: PropTypes.func
+};
+
+export default function Pack({
+  top,
+  left,
+  className,
+  data,
+  radius,
+  size,
+  padding,
+  children,
+  nodeComponent = DefaultNode,
+  ...restProps
+}) {
+  const pack = d3pack();
+  if (size) pack.size(size);
+  if (radius) pack.radius(radius);
+  if (padding) pack.padding(padding);
+
+  const root = pack(data);
+
+  if (!!children) {
+    return (
+      <Group top={top} left={left} className={cx('vx-pack', className)}>
+        {children({ root })}
+      </Group>
+    );
+  }
+
+  return (
+    <Group top={top} left={left} className={cx('vx-pack', className)}>
+      {nodeComponent &&
+        root.descendants().map((node, i) => {
+          return (
+            <Group key={`pack-node-${i}`}>
+              {React.createElement(nodeComponent, { node })}
+            </Group>
+          );
+        })}
+    </Group>
+  );
+}

--- a/packages/vx-hierarchy/src/hierarchies/Pack.js
+++ b/packages/vx-hierarchy/src/hierarchies/Pack.js
@@ -6,7 +6,7 @@ import { pack as d3pack } from 'd3-hierarchy';
 import DefaultNode from '../HierarchyDefaultNode';
 
 Pack.propTypes = {
-  data: PropTypes.object.isRequired,
+  root: PropTypes.object.isRequired,
   children: PropTypes.func
 };
 
@@ -14,7 +14,7 @@ export default function Pack({
   top,
   left,
   className,
-  data,
+  root,
   radius,
   size,
   padding,
@@ -27,12 +27,12 @@ export default function Pack({
   if (radius) pack.radius(radius);
   if (padding) pack.padding(padding);
 
-  const root = pack(data);
+  const data = pack(root);
 
   if (!!children) {
     return (
       <Group top={top} left={left} className={cx('vx-pack', className)}>
-        {children({ root })}
+        {children({ data })}
       </Group>
     );
   }
@@ -40,7 +40,7 @@ export default function Pack({
   return (
     <Group top={top} left={left} className={cx('vx-pack', className)}>
       {nodeComponent &&
-        root.descendants().map((node, i) => {
+        data.descendants().map((node, i) => {
           return (
             <Group key={`pack-node-${i}`}>
               {React.createElement(nodeComponent, { node })}

--- a/packages/vx-hierarchy/src/hierarchies/Partition.js
+++ b/packages/vx-hierarchy/src/hierarchies/Partition.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { Group } from '@vx/group';
+import { partition as d3partition } from 'd3-hierarchy';
+import DefaultNode from '../HierarchyDefaultNode';
+
+Partition.propTypes = {
+  data: PropTypes.object.isRequired,
+  children: PropTypes.func
+};
+
+export default function Partition({
+  top,
+  left,
+  className,
+  data,
+  size,
+  round,
+  padding,
+  children,
+  nodeComponent = DefaultNode,
+  ...restProps
+}) {
+  const partition = d3partition();
+  if (size) partition.size(size);
+  if (round) partition.round(round);
+  if (padding) partition.padding(padding);
+
+  const root = partition(data);
+
+  if (!!children) {
+    return (
+      <Group top={top} left={left} className={cx('vx-pack', className)}>
+        {children({ root })}
+      </Group>
+    );
+  }
+
+  return (
+    <Group top={top} left={left} className={cx('vx-pack', className)}>
+      {nodeComponent &&
+        root.descendants().map((node, i) => {
+          return (
+            <Group key={`pack-node-${i}`}>
+              {React.createElement(nodeComponent, { node })}
+            </Group>
+          );
+        })}
+    </Group>
+  );
+}

--- a/packages/vx-hierarchy/src/hierarchies/Partition.js
+++ b/packages/vx-hierarchy/src/hierarchies/Partition.js
@@ -6,7 +6,7 @@ import { partition as d3partition } from 'd3-hierarchy';
 import DefaultNode from '../HierarchyDefaultNode';
 
 Partition.propTypes = {
-  data: PropTypes.object.isRequired,
+  root: PropTypes.object.isRequired,
   children: PropTypes.func
 };
 
@@ -14,7 +14,7 @@ export default function Partition({
   top,
   left,
   className,
-  data,
+  root,
   size,
   round,
   padding,
@@ -27,12 +27,12 @@ export default function Partition({
   if (round) partition.round(round);
   if (padding) partition.padding(padding);
 
-  const root = partition(data);
+  const data = partition(root);
 
   if (!!children) {
     return (
       <Group top={top} left={left} className={cx('vx-pack', className)}>
-        {children({ root })}
+        {children({ data })}
       </Group>
     );
   }
@@ -40,7 +40,7 @@ export default function Partition({
   return (
     <Group top={top} left={left} className={cx('vx-pack', className)}>
       {nodeComponent &&
-        root.descendants().map((node, i) => {
+        data.descendants().map((node, i) => {
           return (
             <Group key={`pack-node-${i}`}>
               {React.createElement(nodeComponent, { node })}

--- a/packages/vx-hierarchy/src/hierarchies/Tree.js
+++ b/packages/vx-hierarchy/src/hierarchies/Tree.js
@@ -7,7 +7,7 @@ import DefaultLink from '../HierarchyDefaultLink';
 import DefaultNode from '../HierarchyDefaultNode';
 
 Tree.propTypes = {
-  data: PropTypes.object.isRequired,
+  root: PropTypes.object.isRequired,
   children: PropTypes.func,
 };
 
@@ -15,7 +15,7 @@ export default function Tree({
   top,
   left,
   className,
-  data,
+  root,
   size,
   nodeSize,
   separation,
@@ -29,7 +29,7 @@ export default function Tree({
   if (nodeSize) tree.nodeSize(nodeSize);
   if (separation) tree.separation(separation);
 
-  const root = tree(data);
+  const data = tree(root);
 
   if (!!children) {
     return (
@@ -38,7 +38,7 @@ export default function Tree({
         left={left}
         className={cx('vx-tree', className)}
       >
-        {children({ root })}
+        {children({ data })}
       </Group>
     );
   }
@@ -46,7 +46,7 @@ export default function Tree({
   return (
     <Group top={top} left={left} className={cx('vx-tree', className)}>
       {linkComponent &&
-        root.links().map((link, i) => {
+        data.links().map((link, i) => {
           return (
             <Group key={`tree-link-${i}`}>
               {React.createElement(linkComponent, { link })}
@@ -54,7 +54,7 @@ export default function Tree({
           );
         })}
       {nodeComponent &&
-        root.descendants().map((node, i) => {
+        data.descendants().map((node, i) => {
           return (
             <Group key={`tree-node-${i}`}>
               {React.createElement(nodeComponent, { node })}

--- a/packages/vx-hierarchy/src/hierarchies/Tree.js
+++ b/packages/vx-hierarchy/src/hierarchies/Tree.js
@@ -7,7 +7,7 @@ import DefaultLink from '../HierarchyDefaultLink';
 import DefaultNode from '../HierarchyDefaultNode';
 
 Tree.propTypes = {
-  root: PropTypes.object.isRequired,
+  data: PropTypes.object.isRequired,
   children: PropTypes.func,
 };
 
@@ -15,7 +15,7 @@ export default function Tree({
   top,
   left,
   className,
-  root,
+  data,
   size,
   nodeSize,
   separation,
@@ -29,9 +29,7 @@ export default function Tree({
   if (nodeSize) tree.nodeSize(nodeSize);
   if (separation) tree.separation(separation);
 
-  const data = tree(root);
-  const links = data.links();
-  const descendants = root.descendants();
+  const root = tree(data);
 
   if (!!children) {
     return (
@@ -40,7 +38,7 @@ export default function Tree({
         left={left}
         className={cx('vx-tree', className)}
       >
-        {children({ data, links, root, descendants })}
+        {children({ root })}
       </Group>
     );
   }
@@ -48,7 +46,7 @@ export default function Tree({
   return (
     <Group top={top} left={left} className={cx('vx-tree', className)}>
       {linkComponent &&
-        links.map((link, i) => {
+        root.links().map((link, i) => {
           return (
             <Group key={`tree-link-${i}`}>
               {React.createElement(linkComponent, { link })}
@@ -56,7 +54,7 @@ export default function Tree({
           );
         })}
       {nodeComponent &&
-        descendants.map((node, i) => {
+        root.descendants().map((node, i) => {
           return (
             <Group key={`tree-node-${i}`}>
               {React.createElement(nodeComponent, { node })}

--- a/packages/vx-hierarchy/src/hierarchies/Treemap.js
+++ b/packages/vx-hierarchy/src/hierarchies/Treemap.js
@@ -14,7 +14,7 @@ export default function Treemap({
   top,
   left,
   className,
-  data,
+  root,
   tile,
   size,
   round,
@@ -41,12 +41,12 @@ export default function Treemap({
   if (paddingBottom) treemap.paddingBottom(paddingBottom);
   if (paddingLeft) treemap.paddingLeft(paddingLeft);
 
-  const root = treemap(data);
+  const data = treemap(root);
 
   if (!!children) {
     return (
       <Group top={top} left={left} className={cx('vx-treemap', className)}>
-        {children({ root })}
+        {children({ data })}
       </Group>
     );
   }
@@ -54,7 +54,7 @@ export default function Treemap({
   return (
     <Group top={top} left={left} className={cx('vx-treemap', className)}>
       {nodeComponent &&
-        root.descendants().map((node, i) => {
+        data.descendants().map((node, i) => {
           return (
             <Group key={`treemap-node-${i}`}>
               {React.createElement(nodeComponent, { node })}

--- a/packages/vx-hierarchy/src/hierarchies/Treemap.js
+++ b/packages/vx-hierarchy/src/hierarchies/Treemap.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { Group } from '@vx/group';
+import { treemap as d3treemap } from 'd3-hierarchy';
+import DefaultNode from '../HierarchyDefaultNode';
+
+Treemap.propTypes = {
+  root: PropTypes.object.isRequired,
+  children: PropTypes.func
+};
+
+export default function Treemap({
+  top,
+  left,
+  className,
+  data,
+  tile,
+  size,
+  round,
+  padding,
+  paddingInner,
+  paddingOuter,
+  paddingTop,
+  paddingRight,
+  paddingBottom,
+  paddingLeft,
+  children,
+  nodeComponent = DefaultNode,
+  ...restProps
+}) {
+  const treemap = d3treemap();
+  if (tile) treemap.tile(tile);
+  if (size) treemap.size(size);
+  if (round) treemap.round(round);
+  if (padding) treemap.padding(padding);
+  if (paddingInner) treemap.paddingInner(paddingInner);
+  if (paddingOuter) treemap.paddingOuter(paddingOuter);
+  if (paddingTop) treemap.paddingTop(paddingTop);
+  if (paddingRight) treemap.paddingRight(paddingRight);
+  if (paddingBottom) treemap.paddingBottom(paddingBottom);
+  if (paddingLeft) treemap.paddingLeft(paddingLeft);
+
+  const root = treemap(data);
+
+  if (!!children) {
+    return (
+      <Group top={top} left={left} className={cx('vx-treemap', className)}>
+        {children({ root })}
+      </Group>
+    );
+  }
+
+  return (
+    <Group top={top} left={left} className={cx('vx-treemap', className)}>
+      {nodeComponent &&
+        root.descendants().map((node, i) => {
+          return (
+            <Group key={`treemap-node-${i}`}>
+              {React.createElement(nodeComponent, { node })}
+            </Group>
+          );
+        })}
+    </Group>
+  );
+}


### PR DESCRIPTION
I also updated `Tree` and `Cluster` to only pass a single param to the child render function.  Based on [this](https://github.com/d3/d3-hierarchy#hierarchy):

![image](https://user-images.githubusercontent.com/177476/31474342-178d80d4-aec8-11e7-9b0e-b39da273b899.png)

I thought it made sense to swap `data` and `root` names, so now a layout component takes in a `data` prop (instead of `root`) and the child render function receives a `root` prop (instead of `data`, along with removing `descendants`, `links`, etc).

This also makes it more consistent with `BarGroup`, `BarStack`, `Projection`, etc.  I can be talked out of this, but it seemed like it made sense, and since we were already making a breaking change with the number of params passed to the children function, I thought it was worth changing.