### PR TITLE
[deps][test] use react 16 in dev, fix travis test run script. fixes #171

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ git:
 language: node_js
 node_js:
   - "8"
-  - "6"
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
+git:
+  depth: 10
 language: node_js
 node_js:
+  - "8"
   - "6"
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Low-level visualization components",
   "main": "index.js",
   "scripts": {
-    "test": "lerna exec npm install && jest",
+    "test": "lerna clean && lerna exec npm install --silent && lerna run test --parallel",
     "docs": "node ./scripts/docs/index.js",
     "prepare-release": "git checkout master && git pull --rebase origin master && npm run docs && lerna updated",
     "release": "npm run prepare-release && lerna publish --exact"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Low-level visualization components",
   "main": "index.js",
   "scripts": {
-    "test": "lerna clean --yes && lerna exec npm install --silent && lerna run test --parallel",
+    "test": "lerna clean --yes && lerna bootstrap && lerna exec npm run test",
     "docs": "node ./scripts/docs/index.js",
     "prepare-release": "git checkout master && git pull --rebase origin master && npm run docs && lerna updated",
     "release": "npm run prepare-release && lerna publish --exact"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Low-level visualization components",
   "main": "index.js",
   "scripts": {
-    "test": "lerna clean && lerna exec npm install --silent && lerna run test --parallel",
+    "test": "lerna clean --yes && lerna exec npm install --silent && lerna run test --parallel",
     "docs": "node ./scripts/docs/index.js",
     "prepare-release": "git checkout master && git pull --rebase origin master && npm run docs && lerna updated",
     "release": "npm run prepare-release && lerna publish --exact"

--- a/packages/vx-annotation/package.json
+++ b/packages/vx-annotation/package.json
@@ -29,13 +29,15 @@
   },
   "homepage": "https://github.com/hshoff/vx#readme",
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
-    "react-addons-test-utils": "15.4.2",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -51,5 +53,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-annotation/test/enzyme-setup.js
+++ b/packages/vx-annotation/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-axis/package.json
+++ b/packages/vx-axis/package.json
@@ -36,12 +36,15 @@
     "prop-types": "15.5.10"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -50,5 +53,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-axis/test/enzyme-setup.js
+++ b/packages/vx-axis/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-bounds/package.json
+++ b/packages/vx-bounds/package.json
@@ -32,12 +32,14 @@
   },
   "devDependencies": {
     "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
-    "react-dom": "^15.0.0-0 || ^16.0.0-0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -47,5 +49,11 @@
   "peerDependencies": {
     "react": "^15.0.0-0 || ^16.0.0-0",
     "react-dom": "^15.0.0-0 || ^16.0.0-0"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-bounds/test/enzyme-setup.js
+++ b/packages/vx-bounds/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-boxplot/package.json
+++ b/packages/vx-boxplot/package.json
@@ -30,12 +30,15 @@
     "classnames": "^2.2.5"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -44,5 +47,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-boxplot/test/enzyme-setup.js
+++ b/packages/vx-boxplot/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-brush/package.json
+++ b/packages/vx-brush/package.json
@@ -32,12 +32,15 @@
     "access": "public"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -47,5 +50,11 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "recompose": "^0.23.1"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-brush/test/enzyme-setup.js
+++ b/packages/vx-brush/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-clip-path/package.json
+++ b/packages/vx-clip-path/package.json
@@ -30,12 +30,15 @@
   },
   "homepage": "https://github.com/hshoff/vx#readme",
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
-    "react-addons-test-utils": "15.4.2",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -44,5 +47,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-clip-path/test/enzyme-setup.js
+++ b/packages/vx-clip-path/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-curve/package.json
+++ b/packages/vx-curve/package.json
@@ -25,12 +25,25 @@
     "d3-shape": "^1.0.6"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "jest": "^20.0.3",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
+    "react-test-renderer": "^16.0.0",
+    "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-curve/test/enzyme-setup.js
+++ b/packages/vx-curve/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-drag/package.json
+++ b/packages/vx-drag/package.json
@@ -32,16 +32,25 @@
     "access": "public"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
   "peerDependencies": {
     "react": "^15.0.0-0 || ^16.0.0-0"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-drag/test/enzyme-setup.js
+++ b/packages/vx-drag/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-event/package.json
+++ b/packages/vx-event/package.json
@@ -32,15 +32,25 @@
     "access": "public"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
   "dependencies": {
     "@vx/point": "0.0.136"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-event/test/enzyme-setup.js
+++ b/packages/vx-event/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-geo/package.json
+++ b/packages/vx-geo/package.json
@@ -33,12 +33,15 @@
     "prop-types": "^15.5.10"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.9.1",
-    "jest": "^20.0.4",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.13.3",
     "regenerator-runtime": "^0.10.5",
     "topojson-client": "^3.0.0"
@@ -48,5 +51,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-geo/test/enzyme-setup.js
+++ b/packages/vx-geo/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-glyph/package.json
+++ b/packages/vx-glyph/package.json
@@ -32,12 +32,15 @@
     "access": "public"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -48,5 +51,11 @@
     "@vx/group": "0.0.140",
     "classnames": "^2.2.5",
     "d3-shape": "^1.2.0"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-glyph/test/enzyme-setup.js
+++ b/packages/vx-glyph/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-gradient/package.json
+++ b/packages/vx-gradient/package.json
@@ -33,12 +33,15 @@
     "prop-types": "^15.5.7"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -47,5 +50,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-gradient/test/Gradients.test.js
+++ b/packages/vx-gradient/test/Gradients.test.js
@@ -20,7 +20,7 @@ describe('<GradientDarkgreenGreen />', () => {
 
   test('it should render without crashing', () => {
     const div = document.createElement('div')
-    ReactDOM.render(<GradientDarkgreenGreen id="gradient" />, div)
+    ReactDOM.render(<svg><GradientDarkgreenGreen id="gradient" /></svg>, div)
   })
 })
 
@@ -31,7 +31,7 @@ describe('<GradientLightgreenGreen />', () => {
 
   test('it should render without crashing', () => {
     const div = document.createElement('div')
-    ReactDOM.render(<GradientLightgreenGreen id="gradient" />, div)
+    ReactDOM.render(<svg><GradientLightgreenGreen id="gradient" /></svg>, div)
   })
 })
 
@@ -42,7 +42,7 @@ describe('<GradientOrangeRed />', () => {
 
   test('it should render without crashing', () => {
     const div = document.createElement('div')
-    ReactDOM.render(<GradientOrangeRed id="gradient" />, div)
+    ReactDOM.render(<svg><GradientOrangeRed id="gradient" /></svg>, div)
   })
 })
 
@@ -53,7 +53,7 @@ describe('<GradientPinkBlue />', () => {
 
   test('it should render without crashing', () => {
     const div = document.createElement('div')
-    ReactDOM.render(<GradientPinkBlue id="gradient" />, div)
+    ReactDOM.render(<svg><GradientPinkBlue id="gradient" /></svg>, div)
   })
 })
 
@@ -64,7 +64,7 @@ describe('<GradientPinkRed />', () => {
 
   test('it should render without crashing', () => {
     const div = document.createElement('div')
-    ReactDOM.render(<GradientPinkRed id="gradient" />, div)
+    ReactDOM.render(<svg><GradientPinkRed id="gradient" /></svg>, div)
   })
 })
 
@@ -75,7 +75,7 @@ describe('<GradientPurpleOrange />', () => {
 
   test('it should render without crashing', () => {
     const div = document.createElement('div')
-    ReactDOM.render(<GradientPurpleOrange id="gradient" />, div)
+    ReactDOM.render(<svg><GradientPurpleOrange id="gradient" /></svg>, div)
   })
 })
 
@@ -86,7 +86,7 @@ describe('<GradientPurpleRed />', () => {
 
   test('it should render without crashing', () => {
     const div = document.createElement('div')
-    ReactDOM.render(<GradientPurpleRed id="gradient" />, div)
+    ReactDOM.render(<svg><GradientPurpleRed id="gradient" /></svg>, div)
   })
 })
 
@@ -97,7 +97,7 @@ describe('<GradientPurpleTeal />', () => {
 
   test('it should render without crashing', () => {
     const div = document.createElement('div')
-    ReactDOM.render(<GradientPurpleTeal id="gradient" />, div)
+    ReactDOM.render(<svg><GradientPurpleTeal id="gradient" /></svg>, div)
   })
 })
 
@@ -108,7 +108,7 @@ describe('<GradientSteelPurple />', () => {
 
   test('it should render without crashing', () => {
     const div = document.createElement('div')
-    ReactDOM.render(<GradientSteelPurple id="gradient" />, div)
+    ReactDOM.render(<svg><GradientSteelPurple id="gradient" /></svg>, div)
   })
 })
 
@@ -119,6 +119,6 @@ describe('<GradientTealBlue />', () => {
 
   test('it should render without crashing', () => {
     const div = document.createElement('div')
-    ReactDOM.render(<GradientTealBlue id="gradient" />, div)
+    ReactDOM.render(<svg><GradientTealBlue id="gradient" /></svg>, div)
   })
 })

--- a/packages/vx-gradient/test/LinearGradient.test.js
+++ b/packages/vx-gradient/test/LinearGradient.test.js
@@ -9,6 +9,6 @@ describe('<LinearGradient />', () => {
 
   test('it should render without crashing', () => {
     const div = document.createElement('div')
-    ReactDOM.render(<LinearGradient id="linear" />, div)
+    ReactDOM.render(<svg><LinearGradient id="linear" /></svg>, div)
   })
 })

--- a/packages/vx-gradient/test/RadialGradient.test.js
+++ b/packages/vx-gradient/test/RadialGradient.test.js
@@ -9,6 +9,6 @@ describe('<RadialGradient />', () => {
 
   test('it should render without crashing', () => {
     const div = document.createElement('div')
-    ReactDOM.render(<RadialGradient id="radial" />, div)
+    ReactDOM.render(<svg><RadialGradient id="radial" /></svg>, div)
   })
 })

--- a/packages/vx-gradient/test/enzyme-setup.js
+++ b/packages/vx-gradient/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-grid/package.json
+++ b/packages/vx-grid/package.json
@@ -29,12 +29,15 @@
   },
   "homepage": "https://github.com/hshoff/vx#readme",
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -49,5 +52,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-grid/test/enzyme-setup.js
+++ b/packages/vx-grid/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-group/package.json
+++ b/packages/vx-group/package.json
@@ -30,12 +30,15 @@
   },
   "homepage": "https://github.com/hshoff/vx#readme",
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
-    "react-addons-test-utils": "15.4.2",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -47,5 +50,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-group/test/enzyme-setup.js
+++ b/packages/vx-group/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-heatmap/package.json
+++ b/packages/vx-heatmap/package.json
@@ -32,12 +32,15 @@
     "access": "public"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.4",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -47,5 +50,11 @@
   "dependencies": {
     "@vx/group": "0.0.140",
     "classnames": "^2.2.5"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-heatmap/test/enzyme-setup.js
+++ b/packages/vx-heatmap/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-hierarchy/package.json
+++ b/packages/vx-hierarchy/package.json
@@ -26,12 +26,15 @@
   },
   "homepage": "https://github.com/hshoff/vx#readme",
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -45,5 +48,11 @@
   },
   "peerDependencies": {
     "react": "^15.0.0-0 || ^16.0.0-0"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-hierarchy/test/Cluster.test.js
+++ b/packages/vx-hierarchy/test/Cluster.test.js
@@ -28,8 +28,5 @@ describe('<Cluster />', () => {
     const args = childrenFunc.mock.calls[0][0];
     expect(childrenFunc.mock.calls.length).toBe(1);
     expect(args.data).toBeDefined();
-    expect(args.links).toBeDefined();
-    expect(args.descendants).toBeDefined();
-    expect(args.root).toBeDefined();
   });
 });

--- a/packages/vx-hierarchy/test/Tree.test.js
+++ b/packages/vx-hierarchy/test/Tree.test.js
@@ -28,8 +28,5 @@ describe('<Tree />', () => {
     const args = childrenFunc.mock.calls[0][0];
     expect(childrenFunc.mock.calls.length).toBe(1);
     expect(args.data).toBeDefined();
-    expect(args.links).toBeDefined();
-    expect(args.descendants).toBeDefined();
-    expect(args.root).toBeDefined();
   });
 });

--- a/packages/vx-hierarchy/test/enzyme-setup.js
+++ b/packages/vx-hierarchy/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-legend/package.json
+++ b/packages/vx-legend/package.json
@@ -26,12 +26,15 @@
   },
   "homepage": "https://github.com/hshoff/vx#readme",
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -45,5 +48,11 @@
     "@vx/group": "0.0.140",
     "classnames": "^2.2.5",
     "prop-types": "^15.5.10"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-legend/test/enzyme-setup.js
+++ b/packages/vx-legend/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-marker/package.json
+++ b/packages/vx-marker/package.json
@@ -29,12 +29,15 @@
   },
   "homepage": "https://github.com/hshoff/vx#readme",
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -48,5 +51,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-marker/test/enzyme-setup.js
+++ b/packages/vx-marker/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-mock-data/package.json
+++ b/packages/vx-mock-data/package.json
@@ -29,9 +29,15 @@
   },
   "homepage": "https://github.com/hshoff/vx#readme",
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "jest": "^20.0.3",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -40,5 +46,11 @@
   },
   "dependencies": {
     "d3-random": "^1.0.3"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-mock-data/test/enzyme-setup.js
+++ b/packages/vx-mock-data/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-network/package.json
+++ b/packages/vx-network/package.json
@@ -21,10 +21,15 @@
   "author": "@andyfang_dz",
   "license": "MIT",
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -38,5 +43,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-network/test/enzyme-setup.js
+++ b/packages/vx-network/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-pattern/package.json
+++ b/packages/vx-pattern/package.json
@@ -33,12 +33,15 @@
     "prop-types": "^15.5.10"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -47,5 +50,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-pattern/test/enzyme-setup.js
+++ b/packages/vx-pattern/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-point/package.json
+++ b/packages/vx-point/package.json
@@ -21,13 +21,25 @@
   "author": "@hshoff",
   "license": "MIT",
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "jest": "^20.0.3",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-point/test/enzyme-setup.js
+++ b/packages/vx-point/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-responsive/package.json
+++ b/packages/vx-responsive/package.json
@@ -29,12 +29,15 @@
   },
   "homepage": "https://github.com/hshoff/vx#readme",
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -46,5 +49,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-responsive/test/enzyme-setup.js
+++ b/packages/vx-responsive/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-scale/package.json
+++ b/packages/vx-scale/package.json
@@ -29,11 +29,15 @@
   },
   "homepage": "https://github.com/hshoff/vx#readme",
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -42,5 +46,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-scale/test/enzyme-setup.js
+++ b/packages/vx-scale/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-shape/package.json
+++ b/packages/vx-shape/package.json
@@ -30,15 +30,17 @@
     "prop-types": "^15.5.10"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
     "d3-array": "^1.2.0",
     "d3-hierarchy": "^1.1.5",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
-    "react-dom": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -47,5 +49,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-shape/test/enzyme-setup.js
+++ b/packages/vx-shape/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-text/package.json
+++ b/packages/vx-text/package.json
@@ -32,12 +32,15 @@
     "classnames": "^2.2.5"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -46,5 +49,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-text/test/enzyme-setup.js
+++ b/packages/vx-text/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-tooltip/package.json
+++ b/packages/vx-tooltip/package.json
@@ -31,12 +31,15 @@
     "prop-types": "^15.5.10"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -45,5 +48,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-tooltip/test/enzyme-setup.js
+++ b/packages/vx-tooltip/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-voronoi/package.json
+++ b/packages/vx-voronoi/package.json
@@ -32,12 +32,15 @@
     "access": "public"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -48,5 +51,11 @@
   },
   "peerDependencies": {
     "react": "^15.0.0-0 || ^16.0.0-0"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-voronoi/test/enzyme-setup.js
+++ b/packages/vx-voronoi/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-vx/package.json
+++ b/packages/vx-vx/package.json
@@ -32,12 +32,15 @@
     "react": "^15.0.0-0 || ^16.0.0-0"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
   },
@@ -71,5 +74,11 @@
     "@vx/tooltip": "0.0.141",
     "@vx/voronoi": "0.0.140",
     "@vx/zoom": "0.0.140"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-vx/test/enzyme-setup.js
+++ b/packages/vx-vx/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/packages/vx-zoom/package.json
+++ b/packages/vx-zoom/package.json
@@ -32,12 +32,22 @@
     "access": "public"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "enzyme": "^2.8.2",
-    "jest": "^20.0.3",
+    "babel-jest": "^21.2.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
+    "jest": "^21.2.1",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^16.0.0",
     "react-tools": "^0.10.0",
     "regenerator-runtime": "^0.10.5"
+  },
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "<rootDir>/test/enzyme-setup.js"
+    ]
   }
 }

--- a/packages/vx-zoom/test/enzyme-setup.js
+++ b/packages/vx-zoom/test/enzyme-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });


### PR DESCRIPTION
updated dev deps:
- use react 16
- enzyme 3
- enzyme-adapter-react-16
- react-test-renderer
- jest 21

updated travis test script. node 6 passes fine locally for me but was timing out during dep install on travis. node 8 tests run faster with npm 5 so builds went from ~22min => ~11min