### PR TITLE
remove dependeny on resize-observer-polyfill in ParentSize

### DIFF
--- a/packages/vx-demo/components/tiles/responsive.js
+++ b/packages/vx-demo/components/tiles/responsive.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import { ParentSize } from '@vx/responsive';
 import Lines from './lines';
+import ResizeObserver from 'resize-observer-polyfill';
+
+if (!window.ResizeObserver) {
+  window.ResizeObserver = ResizeObserver;
+}
 
 function Nav() {
   return (

--- a/packages/vx-demo/package.json
+++ b/packages/vx-demo/package.json
@@ -66,6 +66,7 @@
     "react-motion": "^0.4.7",
     "react-tilt": "^0.1.3",
     "recompose": "^0.26.0",
+    "resize-observer-polyfill": "^1.5.0",
     "topojson-client": "^3.0.0"
   },
   "browserify": {

--- a/packages/vx-responsive/Readme.md
+++ b/packages/vx-responsive/Readme.md
@@ -54,6 +54,8 @@ let chartToRender = withParentSize(MySuperCoolVxChart);
 
 You might do the same thing using the `ParentSize` component.
 
+*Note: `ParentSize` uses [ResizeObserver](https://developers.google.com/web/updates/2016/10/resizeobserver) which is currently only supported in Chrome 64 and newer ([caniuse](https://caniuse.com/#feat=resizeobserver)). If you need support for other browsers you need a polyfill like `resize-observer-polyfill` which is only a `npm install -S resize-observer-polyfill` away.*
+
 ### Example:
 ``` js
 import { ParentSize } from "@vx/responsive";

--- a/packages/vx-responsive/package.json
+++ b/packages/vx-responsive/package.json
@@ -59,8 +59,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.10",
-    "prop-types": "^15.6.1",
-    "resize-observer-polyfill": "1.5.0"
+    "prop-types": "^15.6.1"
   },
   "peerDependencies": {
     "react": "^15.0.0-0 || ^16.0.0-0"

--- a/packages/vx-responsive/src/components/ParentSize.js
+++ b/packages/vx-responsive/src/components/ParentSize.js
@@ -1,7 +1,6 @@
 import debounce from 'lodash/debounce';
 import PropTypes from 'prop-types';
 import React from 'react';
-import ResizeObserver from 'resize-observer-polyfill';
 
 export default class ParentSize extends React.Component {
   constructor(props) {
@@ -12,6 +11,24 @@ export default class ParentSize extends React.Component {
     this.animationFrameID = null;
   }
   componentDidMount() {
+    if (!window.ResizeObserver) {
+      throw new ReferenceError(`ResizeObserver is not defined.
+
+ParentSize uses window.ResizeObserver to detect size changes of an element.
+If you see this message your browser doesn't support ResizeObserver.
+
+To solve this problem you can load the resize-observer-polyfill.
+Instruction on how to use it are here: 
+
+https://github.com/que-etc/resize-observer-polyfill
+
+More Information:
+
+Specification - https://wicg.github.io/ResizeObserver/
+Google WebFundamentals Article - https://developers.google.com/web/updates/2016/10/resizeobserver
+`)
+    }
+    
     this.ro = new ResizeObserver((entries, observer) => {
       for (const entry of entries) {
         const { left, top, width, height } = entry.contentRect;


### PR DESCRIPTION
## Motivation

To keep bundles slim and give the user of this library a little bit more control I suggest removing the dependency of `resize-observer-polyfill` from `ParentSize`.  
There is a lot of discussion if library authors should ship with polyfills included or not, that's why this is just a suggestion that would make my team at work switch even faster to vx 😄. I think it's fine to tell the user of the library to include a polyfill if needed to save bytes. I'm happy to discuss this!

#### :boom: Breaking Changes

- `ParentSize` doesn't use `resize-observer-polyfill` anymore.

#### :memo: Documentation

- Added a note in the `ParentSize` readme.

Thank you for this library btw. I'm currently convincing my team to switch to vx for our visualizations and it is great to use, whether or not this change happens.
