### PR TITLE
[axis] less restrictive tickValue propTypes

### DIFF
--- a/packages/vx-axis/src/axis/Axis.js
+++ b/packages/vx-axis/src/axis/Axis.js
@@ -38,7 +38,7 @@ const propTypes = {
   tickLength: PropTypes.number,
   tickStroke: PropTypes.string,
   tickTransform: PropTypes.string,
-  tickValues: PropTypes.arrayOf(PropTypes.number),
+  tickValues: PropTypes.array,
   top: PropTypes.number,
   children: PropTypes.func,
 };

--- a/packages/vx-axis/src/axis/AxisBottom.js
+++ b/packages/vx-axis/src/axis/AxisBottom.js
@@ -27,7 +27,7 @@ const propTypes = {
   tickLength: PropTypes.number,
   tickStroke: PropTypes.string,
   tickTransform: PropTypes.string,
-  tickValues: PropTypes.arrayOf(PropTypes.number),
+  tickValues: PropTypes.array,
   top: PropTypes.number,
   children: PropTypes.func,
 };

--- a/packages/vx-axis/src/axis/AxisLeft.js
+++ b/packages/vx-axis/src/axis/AxisLeft.js
@@ -27,7 +27,7 @@ const propTypes = {
   tickLength: PropTypes.number,
   tickStroke: PropTypes.string,
   tickTransform: PropTypes.string,
-  tickValues: PropTypes.arrayOf(PropTypes.number),
+  tickValues: PropTypes.array,
   top: PropTypes.number,
   children: PropTypes.func,
 };

--- a/packages/vx-axis/src/axis/AxisRight.js
+++ b/packages/vx-axis/src/axis/AxisRight.js
@@ -27,7 +27,7 @@ const propTypes = {
   tickLength: PropTypes.number,
   tickStroke: PropTypes.string,
   tickTransform: PropTypes.string,
-  tickValues: PropTypes.arrayOf(PropTypes.number),
+  tickValues: PropTypes.array,
   top: PropTypes.number,
   children: PropTypes.func,
 };

--- a/packages/vx-axis/src/axis/AxisTop.js
+++ b/packages/vx-axis/src/axis/AxisTop.js
@@ -27,7 +27,7 @@ const propTypes = {
   tickLength: PropTypes.number,
   tickStroke: PropTypes.string,
   tickTransform: PropTypes.string,
-  tickValues: PropTypes.arrayOf(PropTypes.number),
+  tickValues: PropTypes.array,
   top: PropTypes.number,
   children: PropTypes.func,
 };


### PR DESCRIPTION
#### :bug: Bug Fix
not realllly a bug, but along those lines this PR makes all `<Axis* />` component `tickValues` `propTypes` less restrictive. currently if you were to specify an array of dates for a timeline axis you would get console warnings.


