### PR TITLE
[build] add travis_wait to install script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,7 @@ node_js:
 cache:
   directories:
     - node_modules
+install:
+  - "npm install"
+  - "travis_wait npm run install"
 after_script: "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "description": "Low-level visualization components",
   "main": "index.js",
   "scripts": {
-    "test": "lerna clean --yes && lerna bootstrap && lerna exec npm run test",
     "docs": "node ./scripts/docs/index.js",
+    "install": "lerna clean --yes && lerna bootstrap",
     "prepare-release": "git checkout master && git pull --rebase origin master && npm run docs && lerna updated",
-    "release": "npm run prepare-release && lerna publish --exact"
+    "release": "npm run prepare-release && lerna publish --exact",
+    "test": "lerna exec npm run test"
   },
   "jest": {
     "projects": [


### PR DESCRIPTION
#### :house: Internal

Looks like travis terminates due to no output on a couple open PRs, so (based on [these docs](https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received)) I added a `travis_wait` in this PR to see if it fixes it 🤞 
