### PR TITLE
Pass props through to underlying Tooltip component

### DIFF
--- a/packages/vx-tooltip/src/tooltips/TooltipWithBounds.js
+++ b/packages/vx-tooltip/src/tooltips/TooltipWithBounds.js
@@ -23,6 +23,7 @@ function TooltipWithBounds({
   parentRect,
   children,
   style,
+  ...otherProps,
 }) {
   let left = initialLeft;
   let top = initialTop;
@@ -36,7 +37,7 @@ function TooltipWithBounds({
   }
 
   return (
-    <Tooltip style={{ top: 0, transform: `translate(${left}px, ${top}px)`, ...style }}>
+    <Tooltip style={{ top: 0, transform: `translate(${left}px, ${top}px)`, ...style }} {...otherProps}>
       {children}
     </Tooltip>
   );


### PR DESCRIPTION
Allows custom classes to be set, as well as the additional flexibility

#### :boom: Breaking Changes

- 

#### :rocket: Enhancements

- Allows custom classes to be set, as well as the additional flexibility of being able to interface with the underlying Tooltip component

#### :memo: Documentation

-

#### :bug: Bug Fix

- 

#### :house: Internal

-
