### PR TITLE
Correct README.md of `@vx/text` package

### DIFF
--- a/packages/vx-text/Readme.md
+++ b/packages/vx-text/Readme.md
@@ -16,7 +16,7 @@ Simple demo to show off a useful feature.  Since svg `<text>` itself does not su
 ```jsx
 import React from 'react';
 import { render } from 'react-dom';
-import Text from 'react-svg-text';
+import { Text } from '@vx/text';
 
 const App = () => (
   <svg>


### PR DESCRIPTION
#### :memo: Documentation

- Importing `Text` component from `@vx/text` was incorrect. (See Example
section)