### PR TITLE
[tooltip] add offset props to <TooltipWithBounds />

### DIFF
--- a/packages/vx-bounds/src/enhancers/withBoundingRects.js
+++ b/packages/vx-bounds/src/enhancers/withBoundingRects.js
@@ -40,7 +40,7 @@ export default function withBoundingRects(BaseComponent) {
 
     componentDidMount() {
       this.node = ReactDOM.findDOMNode(this);
-      this.setState(this.getRects());
+      this.setState(() => this.getRects());
     }
 
     getRects() {

--- a/packages/vx-tooltip/src/tooltips/TooltipWithBounds.js
+++ b/packages/vx-tooltip/src/tooltips/TooltipWithBounds.js
@@ -8,6 +8,8 @@ import Tooltip from './Tooltip';
 const propTypes = {
   ...withBoundingRectsProps,
   ...Tooltip.propTypes,
+  offsetLeft: PropTypes.number,
+  offsetTop: PropTypes.number,
 };
 
 const defaultProps = {};
@@ -15,6 +17,8 @@ const defaultProps = {};
 function TooltipWithBounds({
   left: initialLeft,
   top: initialTop,
+  offsetLeft = 10,
+  offsetTop = 10,
   rect,
   parentRect,
   children,
@@ -24,8 +28,11 @@ function TooltipWithBounds({
   let top = initialTop;
 
   if (rect && parentRect) {
-    left = rect.right > parentRect.right ? (left - rect.width) : left;
-    top = rect.bottom > parentRect.bottom ? (top - rect.height) : top;
+    left = (offsetLeft + rect.right) > parentRect.right
+      ? (left - rect.width - offsetLeft) : left + offsetLeft;
+
+    top = (offsetTop + rect.bottom) > parentRect.bottom
+      ? (top - rect.height - offsetTop) : top + offsetTop;
   }
 
   return (


### PR DESCRIPTION
#### :rocket: Enhancements
The goal of this PR is to fix issues like this where the tooltip overlaps the point:
<img width="120" src="https://user-images.githubusercontent.com/4496521/32583355-08931436-c4a8-11e7-9037-cacbbc05277a.png" />

To do so I added optional `leftOffset` and `topOffset` props to the `<TooltipWithBounds />` which offset the final `left` and `top` positions depending on the `boundingClientRect`s it receives from `withBoundingRects`:

- if the tooltip will be *right* of the pointer, it it shifted `+leftOffset`
- if the tooltip will be *left* of the pointer, it it shifted `-leftOffset`
- if the tooltip will be *below* of the pointer, it it shifted `+topOffset`
- if the tooltip will be *above* of the pointer, it it shifted `-topOffset`

I also considered creating `computeLeft({ left, rect, parentRect })` and `computeTop({ top, rect, parentRect })` props that allow the user to fully override the calculation but decided this was a little simpler. 

Let me know if you have thoughts!

Tested functionally:
<img width="350" src="https://user-images.githubusercontent.com/4496521/32583542-eb80f970-c4a8-11e7-841e-29f1d9bc4b88.gif" />
