### PR TITLE
[drag][demo] remove <Drag /> svg prop, update drag demos

### DIFF
--- a/packages/vx-demo/components/gallery.js
+++ b/packages/vx-demo/components/gallery.js
@@ -891,8 +891,8 @@ export default class Gallery extends React.Component {
                   <ParentSize>
                     {({ width, height }) => (
                       <DragI
-                        width={543}
-                        height={390}
+                        width={width}
+                        height={height}
                         events={false}
                       />
                     )}
@@ -926,8 +926,8 @@ export default class Gallery extends React.Component {
                   <ParentSize>
                     {({ width, height }) => (
                       <DragII
-                        width={543}
-                        height={390}
+                        width={width}
+                        height={height}
                         events={false}
                         data={drawData}
                       />

--- a/packages/vx-demo/components/tiles/drag-i.js
+++ b/packages/vx-demo/components/tiles/drag-i.js
@@ -9,7 +9,7 @@ const colors = [
   '#02efff',
   '#03aeed',
   '#0384d7',
-  `#edfdff`,
+  '#edfdff',
   '#ab31ff',
   '#5924d7',
   '#d145ff',
@@ -34,15 +34,18 @@ function genCircles({ num, width, height }) {
     });
 }
 
+const genItems = ({ width, height }) =>
+  genCircles({
+    num: width < 360 ? 40 : 185,
+    width,
+    height,
+  });
+
 export default class DragI extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      items: genCircles({
-        num: 185,
-        width: props.width,
-        height: props.height,
-      }),
+      items: genItems({ ...props }),
     };
     this.colorScale = scaleOrdinal({
       range: colors,
@@ -50,15 +53,23 @@ export default class DragI extends React.Component {
     });
   }
 
-  componentDidMount() {
-    this.forceUpdate();
+  componentWillReceiveProps(nextProps) {
+    const { width, height } = nextProps;
+    if (width !== this.props.width) {
+      this.setState(() => {
+        return {
+          items: genItems({ ...nextProps }),
+        };
+      });
+    }
   }
 
   render() {
     const { width, height } = this.props;
+    if (width < 10) return null;
     return (
-      <div className="Drag">
-        <svg width={width} height={height} ref={s => (this.svg = s)}>
+      <div className="Drag" style={{ touchAction: 'none' }}>
+        <svg width={width} height={height}>
           <LinearGradient id="stroke" from="#ff00a5" to="#ffc500" />
           <rect
             fill="#c4c3cb"
@@ -69,7 +80,6 @@ export default class DragI extends React.Component {
           {this.state.items.map((d, i) => (
             <Drag
               key={`${d.id}`}
-              svg={this.svg}
               width={width}
               height={height}
               onDragStart={() => {

--- a/packages/vx-demo/components/tiles/drag-ii.js
+++ b/packages/vx-demo/components/tiles/drag-ii.js
@@ -12,14 +12,13 @@ export default class DragII extends React.Component {
       data: props.data || [],
     };
   }
-  componentDidMount() {
-    this.forceUpdate();
-  }
+
   render() {
     const { width, height } = this.props;
+    if (width < 10) return null;
     return (
-      <div className="DragII">
-        <svg width={width} height={height} ref={s => (this.svg = s)}>
+      <div className="DragII" style={{ touchAction: 'none' }}>
+        <svg width={width} height={height}>
           <LinearGradient id="stroke" from="#ff614e" to="#ffdc64" />
           <rect
             fill="#04002b"
@@ -43,7 +42,6 @@ export default class DragII extends React.Component {
             );
           })}
           <Drag
-            svg={this.svg}
             width={width}
             height={height}
             resetOnStart={true}
@@ -108,6 +106,9 @@ export default class DragII extends React.Component {
                     onMouseDown={dragStart}
                     onMouseUp={dragEnd}
                     onMouseMove={dragMove}
+                    onTouchStart={dragStart}
+                    onTouchEnd={dragEnd}
+                    onTouchMove={dragMove}
                   />
                 </g>
               );

--- a/packages/vx-demo/pages/drag-i.js
+++ b/packages/vx-demo/pages/drag-i.js
@@ -41,29 +41,42 @@ function genCircles({ num, width, height }) {
     });
 }
 
+const genItems = ({ width, height }) =>
+  genCircles({
+    num: width < 360 ? 40 : 185,
+    width,
+    height,
+  });
+
 export default class DragI extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      items: genCircles({
-        num: 185,
-        width: props.width,
-        height: props.height,
-      }),
+      items: genItems({ ...props }),
     };
     this.colorScale = scaleOrdinal({
       range: colors,
       domain: this.state.items.map(d => d.id),
     });
   }
-  componentDidMount() {
-    this.forceUpdate();
+
+  componentWillReceiveProps(nextProps) {
+    const { width, height } = nextProps;
+    if (width !== this.props.width) {
+      this.setState(() => {
+        return {
+          items: genItems({ ...nextProps }),
+        };
+      });
+    }
   }
+
   render() {
     const { width, height } = this.props;
+    if (width < 10) return null;
     return (
-      <div className="Drag">
-        <svg width={width} height={height} ref={s => (this.svg = s)}>
+      <div className="Drag" style={{ touchAction: 'none' }}>
+        <svg width={width} height={height}>
           <LinearGradient id="stroke" from="#ff00a5" to="#ffc500" />
           <rect
             fill="#c4c3cb"
@@ -74,7 +87,6 @@ export default class DragI extends React.Component {
           {this.state.items.map((d, i) => (
             <Drag
               key={\`\${d.id}\`}
-              svg={this.svg}
               width={width}
               height={height}
               onDragStart={() => {
@@ -103,28 +115,40 @@ export default class DragI extends React.Component {
                     cx={d.x}
                     cy={d.y}
                     r={isDragging ? d.radius + 4 : d.radius}
-                    transform={\`translate(\${dx}, \${dy})\`}
-                    onMouseMove={dragMove}
-                    onMouseUp={dragEnd}
-                    onMouseDown={dragStart}
-                    stroke={isDragging ? 'white' : 'transparent'}
-                    strokeWidth={2}
-                    fillOpacity={0.9}
                     fill={
                       isDragging
                         ? 'url(#stroke)'
                         : this.colorScale(d.id)
                     }
+                    transform={\`translate(\${dx}, \${dy})\`}
+                    fillOpacity={0.9}
+                    stroke={isDragging ? 'white' : 'transparent'}
+                    strokeWidth={2}
+                    onMouseMove={dragMove}
+                    onMouseUp={dragEnd}
+                    onMouseDown={dragStart}
+                    onTouchStart={dragStart}
+                    onTouchMove={dragMove}
+                    onTouchEnd={dragEnd}
                   />
                 );
               }}
             </Drag>
           ))}
         </svg>
+        <div className="deets">
+          <div>
+            Based on Mike Bostock's{' '}
+            <a href="https://bl.ocks.org/mbostock/c206c20294258c18832ff80d8fd395c3">
+              Circle Dragging II
+            </a>
+          </div>
+        </div>
       </div>
     );
   }
-}`}
+}
+`}
     </Show>
   );
 };

--- a/packages/vx-demo/pages/drag-ii.js
+++ b/packages/vx-demo/pages/drag-ii.js
@@ -16,17 +16,16 @@ export default class DragII extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      data: [],
+      data: props.data || [],
     };
   }
-  componentDidMount() {
-    this.forceUpdate();
-  }
+
   render() {
     const { width, height } = this.props;
+    if (width < 10) return null;
     return (
-      <div className="DragII">
-        <svg width={width} height={height} ref={s => (this.svg = s)}>
+      <div className="DragII" style={{ touchAction: 'none' }}>
+        <svg width={width} height={height}>
           <LinearGradient id="stroke" from="#ff614e" to="#ffdc64" />
           <rect
             fill="#04002b"
@@ -50,7 +49,6 @@ export default class DragII extends React.Component {
             );
           })}
           <Drag
-            svg={this.svg}
             width={width}
             height={height}
             resetOnStart={true}
@@ -115,6 +113,9 @@ export default class DragII extends React.Component {
                     onMouseDown={dragStart}
                     onMouseUp={dragEnd}
                     onMouseMove={dragMove}
+                    onTouchStart={dragStart}
+                    onTouchEnd={dragEnd}
+                    onTouchMove={dragMove}
                   />
                 </g>
               );

--- a/packages/vx-drag/src/Drag.js
+++ b/packages/vx-drag/src/Drag.js
@@ -7,7 +7,6 @@ export default class Drag extends React.Component {
     children: PropTypes.func.isRequired,
     width: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,
-    svg: PropTypes.element,
     captureDragArea: PropTypes.bool,
     resetOnStart: PropTypes.bool,
   };
@@ -32,9 +31,9 @@ export default class Drag extends React.Component {
   }
 
   dragStart(event) {
-    const { svg, onDragStart, resetOnStart } = this.props;
+    const { onDragStart, resetOnStart } = this.props;
     const { dx, dy } = this.state;
-    const point = localPoint(svg, event);
+    const point = localPoint(event);
     const nextState = {
       ...this.state,
       isDragging: true,
@@ -48,10 +47,10 @@ export default class Drag extends React.Component {
   }
 
   dragMove(event) {
-    const { svg, onDragMove } = this.props;
+    const { onDragMove } = this.props;
     const { x, y, isDragging } = this.state;
     if (!isDragging) return;
-    const point = localPoint(svg, event);
+    const point = localPoint(event);
     const nextState = {
       ...this.state,
       isDragging: true,
@@ -63,8 +62,8 @@ export default class Drag extends React.Component {
   }
 
   dragEnd(event) {
-    const { svg, onDragEnd } = this.props;
-    const point = localPoint(svg, event);
+    const { onDragEnd } = this.props;
+    const point = localPoint(event);
     const nextState = {
       ...this.state,
       isDragging: false,


### PR DESCRIPTION
#### :rocket: Enhancements

- [drag] remove `svg` prop. This was causing hacky problems like calling `forceUpdate` in `cDM`. `localPoint()` now finds svg from the event argument.

#### :memo: Documentation

- [demo] update drag demos, add `touch-action: none` on drag demos so no scrolling when dragging
