### PR TITLE
Fix styled text wrapping

### DIFF
--- a/packages/vx-demo/pages/text.js
+++ b/packages/vx-demo/pages/text.js
@@ -16,6 +16,7 @@ class TextDemo extends Component {
     verticalAnchor: 'start',
     fontSize: '1em',
     fontFamily: 'Arial',
+    fontWeight: 400,
     lineHeight: '1em',
     showAnchor: true,
     resizeSvg: true,
@@ -59,6 +60,7 @@ class TextDemo extends Component {
                 style={{
                   fontSize: this.state.fontSize,
                   fontFamily: this.state.fontFamily,
+                  fontWeight: this.state.fontWeight,
                 }}
               >
                 {this.state.exampleText}
@@ -235,6 +237,17 @@ class TextDemo extends Component {
                 value={this.state.fontFamily}
                 onChange={e =>
                   this.setState({ fontFamily: e.target.value })
+                }
+              />
+            </div>
+            
+            <div>
+              fontWeight:
+              <input
+                type="text"
+                value={this.state.fontWeight}
+                onChange={e =>
+                  this.setState({ fontWeight: e.target.value })
                 }
               />
             </div>

--- a/packages/vx-text/src/util/getStringWidth.js
+++ b/packages/vx-text/src/util/getStringWidth.js
@@ -22,4 +22,4 @@ function getStringWidth(str, style) {
   }
 }
 
-export default memoize(getStringWidth);
+export default memoize(getStringWidth, (str, style) => `${str}_${JSON.stringify(style)}`);


### PR DESCRIPTION
#### :rocket: Enhancements

- Add `fontWeight` option to vx-text demo

#### :bug: Bug Fix

- Fix memoized `getStringWidth` ignoring styles 

---

## Before
![image](https://user-images.githubusercontent.com/177476/34021234-a59a6cd2-e106-11e7-9ca9-972b018f8f1e.png)

## After
![image](https://user-images.githubusercontent.com/177476/34021254-ba4654ca-e106-11e7-908b-16abc2e38d08.png)
