### PR TITLE
[internal] fix travis builds, vx text test, bump axis prop-types dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ node_js:
 cache:
   directories:
     - node_modules
+script: travis_wait npm test
 after_script: "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ node_js:
 cache:
   directories:
     - node_modules
-script: travis_wait npm test
+script: travis_wait 30 npm test
 after_script: "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test":
-      "lerna bootstrap && lerna exec npm run build && lerna exec npm run test",
+      "lerna bootstrap && lerna exec npm run test && lerna exec npm run test",
     "docs": "node ./scripts/docs/index.js",
     "prepare-release":
       "git checkout master && git pull --rebase origin master && npm run docs && lerna updated",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Low-level visualization components",
   "main": "index.js",
   "scripts": {
-    "test": "lerna bootstrap && lerna exec npm run test",
+    "test":
+      "lerna bootstrap && lerna exec npm run build && lerna exec npm run test",
     "docs": "node ./scripts/docs/index.js",
     "prepare-release":
       "git checkout master && git pull --rebase origin master && npm run docs && lerna updated",

--- a/package.json
+++ b/package.json
@@ -4,32 +4,20 @@
   "description": "Low-level visualization components",
   "main": "index.js",
   "scripts": {
-    "test": "lerna clean --yes && lerna bootstrap && lerna exec npm run test",
+    "test": "lerna bootstrap && lerna exec npm run test",
     "docs": "node ./scripts/docs/index.js",
-    "prepare-release": "git checkout master && git pull --rebase origin master && npm run docs && lerna updated",
+    "prepare-release":
+      "git checkout master && git pull --rebase origin master && npm run docs && lerna updated",
     "release": "npm run prepare-release && lerna publish --exact"
   },
   "jest": {
-    "projects": [
-      "<rootDir>/packages/*"
-    ],
+    "projects": ["<rootDir>/packages/*"],
     "collectCoverage": true,
     "coverageDirectory": "<rootDir>/coverage",
-    "coveragePathIgnorePatterns": [
-      "/node_modules/"
-    ],
-    "coverageReporters": [
-      "text",
-      "lcov"
-    ]
+    "coveragePathIgnorePatterns": ["/node_modules/"],
+    "coverageReporters": ["text", "lcov"]
   },
-  "keywords": [
-    "react",
-    "d3",
-    "visualization",
-    "vx",
-    "charts"
-  ],
+  "keywords": ["react", "d3", "visualization", "vx", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Low-level visualization components",
   "main": "index.js",
   "scripts": {
-    "test":
-      "lerna bootstrap && lerna exec npm run test && lerna exec npm run test",
+    "test": "lerna bootstrap && lerna exec npm run test",
     "docs": "node ./scripts/docs/index.js",
     "prepare-release":
       "git checkout master && git pull --rebase origin master && npm run docs && lerna updated",

--- a/packages/vx-axis/package.json
+++ b/packages/vx-axis/package.json
@@ -8,20 +8,12 @@
     "prepublish": "make build SRC=./src",
     "test": "jest"
   },
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -33,7 +25,7 @@
     "@vx/point": "0.0.143",
     "@vx/shape": "0.0.147",
     "classnames": "^2.2.5",
-    "prop-types": "15.5.10"
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "babel-jest": "^21.2.0",
@@ -55,9 +47,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-vx/test/index.test.js
+++ b/packages/vx-vx/test/index.test.js
@@ -106,7 +106,7 @@ describe('vx', () => {
   });
 
   test('it should export @vx/text', () => {
-    expect(vx.TextOutline).toBeDefined();
+    expect(vx.Text).toBeDefined();
   });
 
   test('it should export @vx/tooltip', () => {


### PR DESCRIPTION
#### :house: Internal

- [travis] fix for travis failing for timing out when [not receiving output for 10min](https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received)
- [vx][test] fix `@vx/vx` text test. It was looking for `TextOutline` export which was removed with the [new `@vx/text`](https://github.com/hshoff/vx/pull/208)
- [axis] bump `prop-types` dep and use `^`
