### PR TITLE
Link path improvements

### DIFF
--- a/packages/vx-demo/components/tiles/linkTypes.js
+++ b/packages/vx-demo/components/tiles/linkTypes.js
@@ -189,7 +189,7 @@ export default class extends React.Component {
                   return (
                     <LinkComponent
                       data={link}
-                      percent={stepPercent}
+                      percent={+stepPercent}
                       stroke="#374469"
                       strokeWidth="1"
                       fill="none"

--- a/packages/vx-shape/package.json
+++ b/packages/vx-shape/package.json
@@ -27,6 +27,7 @@
     "@vx/group": "0.0.153",
     "@vx/point": "0.0.153",
     "classnames": "^2.2.5",
+    "d3-path": "^1.0.5",
     "d3-shape": "^1.2.0",
     "prop-types": "^15.5.10"
   },

--- a/packages/vx-shape/src/shapes/link/curve/LinkHorizontalCurve.js
+++ b/packages/vx-shape/src/shapes/link/curve/LinkHorizontalCurve.js
@@ -2,6 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import { pointRadial } from 'd3-shape';
+import { path as d3Path } from 'd3-path';
 import additionalProps from '../../../util/additionalProps';
 
 LinkHorizontalCurve.propTypes = {
@@ -14,32 +15,37 @@ export default function LinkHorizontalCurve({
   data,
   x = d => d.y,
   y = d => d.x,
+  source = d => d.source,
+  target = d => d.target,
   ...restProps
 }) {
 
-  const curve = (source, target) => {
-    const sx = x(source);
-    const sy = y(source);
-    const tx = x(target);
-    const ty = y(target);
+  const link = (data) => {
+    const sourceData = source(data);
+    const targetData = target(data);
+
+    const sx = x(sourceData);
+    const sy = y(sourceData);
+    const tx = x(targetData);
+    const ty = y(targetData);
 
     const dx = tx - sx;
     const dy = ty - sy;
     const ix = 0.2 * (dx + dy);
     const iy = 0.2 * (dy - dx);
 
-    return `M${sx},${sy}
-      C${sx + ix},${sy + iy}
-      ${tx + iy},${ty - ix}
-      ${tx},${ty}
-    `;
+    const path =  d3Path();
+    path.moveTo(sx, sy)
+    path.bezierCurveTo(sx + ix, sy + iy, tx + iy, ty - ix, tx, ty)
+
+    return path.toString();
   };
 
   return (
     <path
       ref={innerRef}
       className={cx('vx-link', className)}
-      d={curve(data.source, data.target)}
+      d={link(data)}
       {...restProps}
     />
   );

--- a/packages/vx-shape/src/shapes/link/curve/LinkRadialCurve.js
+++ b/packages/vx-shape/src/shapes/link/curve/LinkRadialCurve.js
@@ -2,6 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import { pointRadial } from 'd3-shape';
+import { path as d3Path } from 'd3-path';
 import additionalProps from '../../../util/additionalProps';
 
 LinkRadialCurve.propTypes = {
@@ -14,14 +15,19 @@ export default function LinkRadialCurve({
   data,
   x = d => d.x,
   y = d => d.y,
+  source = d => d.source,
+  target = d => d.target,
   ...restProps
 }) {
 
-  const curve = (source, target) => {
-    const sa = x(source) - Math.PI / 2;
-    const sr = y(source);
-    const ta = x(target) - Math.PI / 2;
-    const tr = y(target);
+  const link = (data) => {
+    const sourceData = source(data);
+    const targetData = target(data);
+
+    const sa = x(sourceData) - Math.PI / 2;
+    const sr = y(sourceData);
+    const ta = x(targetData) - Math.PI / 2;
+    const tr = y(targetData);
 
     const sc = Math.cos(sa);
     const ss = Math.sin(sa);
@@ -38,18 +44,18 @@ export default function LinkRadialCurve({
     const ix = 0.2 * (dx + dy);
     const iy = 0.2 * (dy - dx);
 
-    return `M${sx},${sy}
-      C${sx + ix},${sy + iy}
-      ${tx + iy},${ty - ix}
-      ${tx},${ty}
-    `;
+    const path =  d3Path();
+    path.moveTo(sx, sy)
+    path.bezierCurveTo(sx + ix, sy + iy, tx + iy, ty - ix, tx, ty)
+
+    return path.toString();
   };
 
   return (
     <path
       ref={innerRef}
       className={cx('vx-link', className)}
-      d={curve(data.source, data.target)}
+      d={link(data)}
       {...restProps}
     />
   );

--- a/packages/vx-shape/src/shapes/link/curve/LinkVerticalCurve.js
+++ b/packages/vx-shape/src/shapes/link/curve/LinkVerticalCurve.js
@@ -2,6 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import { pointRadial } from 'd3-shape';
+import { path as d3Path } from 'd3-path';
 import additionalProps from '../../../util/additionalProps';
 
 LinkVerticalCurve.propTypes = {
@@ -14,32 +15,37 @@ export default function LinkVerticalCurve({
   data,
   x = d => d.x,
   y = d => d.y,
+  source = d => d.source,
+  target = d => d.target,
   ...restProps
 }) {
 
-  const curve = (source, target) => {
-    const sx = x(source);
-    const sy = y(source);
-    const tx = x(target);
-    const ty = y(target);
+  const link = (data) => {
+    const sourceData = source(data);
+    const targetData = target(data);
+
+    const sx = x(sourceData);
+    const sy = y(sourceData);
+    const tx = x(targetData);
+    const ty = y(targetData);
 
     const dx = tx - sx;
     const dy = ty - sy;
     const ix = 0.2 * (dx + dy);
     const iy = 0.2 * (dy - dx);
 
-    return `M${sx},${sy}
-      C${sx + ix},${sy + iy}
-      ${tx + iy},${ty - ix}
-      ${tx},${ty}
-    `;    
+    const path =  d3Path();
+    path.moveTo(sx, sy)
+    path.bezierCurveTo(sx + ix, sy + iy, tx + iy, ty - ix, tx, ty)
+
+    return path.toString();
   };
 
   return (
     <path
       ref={innerRef}
       className={cx('vx-link', className)}
-      d={curve(data.source, data.target)}
+      d={link(data)}
       {...restProps}
     />
   );

--- a/packages/vx-shape/src/shapes/link/diagonal/LinkHorizontal.js
+++ b/packages/vx-shape/src/shapes/link/diagonal/LinkHorizontal.js
@@ -14,11 +14,16 @@ export default function LinkHorizontal({
   data,
   x = d => d.y,
   y = d => d.x,
+  source = d => d.source,
+  target = d => d.target,
   ...restProps
 }) {
   const link = linkHorizontal();
   link.x(x);
   link.y(y);
+  link.source(source);
+  link.target(target);
+
   return (
     <path
       ref={innerRef}

--- a/packages/vx-shape/src/shapes/link/diagonal/LinkRadial.js
+++ b/packages/vx-shape/src/shapes/link/diagonal/LinkRadial.js
@@ -14,11 +14,16 @@ export default function LinkRadial({
   data,
   angle = d => d.x,
   radius = d => d.y,
+  source = d => d.source,
+  target = d => d.target, 
   ...restProps
 }) {
   const link = linkRadial()
   link.angle(angle);
   link.radius(radius);
+  link.source(source);
+  link.target(target);
+
   return (
     <path
       ref={innerRef}

--- a/packages/vx-shape/src/shapes/link/diagonal/LinkVertical.js
+++ b/packages/vx-shape/src/shapes/link/diagonal/LinkVertical.js
@@ -14,11 +14,16 @@ export default function LinkVertical({
   data,
   x = d => d.x,
   y = d => d.y,
+  source = d => d.source,
+  target = d => d.target,
   ...restProps
 }) {
   const link = linkVertical();
   link.x(x);
   link.y(y);
+  link.source(source);
+  link.target(target);
+
   return (
     <path
       ref={innerRef}

--- a/packages/vx-shape/src/shapes/link/line/LinkHorizontalLine.js
+++ b/packages/vx-shape/src/shapes/link/line/LinkHorizontalLine.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
+import { path as d3Path } from 'd3-path';
 import additionalProps from '../../../util/additionalProps';
 
 LinkHorizontalLine.propTypes = {
@@ -13,18 +14,31 @@ export default function LinkHorizontalLine({
   data,
   x = d => d.y,
   y = d => d.x,
+  source = d => d.source,
+  target = d => d.target,
   ...restProps
 }) {
-  const line = (source, target) => `
-    M${x(source)},${y(source)}
-    L${x(target)},${y(target)}
-  `;
+  const link = (data) => {
+    const sourceData = source(data);
+    const targetData = target(data);
+
+    const sx = x(sourceData);
+    const sy = y(sourceData);
+    const tx = x(targetData);
+    const ty = y(targetData);
+
+    const path =  d3Path();
+    path.moveTo(sx, sy)
+    path.lineTo(tx, ty)
+
+    return path.toString();
+  };
 
   return (
     <path
       ref={innerRef}
       className={cx('vx-link', className)}
-      d={line(data.source, data.target)}
+      d={link(data)}
       {...restProps}
     />
   );

--- a/packages/vx-shape/src/shapes/link/line/LinkRadialLine.js
+++ b/packages/vx-shape/src/shapes/link/line/LinkRadialLine.js
@@ -2,6 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import { pointRadial } from 'd3-shape';
+import { path as d3Path } from 'd3-path';
 import additionalProps from '../../../util/additionalProps';
 
 LinkRadialStep.propTypes = {
@@ -14,31 +15,37 @@ export default function LinkRadialStep({
   data,
   x = d => d.x,
   y = d => d.y,
+  source = d => d.source,
+  target = d => d.target,
   ...restProps
 }) {
 
-  const line = (source, target) => {
-    const sa = x(source) - Math.PI / 2;
-    const sr = y(source);
-    const ta = x(target) - Math.PI / 2;
-    const tr = y(target);
+  const link = (data) => {
+    const sourceData = source(data);
+    const targetData = target(data);
+
+    const sa = x(sourceData) - Math.PI / 2;
+    const sr = y(sourceData);
+    const ta = x(targetData) - Math.PI / 2;
+    const tr = y(targetData);
 
     const sc = Math.cos(sa);
     const ss = Math.sin(sa);
     const tc = Math.cos(ta);
     const ts = Math.sin(ta);
 
-    return `
-      M${sr * sc},${sr * ss}
-      L${tr * tc},${tr * ts}
-    `;
+    const path =  d3Path();
+    path.moveTo(sr * sc, sr * ss)
+    path.lineTo(tr * tc, tr * ts)
+
+    return path.toString();
   };
 
   return (
     <path
       ref={innerRef}
       className={cx('vx-link', className)}
-      d={line(data.source, data.target)}
+      d={link(data)}
       {...restProps}
     />
   );

--- a/packages/vx-shape/src/shapes/link/line/LinkVerticalLine.js
+++ b/packages/vx-shape/src/shapes/link/line/LinkVerticalLine.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
+import { path as d3Path } from 'd3-path';
 import additionalProps from '../../../util/additionalProps';
 
 LinkVerticalLine.propTypes = {
@@ -13,18 +14,31 @@ export default function LinkVerticalLine({
   data,
   x = d => d.x,
   y = d => d.y,
+  source = d => d.source,
+  target = d => d.target,
   ...restProps
 }) {
-  const line = (source, target) => `
-    M${x(source)},${y(source)}
-    L${x(target)},${y(target)}
-  `;
+  const link = (data) => {
+    const sourceData = source(data);
+    const targetData = target(data);
+
+    const sx = x(sourceData);
+    const sy = y(sourceData);
+    const tx = x(targetData);
+    const ty = y(targetData);
+
+    const path =  d3Path();
+    path.moveTo(sx, sy)
+    path.lineTo(tx, ty)
+
+    return path.toString();
+  };
 
   return (
     <path
       ref={innerRef}
       className={cx('vx-link', className)}
-      d={line(data.source, data.target)}
+      d={link(data)}
       {...restProps}
     />
   );

--- a/packages/vx-shape/src/shapes/link/step/LinkHorizontalStep.js
+++ b/packages/vx-shape/src/shapes/link/step/LinkHorizontalStep.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
+import { path as d3Path } from 'd3-path';
 import additionalProps from '../../../util/additionalProps';
 
 LinkHorizontalStep.propTypes = {
@@ -15,20 +16,33 @@ export default function LinkHorizontalStep({
   percent = 0.5,
   x = d => d.y,
   y = d => d.x,
+  source = d => d.source,
+  target = d => d.target,
   ...restProps
 }) {
-  const line = (source, target) => `
-    M${x(source)},${y(source)}
-    H${x(source) + (x(target) - x(source)) * percent}
-    V${y(target)}
-    H${x(target)}
-  `;
+  const link = (data) => {
+    const sourceData = source(data);
+    const targetData = target(data);
+
+    const sx = x(sourceData);
+    const sy = y(sourceData);
+    const tx = x(targetData);
+    const ty = y(targetData);
+
+    const path =  d3Path();
+    path.moveTo(sx, sy)
+    path.lineTo(sx + (tx - sx) * percent, sy)
+    path.lineTo(sx + (tx - sx) * percent, ty)
+    path.lineTo(tx, ty)
+
+    return path.toString();
+  };
 
   return (
     <path
       ref={innerRef}
       className={cx('vx-link', className)}
-      d={line(data.source, data.target)}
+      d={link(data)}
       {...restProps}
     />
   );

--- a/packages/vx-shape/src/shapes/link/step/LinkRadialStep.js
+++ b/packages/vx-shape/src/shapes/link/step/LinkRadialStep.js
@@ -2,6 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import { pointRadial } from 'd3-shape';
+import { path as d3Path } from 'd3-path';
 import additionalProps from '../../../util/additionalProps';
 
 LinkRadialStep.propTypes = {
@@ -14,36 +15,51 @@ export default function LinkRadialStep({
   data,
   x = d => d.x,
   y = d => d.y,
+  source = d => d.source,
+  target = d => d.target,
   ...restProps
 }) {
   
-  const step = (source, target) => {
-    const sa = x(source) - Math.PI / 2;
-    const sr = y(source);
-    const ta = x(target) - Math.PI / 2;
-    const tr = y(target);
+  const link = (data) => {
+    const sourceData = source(data);
+    const targetData = target(data);
+
+    const sx = x(sourceData);
+    const sy = y(sourceData);
+    const tx = x(targetData);
+    const ty = y(targetData);
+
+    const sa = sx - Math.PI / 2;
+    const sr = sy;
+    const ta = tx - Math.PI / 2;
+    const tr = ty;
 
     const sc = Math.cos(sa);
     const ss = Math.sin(sa);
     const tc = Math.cos(ta);
     const ts = Math.sin(ta);
     const sf = Math.abs(ta - sa) > Math.PI ? ta <= sa : ta > sa;
-    
+
     return `
       M${sr * sc},${sr * ss}
-      A${sr},${sr} 0 0,${sf ? 1 : 0}
-      ${sr * tc},${sr * ts}
+      A${sr},${sr},0,0,${sf ? 1 : 0},${sr * tc},${sr * ts}
       L${tr * tc},${tr * ts}
     `;
-  };
 
-  const line = step;
+    // TODO: Port to d3-path
+    // const path =  d3Path();
+    // path.moveTo(sr * sc, sr * ss)
+    // path.arcTo(/* TODO */);
+    // path.lineTo(tr * tc, tr * ts)
+
+    // return path.toString();
+  };
 
   return (
     <path
       ref={innerRef}
       className={cx('vx-link', className)}
-      d={line(data.source, data.target)}
+      d={link(data)}
       {...restProps}
     />
   );

--- a/packages/vx-shape/src/shapes/link/step/LinkVerticalStep.js
+++ b/packages/vx-shape/src/shapes/link/step/LinkVerticalStep.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
+import { path as d3Path } from 'd3-path';
 import additionalProps from '../../../util/additionalProps';
 
 LinkVerticalStep.propTypes = {
@@ -15,20 +16,33 @@ export default function LinkVerticalStep({
   percent = 0.5,
   x = d => d.x,
   y = d => d.y,
+  source = d => d.source,
+  target = d => d.target,
   ...restProps
 }) {
-  const line = (source, target) => `
-    M${x(source)},${y(source)}
-    V${y(source) + (y(target) - y(source)) * percent}
-    H${x(target)}
-    V${y(target)}
-  `;
+  const link = (data) => {
+    const sourceData = source(data);
+    const targetData = target(data);
+
+    const sx = x(sourceData);
+    const sy = y(sourceData);
+    const tx = x(targetData);
+    const ty = y(targetData);
+
+    const path =  d3Path();
+    path.moveTo(sx, sy)
+    path.lineTo(sx, sy + (ty - sy) * percent)
+    path.lineTo(tx, sy + (ty - sy) * percent)
+    path.lineTo(tx, ty)
+
+    return path.toString();
+  };
 
   return (
     <path
       ref={innerRef}
       className={cx('vx-link', className)}
-      d={line(data.source, data.target)}
+      d={link(data)}
       {...restProps}
     />
   );


### PR DESCRIPTION
#### :rocket: Enhancements

- Export `source` and `target` props on all `<Link*>` components

#### :house: Internal

- Switch all (except `<LinkRadialStep>`) to use [d3-path](https://github.com/d3/d3-path) instead of svg path data to possibly support `<canvas>` in the future
