### PR TITLE
add tickComponent prop and use @vx/text for axis ticks

### DIFF
--- a/packages/vx-axis/package.json
+++ b/packages/vx-axis/package.json
@@ -33,6 +33,7 @@
     "@vx/group": "0.0.153",
     "@vx/point": "0.0.153",
     "@vx/shape": "0.0.158",
+    "@vx/text": "0.0.153",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.0"
   },

--- a/packages/vx-axis/src/axis/Axis.js
+++ b/packages/vx-axis/src/axis/Axis.js
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import { Line } from '@vx/shape';
 import { Point } from '@vx/point';
 import { Group } from '@vx/group';
+import { Text } from '@vx/text';
 import center from '../utils/center';
 import identity from '../utils/identity';
 import getLabelTransform from '../utils/labelTransform';
@@ -39,6 +40,7 @@ const propTypes = {
   tickStroke: PropTypes.string,
   tickTransform: PropTypes.string,
   tickValues: PropTypes.array,
+  tickComponent: PropTypes.func,
   top: PropTypes.number,
   children: PropTypes.func,
 };
@@ -79,6 +81,7 @@ export default function Axis({
   tickStroke = 'black',
   tickTransform,
   tickValues,
+  tickComponent,
   top = 0,
 }) {
   let values = scale.ticks ? scale.ticks(numTicks) : scale.domain();
@@ -187,18 +190,25 @@ export default function Axis({
                 to={tickToPoint}
                 stroke={tickStroke}
               />
+              )}
+            {tickComponent ? tickComponent({
+              x: tickToPoint.x,
+              y: tickToPoint.y + (horizontal && !isTop ? tickLabelFontSize : 0),
+              formattedValue: format(val, index),
+              ...tickLabelPropsObj
+            }) : (
+              <Text
+                x={tickToPoint.x}
+                y={
+                  tickToPoint.y +
+                  (horizontal && !isTop ? tickLabelFontSize : 0)
+  
+                }
+                {...tickLabelPropsObj}
+              >
+                {format(val, index)}
+              </Text>
             )}
-            <text
-              x={tickToPoint.x}
-              y={
-                tickToPoint.y +
-                (horizontal && !isTop ? tickLabelFontSize : 0)
-
-              }
-              {...tickLabelPropsObj}
-            >
-              {format(val, index)}
-            </text>
           </Group>
         );
       })}
@@ -215,7 +225,7 @@ export default function Axis({
       )}
 
       {label && (
-        <text
+        <Text
           className={cx('vx-axis-label', labelClassName)}
           {...getLabelTransform({
             labelOffset,
@@ -228,7 +238,7 @@ export default function Axis({
           {...labelProps}
         >
           {label}
-        </text>
+        </Text>
       )}
     </Group>
   );

--- a/packages/vx-axis/src/axis/AxisBottom.js
+++ b/packages/vx-axis/src/axis/AxisBottom.js
@@ -28,6 +28,7 @@ const propTypes = {
   tickStroke: PropTypes.string,
   tickTransform: PropTypes.string,
   tickValues: PropTypes.array,
+  tickComponent: PropTypes.func,
   top: PropTypes.number,
   children: PropTypes.func,
 };
@@ -63,6 +64,7 @@ export default function AxisBottom({
   tickStroke,
   tickTransform,
   tickValues,
+  tickComponent,
   top,
 }) {
   return (
@@ -91,6 +93,7 @@ export default function AxisBottom({
       tickStroke={tickStroke}
       tickTransform={tickTransform}
       tickValues={tickValues}
+      tickComponent={tickComponent}
       top={top}
       children={children}
     />

--- a/packages/vx-axis/src/axis/AxisLeft.js
+++ b/packages/vx-axis/src/axis/AxisLeft.js
@@ -28,6 +28,7 @@ const propTypes = {
   tickStroke: PropTypes.string,
   tickTransform: PropTypes.string,
   tickValues: PropTypes.array,
+  tickComponent: PropTypes.func,
   top: PropTypes.number,
   children: PropTypes.func,
 };
@@ -64,6 +65,7 @@ export default function AxisLeft({
   tickStroke,
   tickTransform,
   tickValues,
+  tickComponent,
   top,
 }) {
   return (
@@ -92,6 +94,7 @@ export default function AxisLeft({
       tickStroke={tickStroke}
       tickTransform={tickTransform}
       tickValues={tickValues}
+      tickComponent={tickComponent}
       top={top}
       children={children}
     />

--- a/packages/vx-axis/src/axis/AxisRight.js
+++ b/packages/vx-axis/src/axis/AxisRight.js
@@ -28,6 +28,7 @@ const propTypes = {
   tickStroke: PropTypes.string,
   tickTransform: PropTypes.string,
   tickValues: PropTypes.array,
+  tickComponent: PropTypes.func,
   top: PropTypes.number,
   children: PropTypes.func,
 };
@@ -64,6 +65,7 @@ export default function AxisRight({
   tickStroke,
   tickTransform,
   tickValues,
+  tickComponent,
   top,
 }) {
   return (
@@ -92,6 +94,7 @@ export default function AxisRight({
       tickStroke={tickStroke}
       tickTransform={tickTransform}
       tickValues={tickValues}
+      tickComponent={tickComponent}
       top={top}
       children={children}
     />

--- a/packages/vx-axis/src/axis/AxisTop.js
+++ b/packages/vx-axis/src/axis/AxisTop.js
@@ -28,6 +28,7 @@ const propTypes = {
   tickStroke: PropTypes.string,
   tickTransform: PropTypes.string,
   tickValues: PropTypes.array,
+  tickComponent: PropTypes.func,
   top: PropTypes.number,
   children: PropTypes.func,
 };
@@ -63,6 +64,7 @@ export default function AxisTop({
   tickStroke,
   tickTransform,
   tickValues,
+  tickComponent,
   top,
 }) {
   return (
@@ -91,6 +93,7 @@ export default function AxisTop({
       tickStroke={tickStroke}
       tickTransform={tickTransform}
       tickValues={tickValues}
+      tickComponent={tickComponent}
       top={top}
       children={children}
     />

--- a/packages/vx-axis/test/Axis.test.js
+++ b/packages/vx-axis/test/Axis.test.js
@@ -3,6 +3,7 @@ import { Axis } from '../src';
 import { shallow } from 'enzyme';
 import { scaleLinear, scaleBand } from '../../vx-scale';
 import { Line } from '@vx/shape';
+import { Text } from '@vx/text'
 
 const axisProps = {
   orientation: 'left',
@@ -79,7 +80,7 @@ describe('<Axis />', () => {
 
     const ticks = wrapper.find('.vx-axis-tick');
     ticks.forEach(tick => {
-      expect(tick.find('text').props()).toEqual(
+      expect(tick.find(Text).props()).toEqual(
         expect.objectContaining(tickProps),
       );
     });
@@ -109,7 +110,7 @@ describe('<Axis />', () => {
     );
 
     const label = wrapper.find('.vx-axis-label');
-    expect(label.find('text').props()).toEqual(
+    expect(label.find(Text).props()).toEqual(
       expect.objectContaining(labelProps),
     );
   });
@@ -218,8 +219,8 @@ describe('<Axis />', () => {
       wrapper
         .children()
         .find('.vx-axis-tick')
-        .find('text')
-        .text(),
+        .find(Text)
+        .prop('children')
     ).toBe('test!!!');
   });
 
@@ -235,9 +236,9 @@ describe('<Axis />', () => {
       wrapper
         .children()
         .find('.vx-axis-tick')
-        .find('text')
-        .text(),
-    ).toBe('0');
+        .find(Text)
+        .prop('children')
+    ).toBe(0);
   });
 
   test('it should use center if scale is band', () => {

--- a/packages/vx-axis/test/AxisBottom.test.js
+++ b/packages/vx-axis/test/AxisBottom.test.js
@@ -69,6 +69,6 @@ describe('<AxisBottom />', () => {
     const label = 'test';
     const wrapper = shallow(<AxisBottom {...axisProps} label={label} />).dive();
     const text = wrapper.find('.vx-axis-label');
-    expect(text.text()).toEqual(label);
+    expect(text.prop('children')).toEqual(label);
   });
 });

--- a/packages/vx-axis/test/AxisLeft.test.js
+++ b/packages/vx-axis/test/AxisLeft.test.js
@@ -69,6 +69,6 @@ describe('<AxisLeft />', () => {
     const label = 'test';
     const wrapper = shallow(<AxisLeft {...axisProps} label={label} />).dive();
     const text = wrapper.find('.vx-axis-label');
-    expect(text.text()).toEqual(label);
+    expect(text.prop('children')).toEqual(label);
   });
 });

--- a/packages/vx-axis/test/AxisRight.test.js
+++ b/packages/vx-axis/test/AxisRight.test.js
@@ -69,6 +69,6 @@ describe('<AxisRight />', () => {
     const label = 'test';
     const wrapper = shallow(<AxisRight {...axisProps} label={label} />).dive();
     const text = wrapper.find('.vx-axis-label');
-    expect(text.text()).toEqual(label);
+    expect(text.prop('children')).toEqual(label);
   });
 });

--- a/packages/vx-axis/test/AxisTop.test.js
+++ b/packages/vx-axis/test/AxisTop.test.js
@@ -69,6 +69,6 @@ describe('<AxisTop />', () => {
     const label = 'test';
     const wrapper = shallow(<AxisTop {...axisProps} label={label} />).dive();
     const text = wrapper.find('.vx-axis-label');
-    expect(text.text()).toEqual(label);
+    expect(text.prop('children')).toEqual(label);
   });
 })

--- a/packages/vx-demo/components/tiles/axis.js
+++ b/packages/vx-demo/components/tiles/axis.js
@@ -123,6 +123,9 @@ export default ({ width, height, margin }) => {
           dx: '-0.25em',
           dy: '0.25em',
         })}
+        tickComponent={({ formattedValue, ...tickProps}) => (
+          <text {...tickProps}>{formattedValue}</text>
+        )}
       />
       <AxisBottom
         top={height - margin.bottom}

--- a/packages/vx-demo/pages/axis.js
+++ b/packages/vx-demo/pages/axis.js
@@ -139,6 +139,9 @@ export default ({ width, height, margin }) => {
           dx: '-0.25em',
           dy: '0.25em',
         })}
+        tickComponent={({ formattedValue, ...tickProps}) => (
+          <text {...tickProps}>{formattedValue}</text>
+        )}
       />
       <AxisBottom
         top={height - margin.bottom}

--- a/packages/vx-demo/static/docs/vx-axis.html
+++ b/packages/vx-demo/static/docs/vx-axis.html
@@ -207,6 +207,12 @@ const axis = (
 <td style="text-align:left">The x offset to the tick&#39;s text.</td>
 </tr>
 <tr>
+<td style="text-align:left">tickComponent</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">Function returning a React component to render as tick.</td>
+</tr>
+<tr>
 <td style="text-align:left">hideAxisLine</td>
 <td style="text-align:left">false</td>
 <td style="text-align:left">bool</td>
@@ -374,6 +380,12 @@ const axis = (
 <td style="text-align:left"></td>
 <td style="text-align:left">number</td>
 <td style="text-align:left">The x offset to the tick&#39;s text.</td>
+</tr>
+<tr>
+<td style="text-align:left">tickComponent</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">Function returning a React component to render as tick.</td>
 </tr>
 <tr>
 <td style="text-align:left">hideAxisLine</td>
@@ -545,6 +557,12 @@ const axis = (
 <td style="text-align:left">The x offset to the tick&#39;s text.</td>
 </tr>
 <tr>
+<td style="text-align:left">tickComponent</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">Function returning a React component to render as tick.</td>
+</tr>
+<tr>
 <td style="text-align:left">hideAxisLine</td>
 <td style="text-align:left">false</td>
 <td style="text-align:left">bool</td>
@@ -712,6 +730,12 @@ const axis = (
 <td style="text-align:left"></td>
 <td style="text-align:left">number</td>
 <td style="text-align:left">The x offset to the tick&#39;s text.</td>
+</tr>
+<tr>
+<td style="text-align:left">tickComponent</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">Function returning a React component to render as tick.</td>
 </tr>
 <tr>
 <td style="text-align:left">hideAxisLine</td>
@@ -887,6 +911,12 @@ const axis = (
 <td style="text-align:left"></td>
 <td style="text-align:left">number</td>
 <td style="text-align:left">The x offset to the tick&#39;s text.</td>
+</tr>
+<tr>
+<td style="text-align:left">tickComponent</td>
+<td style="text-align:left"></td>
+<td style="text-align:left">function</td>
+<td style="text-align:left">Function returning a React component to render as tick.</td>
 </tr>
 <tr>
 <td style="text-align:left">hideAxisLine</td>


### PR DESCRIPTION
#### :boom: Breaking Changes

None 🎉 

#### :rocket: Enhancements

Implements features mentioned in #259 

- use `@vx/text` for axis ticks and axis label
- add `tickComponent` prop to all axis components

#### :memo: Documentation

1. By default `<Axis />` components now use `@vx/text` to render tick labels. This enables multi line labels and scaling text to fit in a certain amount of space.

Example:
```jsx
<Axis 
  {...axisProps}
  tickLabelProps = (tickValue, index) => ({
    textAnchor: 'middle',
    verticalAnchor: 'middle',
    width: 100,
    scaleToFit: true
  })
/>
```

2. `<Axis />` components got a new prop `tickComponent` to enable rendering of custom ticks. With this prop one can completely customize ticks without having to create a new custom `<Axis />` component.

Example:
```jsx
<Axis
  {...axisProps}
  tickComponent={({ x, y, formattedValue }) => (
    <g>
      <circle cx={x} cy={y} r={2} fill='rebeccapurple' />
      <text x={x + 4} y={y}>{formattedValue}</text>
    </g>
  )}
/>
```

`tickComponent` accepts a function and gets called with the following attribute:
```js
tickComponent({ x, y, formattedValue, ...tickLabelPropsObj })
```

---

P.S.: I think currently it's quite hard to get started developing on `vx`. I don't really know how lerna works and if I maybe did something wrong, please let me know. A little __Getting started developing vx__ section in the readme would be lovely. 