### PR TITLE
Added debounceTime prop to ParentSize

### DIFF
--- a/packages/vx-responsive/src/components/ParentSize.js
+++ b/packages/vx-responsive/src/components/ParentSize.js
@@ -2,11 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ResizeObserver from 'resize-observer-polyfill';
 
+import debounce from 'lodash/debounce';
+
 export default class ParentSize extends React.Component {
+  static defaultProps = {
+    debounceTime: 300,
+  };
+
   constructor(props) {
     super(props);
     this.state = { width: 0, height: 0, top: 0, left: 0 };
-    this.resize = this.resize.bind(this);
+    this.resize = debounce(this.resize.bind(this), props.debounceTime);
     this.setTarget = this.setTarget.bind(this);
   }
   componentDidMount() {
@@ -58,4 +64,5 @@ export default class ParentSize extends React.Component {
 ParentSize.propTypes = {
   className: PropTypes.string,
   children: PropTypes.func.isRequired,
+  debounceTime: PropTypes.number,
 };


### PR DESCRIPTION
Here is a proposed solution for #228 

Just adds debounceTime prop with a default of 300ms.

Note, resize-observer-polyfill waits on requestAnimationFrame between invocations. https://github.com/que-etc/resize-observer-polyfill/blob/a3ae98bcd34e972b92d9e40e8b974a75399503e8/dist/ResizeObserver.js#L214
