### PR TITLE
[shape] export link path generators, Link* use additonalProps. fixes #263

### DIFF
--- a/packages/vx-demo/components/tiles/linkTypes.js
+++ b/packages/vx-demo/components/tiles/linkTypes.js
@@ -6,10 +6,18 @@ import { hierarchy } from 'd3-hierarchy';
 import { pointRadial } from 'd3-shape';
 
 import {
-  LinkHorizontal, LinkVertical, LinkRadial,
-  LinkHorizontalStep, LinkVerticalStep, LinkRadialStep,
-  LinkHorizontalCurve, LinkVerticalCurve, LinkRadialCurve,
-  LinkHorizontalLine, LinkVerticalLine, LinkRadialLine
+  LinkHorizontal,
+  LinkVertical,
+  LinkRadial,
+  LinkHorizontalStep,
+  LinkVerticalStep,
+  LinkRadialStep,
+  LinkHorizontalCurve,
+  LinkVerticalCurve,
+  LinkRadialCurve,
+  LinkHorizontalLine,
+  LinkVerticalLine,
+  LinkRadialLine
 } from '@vx/shape';
 
 const data = {
@@ -25,32 +33,32 @@ const data = {
           name: 'C',
           children: [
             {
-              name: 'C1',
+              name: 'C1'
             },
             {
               name: 'D',
               children: [
                 {
-                  name: 'D1',
+                  name: 'D1'
                 },
                 {
-                  name: 'D2',
+                  name: 'D2'
                 },
                 {
-                  name: 'D3',
-                },
-              ],
-            },
-          ],
-        },
-      ],
+                  name: 'D3'
+                }
+              ]
+            }
+          ]
+        }
+      ]
     },
     { name: 'Z' },
     {
       name: 'B',
-      children: [{ name: 'B1' }, { name: 'B2' }, { name: 'B3' }],
-    },
-  ],
+      children: [{ name: 'B1' }, { name: 'B2' }, { name: 'B3' }]
+    }
+  ]
 };
 
 export default class extends React.Component {
@@ -89,9 +97,9 @@ export default class extends React.Component {
       origin = {
         x: innerWidth / 2,
         y: innerHeight / 2
-      }
-      sizeWidth = 2 * Math.PI
-      sizeHeight = Math.min(innerWidth, innerHeight) / 2
+      };
+      sizeWidth = 2 * Math.PI;
+      sizeHeight = Math.min(innerWidth, innerHeight) / 2;
     } else {
       origin = { x: 0, y: 0 };
       if (orientation === 'vertical') {
@@ -105,21 +113,34 @@ export default class extends React.Component {
 
     return (
       <div>
-        <div>
+        <div style={{ color: 'rgba(38, 150, 136, 1.000)', fontSize: 10 }}>
           <label>layout:</label>
-          <select onChange={e => this.setState({ layout: e.target.value })} value={layout}>
+          <select
+            onClick={e => e.stopPropagation()}
+            onChange={e => this.setState({ layout: e.target.value })}
+            value={layout}
+          >
             <option value="cartesian">cartesian</option>
             <option value="polar">polar</option>
           </select>
 
           <label>orientation:</label>
-          <select onChange={e => this.setState({ orientation: e.target.value })} value={orientation} disabled={layout === 'polar'}>
+          <select
+            onClick={e => e.stopPropagation()}
+            onChange={e => this.setState({ orientation: e.target.value })}
+            value={orientation}
+            disabled={layout === 'polar'}
+          >
             <option value="vertical">vertical</option>
             <option value="horizontal">horizontal</option>
           </select>
 
           <label>link:</label>
-          <select onChange={e => this.setState({ linkType: e.target.value })} value={linkType}>
+          <select
+            onClick={e => e.stopPropagation()}
+            onChange={e => this.setState({ linkType: e.target.value })}
+            value={linkType}
+          >
             <option value="diagonal">diagonal</option>
             <option value="step">step</option>
             <option value="curve">curve</option>
@@ -127,7 +148,16 @@ export default class extends React.Component {
           </select>
 
           <label>step:</label>
-          <input type="range" min={0} max={1} step={.1} onChange={e => this.setState({ stepPercent: e.target.value })} value={stepPercent} disabled={linkType !== 'step' || layout === 'polar'} />
+          <input
+            onClick={e => e.stopPropagation()}
+            type="range"
+            min={0}
+            max={1}
+            step={0.1}
+            onChange={e => this.setState({ stepPercent: e.target.value })}
+            value={stepPercent}
+            disabled={linkType !== 'step' || layout === 'polar'}
+          />
         </div>
 
         <svg width={width} height={height}>
@@ -136,40 +166,33 @@ export default class extends React.Component {
           <Tree
             top={margin.top}
             left={margin.left}
-            root={hierarchy(data, d => (d.isExpanded ? d.children : null))}
-            size={[
-              sizeWidth,
-              sizeHeight
-            ]}
-            separation={(a, b) => (a.parent == b.parent ? 1 : .5) / a.depth}
+            root={hierarchy(data, d => (d.isExpanded ? null : d.children))}
+            size={[sizeWidth, sizeHeight]}
+            separation={(a, b) => (a.parent == b.parent ? 1 : 0.5) / a.depth}
           >
             {({ data }) => (
-              <Group
-                top={origin.y}
-                left={origin.x}
-              >
+              <Group top={origin.y} left={origin.x}>
                 {data.links().map((link, i) => {
-
                   let LinkComponent;
 
                   if (layout === 'polar') {
                     if (linkType === 'step') {
                       LinkComponent = LinkRadialStep;
                     } else if (linkType === 'curve') {
-                      LinkComponent = LinkRadialCurve
+                      LinkComponent = LinkRadialCurve;
                     } else if (linkType === 'line') {
-                      LinkComponent = LinkRadialLine
+                      LinkComponent = LinkRadialLine;
                     } else {
-                      LinkComponent = LinkRadial
+                      LinkComponent = LinkRadial;
                     }
                   } else {
                     if (orientation === 'vertical') {
                       if (linkType === 'step') {
                         LinkComponent = LinkVerticalStep;
                       } else if (linkType === 'curve') {
-                        LinkComponent = LinkVerticalCurve
+                        LinkComponent = LinkVerticalCurve;
                       } else if (linkType === 'line') {
-                        LinkComponent = LinkVerticalLine
+                        LinkComponent = LinkVerticalLine;
                       } else {
                         LinkComponent = LinkVertical;
                       }
@@ -177,9 +200,9 @@ export default class extends React.Component {
                       if (linkType === 'step') {
                         LinkComponent = LinkHorizontalStep;
                       } else if (linkType === 'curve') {
-                        LinkComponent = LinkHorizontalCurve
+                        LinkComponent = LinkHorizontalCurve;
                       } else if (linkType === 'line') {
-                        LinkComponent = LinkHorizontalLine
+                        LinkComponent = LinkHorizontalLine;
                       } else {
                         LinkComponent = LinkHorizontal;
                       }
@@ -194,8 +217,11 @@ export default class extends React.Component {
                       strokeWidth="1"
                       fill="none"
                       key={i}
+                      onClick={data => event => {
+                        console.log(data);
+                      }}
                     />
-                  )
+                  );
                 })}
 
                 {data.descendants().map((node, key) => {
@@ -257,13 +283,9 @@ export default class extends React.Component {
                         textAnchor={'middle'}
                         style={{ pointerEvents: 'none' }}
                         fill={
-                          node.depth === 0 ? (
-                            '#71248e'
-                          ) : node.children ? (
-                            'white'
-                          ) : (
-                            '#26deb0'
-                          )
+                          node.depth === 0
+                            ? '#71248e'
+                            : node.children ? 'white' : '#26deb0'
                         }
                       >
                         {node.data.name}

--- a/packages/vx-shape/src/index.js
+++ b/packages/vx-shape/src/index.js
@@ -3,18 +3,6 @@ export { default as Pie } from './shapes/Pie';
 export { default as Line } from './shapes/Line';
 export { default as LinePath } from './shapes/LinePath';
 export { default as LineRadial } from './shapes/LineRadial';
-export { default as LinkHorizontal } from './shapes/link/diagonal/LinkHorizontal';
-export { default as LinkVertical } from './shapes/link/diagonal/LinkVertical';
-export { default as LinkRadial } from './shapes/link/diagonal/LinkRadial';
-export { default as LinkHorizontalCurve } from './shapes/link/curve/LinkHorizontalCurve';
-export { default as LinkVerticalCurve } from './shapes/link/curve/LinkVerticalCurve';
-export { default as LinkRadialCurve } from './shapes/link/curve/LinkRadialCurve';
-export { default as LinkHorizontalLine } from './shapes/link/line/LinkHorizontalLine';
-export { default as LinkVerticalLine } from './shapes/link/line/LinkVerticalLine';
-export { default as LinkRadialLine } from './shapes/link/line/LinkRadialLine';
-export { default as LinkHorizontalStep } from './shapes/link/step/LinkHorizontalStep';
-export { default as LinkVerticalStep } from './shapes/link/step/LinkVerticalStep';
-export { default as LinkRadialStep } from './shapes/link/step/LinkRadialStep';
 export { default as Area } from './shapes/Area';
 export { default as AreaClosed } from './shapes/AreaClosed';
 export { default as AreaStack } from './shapes/AreaStack';
@@ -27,10 +15,58 @@ export { default as callOrValue } from './util/callOrValue';
 export {
   default as stackOffset,
   STACK_OFFSETS,
-  STACK_OFFSET_NAMES,
+  STACK_OFFSET_NAMES
 } from './util/stackOffset';
 export {
   default as stackOrder,
   STACK_ORDERS,
-  STACK_ORDER_NAMES,
+  STACK_ORDER_NAMES
 } from './util/stackOrder';
+export {
+  default as LinkHorizontal,
+  pathHorizontalDiagonal
+} from './shapes/link/diagonal/LinkHorizontal';
+export {
+  default as LinkVertical,
+  pathVerticalDiagonal
+} from './shapes/link/diagonal/LinkVertical';
+export {
+  default as LinkRadial,
+  pathRadialDiagonal
+} from './shapes/link/diagonal/LinkRadial';
+export {
+  default as LinkHorizontalCurve,
+  pathHorizontalCurve
+} from './shapes/link/curve/LinkHorizontalCurve';
+export {
+  default as LinkVerticalCurve,
+  pathVerticalCurve
+} from './shapes/link/curve/LinkVerticalCurve';
+export {
+  default as LinkRadialCurve,
+  pathRadialCurve
+} from './shapes/link/curve/LinkRadialCurve';
+export {
+  default as LinkHorizontalLine,
+  pathHorizontalLine
+} from './shapes/link/line/LinkHorizontalLine';
+export {
+  default as LinkVerticalLine,
+  pathVerticalLine
+} from './shapes/link/line/LinkVerticalLine';
+export {
+  default as LinkRadialLine,
+  pathRadialLine
+} from './shapes/link/line/LinkRadialLine';
+export {
+  default as LinkHorizontalStep,
+  pathHorizontalStep
+} from './shapes/link/step/LinkHorizontalStep';
+export {
+  default as LinkVerticalStep,
+  pathVerticalStep
+} from './shapes/link/step/LinkVerticalStep';
+export {
+  default as LinkRadialStep,
+  pathRadialStep
+} from './shapes/link/step/LinkRadialStep';

--- a/packages/vx-shape/src/shapes/link/curve/LinkHorizontalCurve.js
+++ b/packages/vx-shape/src/shapes/link/curve/LinkHorizontalCurve.js
@@ -1,26 +1,11 @@
 import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import { pointRadial } from 'd3-shape';
 import { path as d3Path } from 'd3-path';
 import additionalProps from '../../../util/additionalProps';
 
-LinkHorizontalCurve.propTypes = {
-  innerRef: PropTypes.func
-};
-
-export default function LinkHorizontalCurve({
-  className,
-  innerRef,
-  data,
-  x = d => d.y,
-  y = d => d.x,
-  source = d => d.source,
-  target = d => d.target,
-  ...restProps
-}) {
-
-  const link = (data) => {
+export function pathHorizontalCurve({ source, target, x, y, percent }) {
+  return data => {
     const sourceData = source(data);
     const targetData = target(data);
 
@@ -31,22 +16,46 @@ export default function LinkHorizontalCurve({
 
     const dx = tx - sx;
     const dy = ty - sy;
-    const ix = 0.2 * (dx + dy);
-    const iy = 0.2 * (dy - dx);
+    const ix = percent * (dx + dy);
+    const iy = percent * (dy - dx);
 
-    const path =  d3Path();
-    path.moveTo(sx, sy)
-    path.bezierCurveTo(sx + ix, sy + iy, tx + iy, ty - ix, tx, ty)
+    const path = d3Path();
+    path.moveTo(sx, sy);
+    path.bezierCurveTo(sx + ix, sy + iy, tx + iy, ty - ix, tx, ty);
 
     return path.toString();
   };
+}
 
+LinkHorizontalCurve.propTypes = {
+  innerRef: PropTypes.func,
+  percent: PropTypes.number,
+  x: PropTypes.func,
+  y: PropTypes.func,
+  source: PropTypes.func,
+  target: PropTypes.func,
+  path: PropTypes.func
+};
+
+export default function LinkHorizontalCurve({
+  className,
+  innerRef,
+  data,
+  path,
+  x = d => d.y,
+  y = d => d.x,
+  source = d => d.source,
+  target = d => d.target,
+  percent = 0.2,
+  ...restProps
+}) {
+  path = path || pathHorizontalCurve({ source, target, x, y, percent });
   return (
     <path
       ref={innerRef}
       className={cx('vx-link', className)}
-      d={link(data)}
-      {...restProps}
+      d={path(data)}
+      {...additionalProps(restProps, data)}
     />
   );
 }

--- a/packages/vx-shape/src/shapes/link/curve/LinkRadialCurve.js
+++ b/packages/vx-shape/src/shapes/link/curve/LinkRadialCurve.js
@@ -1,26 +1,11 @@
 import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import { pointRadial } from 'd3-shape';
 import { path as d3Path } from 'd3-path';
 import additionalProps from '../../../util/additionalProps';
 
-LinkRadialCurve.propTypes = {
-  innerRef: PropTypes.func
-};
-
-export default function LinkRadialCurve({
-  className,
-  innerRef,
-  data,
-  x = d => d.x,
-  y = d => d.y,
-  source = d => d.source,
-  target = d => d.target,
-  ...restProps
-}) {
-
-  const link = (data) => {
+export function pathRadialCurve({ source, target, x, y, percent }) {
+  return data => {
     const sourceData = source(data);
     const targetData = target(data);
 
@@ -41,22 +26,46 @@ export default function LinkRadialCurve({
 
     const dx = tx - sx;
     const dy = ty - sy;
-    const ix = 0.2 * (dx + dy);
-    const iy = 0.2 * (dy - dx);
+    const ix = percent * (dx + dy);
+    const iy = percent * (dy - dx);
 
-    const path =  d3Path();
-    path.moveTo(sx, sy)
-    path.bezierCurveTo(sx + ix, sy + iy, tx + iy, ty - ix, tx, ty)
+    const path = d3Path();
+    path.moveTo(sx, sy);
+    path.bezierCurveTo(sx + ix, sy + iy, tx + iy, ty - ix, tx, ty);
 
     return path.toString();
   };
+}
 
+LinkRadialCurve.propTypes = {
+  innerRef: PropTypes.func,
+  percent: PropTypes.number,
+  x: PropTypes.func,
+  y: PropTypes.func,
+  source: PropTypes.func,
+  target: PropTypes.func,
+  path: PropTypes.func
+};
+
+export default function LinkRadialCurve({
+  className,
+  innerRef,
+  data,
+  path,
+  x = d => d.x,
+  y = d => d.y,
+  source = d => d.source,
+  target = d => d.target,
+  percent = 0.2,
+  ...restProps
+}) {
+  path = path || pathRadialCurve({ source, target, x, y, percent });
   return (
     <path
       ref={innerRef}
       className={cx('vx-link', className)}
-      d={link(data)}
-      {...restProps}
+      d={path(data)}
+      {...additionalProps(restProps, data)}
     />
   );
 }

--- a/packages/vx-shape/src/shapes/link/curve/LinkVerticalCurve.js
+++ b/packages/vx-shape/src/shapes/link/curve/LinkVerticalCurve.js
@@ -1,26 +1,11 @@
 import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import { pointRadial } from 'd3-shape';
 import { path as d3Path } from 'd3-path';
 import additionalProps from '../../../util/additionalProps';
 
-LinkVerticalCurve.propTypes = {
-  innerRef: PropTypes.func
-};
-
-export default function LinkVerticalCurve({
-  className,
-  innerRef,
-  data,
-  x = d => d.x,
-  y = d => d.y,
-  source = d => d.source,
-  target = d => d.target,
-  ...restProps
-}) {
-
-  const link = (data) => {
+export function pathVerticalCurve({ source, target, x, y, percent }) {
+  return data => {
     const sourceData = source(data);
     const targetData = target(data);
 
@@ -31,22 +16,46 @@ export default function LinkVerticalCurve({
 
     const dx = tx - sx;
     const dy = ty - sy;
-    const ix = 0.2 * (dx + dy);
-    const iy = 0.2 * (dy - dx);
+    const ix = percent * (dx + dy);
+    const iy = percent * (dy - dx);
 
-    const path =  d3Path();
-    path.moveTo(sx, sy)
-    path.bezierCurveTo(sx + ix, sy + iy, tx + iy, ty - ix, tx, ty)
+    const path = d3Path();
+    path.moveTo(sx, sy);
+    path.bezierCurveTo(sx + ix, sy + iy, tx + iy, ty - ix, tx, ty);
 
     return path.toString();
   };
+}
 
+LinkVerticalCurve.propTypes = {
+  innerRef: PropTypes.func,
+  percent: PropTypes.number,
+  x: PropTypes.func,
+  y: PropTypes.func,
+  source: PropTypes.func,
+  target: PropTypes.func,
+  path: PropTypes.func
+};
+
+export default function LinkVerticalCurve({
+  className,
+  innerRef,
+  data,
+  path,
+  x = d => d.x,
+  y = d => d.y,
+  source = d => d.source,
+  target = d => d.target,
+  percent = 0.2,
+  ...restProps
+}) {
+  path = path || pathVerticalCurve({ source, target, x, y, percent });
   return (
     <path
       ref={innerRef}
       className={cx('vx-link', className)}
-      d={link(data)}
-      {...restProps}
+      d={path(data)}
+      {...additionalProps(restProps, data)}
     />
   );
 }

--- a/packages/vx-shape/src/shapes/link/diagonal/LinkHorizontal.js
+++ b/packages/vx-shape/src/shapes/link/diagonal/LinkHorizontal.js
@@ -4,31 +4,43 @@ import PropTypes from 'prop-types';
 import { linkHorizontal } from 'd3-shape';
 import additionalProps from '../../../util/additionalProps';
 
+export function pathHorizontalDiagonal({ source, target, x, y }) {
+  return data => {
+    const link = linkHorizontal();
+    link.x(x);
+    link.y(y);
+    link.source(source);
+    link.target(target);
+    return link(data);
+  };
+}
+
 LinkHorizontal.propTypes = {
   innerRef: PropTypes.func,
+  x: PropTypes.func,
+  y: PropTypes.func,
+  source: PropTypes.func,
+  target: PropTypes.func,
+  path: PropTypes.func
 };
 
 export default function LinkHorizontal({
   className,
   innerRef,
   data,
+  path,
   x = d => d.y,
   y = d => d.x,
   source = d => d.source,
   target = d => d.target,
   ...restProps
 }) {
-  const link = linkHorizontal();
-  link.x(x);
-  link.y(y);
-  link.source(source);
-  link.target(target);
-
+  path = path || pathHorizontalDiagonal({ source, target, x, y });
   return (
     <path
       ref={innerRef}
       className={cx('vx-link-horizontal', className)}
-      d={link(data)}
+      d={path(data)}
       {...additionalProps(restProps, data)}
     />
   );

--- a/packages/vx-shape/src/shapes/link/diagonal/LinkRadial.js
+++ b/packages/vx-shape/src/shapes/link/diagonal/LinkRadial.js
@@ -4,31 +4,43 @@ import PropTypes from 'prop-types';
 import { linkRadial } from 'd3-shape';
 import additionalProps from '../../../util/additionalProps';
 
+export function pathRadialDiagonal({ source, target, angle, radius }) {
+  return data => {
+    const link = linkRadial();
+    link.angle(angle);
+    link.radius(radius);
+    link.source(source);
+    link.target(target);
+    return link(data);
+  };
+}
+
 LinkRadial.propTypes = {
   innerRef: PropTypes.func,
+  angle: PropTypes.func,
+  radius: PropTypes.func,
+  source: PropTypes.func,
+  target: PropTypes.func,
+  path: PropTypes.func
 };
 
 export default function LinkRadial({
   className,
   innerRef,
   data,
+  path,
   angle = d => d.x,
   radius = d => d.y,
   source = d => d.source,
-  target = d => d.target, 
+  target = d => d.target,
   ...restProps
 }) {
-  const link = linkRadial()
-  link.angle(angle);
-  link.radius(radius);
-  link.source(source);
-  link.target(target);
-
+  path = path || pathRadialDiagonal({ source, target, angle, radius });
   return (
     <path
       ref={innerRef}
       className={cx('vx-link-radius', className)}
-      d={link(data)}
+      d={path(data)}
       {...additionalProps(restProps, data)}
     />
   );

--- a/packages/vx-shape/src/shapes/link/diagonal/LinkVertical.js
+++ b/packages/vx-shape/src/shapes/link/diagonal/LinkVertical.js
@@ -4,31 +4,43 @@ import PropTypes from 'prop-types';
 import { linkVertical } from 'd3-shape';
 import additionalProps from '../../../util/additionalProps';
 
+export function pathVerticalDiagonal({ source, target, x, y }) {
+  return data => {
+    const link = linkVertical();
+    link.x(x);
+    link.y(y);
+    link.source(source);
+    link.target(target);
+    return link(data);
+  };
+}
+
 LinkVertical.propTypes = {
   innerRef: PropTypes.func,
+  x: PropTypes.func,
+  y: PropTypes.func,
+  source: PropTypes.func,
+  target: PropTypes.func,
+  path: PropTypes.func
 };
 
 export default function LinkVertical({
   className,
   innerRef,
   data,
+  path,
   x = d => d.x,
   y = d => d.y,
   source = d => d.source,
   target = d => d.target,
   ...restProps
 }) {
-  const link = linkVertical();
-  link.x(x);
-  link.y(y);
-  link.source(source);
-  link.target(target);
-
+  path = path || pathVerticalDiagonal({ source, target, x, y });
   return (
     <path
       ref={innerRef}
       className={cx('vx-link-vertical', className)}
-      d={link(data)}
+      d={path(data)}
       {...additionalProps(restProps, data)}
     />
   );

--- a/packages/vx-shape/src/shapes/link/line/LinkHorizontalLine.js
+++ b/packages/vx-shape/src/shapes/link/line/LinkHorizontalLine.js
@@ -4,21 +4,8 @@ import PropTypes from 'prop-types';
 import { path as d3Path } from 'd3-path';
 import additionalProps from '../../../util/additionalProps';
 
-LinkHorizontalLine.propTypes = {
-  innerRef: PropTypes.func
-};
-
-export default function LinkHorizontalLine({
-  className,
-  innerRef,
-  data,
-  x = d => d.y,
-  y = d => d.x,
-  source = d => d.source,
-  target = d => d.target,
-  ...restProps
-}) {
-  const link = (data) => {
+export function pathHorizontalLine({ source, target, x, y }) {
+  return data => {
     const sourceData = source(data);
     const targetData = target(data);
 
@@ -27,19 +14,41 @@ export default function LinkHorizontalLine({
     const tx = x(targetData);
     const ty = y(targetData);
 
-    const path =  d3Path();
-    path.moveTo(sx, sy)
-    path.lineTo(tx, ty)
+    const path = d3Path();
+    path.moveTo(sx, sy);
+    path.lineTo(tx, ty);
 
     return path.toString();
   };
+}
 
+LinkHorizontalLine.propTypes = {
+  innerRef: PropTypes.func,
+  path: PropTypes.func,
+  x: PropTypes.func,
+  y: PropTypes.func,
+  source: PropTypes.func,
+  target: PropTypes.func
+};
+
+export default function LinkHorizontalLine({
+  className,
+  innerRef,
+  data,
+  path,
+  x = d => d.y,
+  y = d => d.x,
+  source = d => d.source,
+  target = d => d.target,
+  ...restProps
+}) {
+  path = path || pathHorizontalLine({ source, target, x, y });
   return (
     <path
       ref={innerRef}
       className={cx('vx-link', className)}
-      d={link(data)}
-      {...restProps}
+      d={path(data)}
+      {...additionalProps(restProps, data)}
     />
   );
 }

--- a/packages/vx-shape/src/shapes/link/line/LinkRadialLine.js
+++ b/packages/vx-shape/src/shapes/link/line/LinkRadialLine.js
@@ -1,26 +1,11 @@
 import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import { pointRadial } from 'd3-shape';
 import { path as d3Path } from 'd3-path';
 import additionalProps from '../../../util/additionalProps';
 
-LinkRadialStep.propTypes = {
-  innerRef: PropTypes.func
-};
-
-export default function LinkRadialStep({
-  className,
-  innerRef,
-  data,
-  x = d => d.x,
-  y = d => d.y,
-  source = d => d.source,
-  target = d => d.target,
-  ...restProps
-}) {
-
-  const link = (data) => {
+export function pathRadialLine({ source, target, x, y }) {
+  return data => {
     const sourceData = source(data);
     const targetData = target(data);
 
@@ -34,19 +19,41 @@ export default function LinkRadialStep({
     const tc = Math.cos(ta);
     const ts = Math.sin(ta);
 
-    const path =  d3Path();
-    path.moveTo(sr * sc, sr * ss)
-    path.lineTo(tr * tc, tr * ts)
+    const path = d3Path();
+    path.moveTo(sr * sc, sr * ss);
+    path.lineTo(tr * tc, tr * ts);
 
     return path.toString();
   };
+}
 
+LinkRadialStep.propTypes = {
+  innerRef: PropTypes.func,
+  path: PropTypes.func,
+  x: PropTypes.func,
+  y: PropTypes.func,
+  source: PropTypes.func,
+  target: PropTypes.func
+};
+
+export default function LinkRadialStep({
+  className,
+  innerRef,
+  data,
+  path,
+  x = d => d.x,
+  y = d => d.y,
+  source = d => d.source,
+  target = d => d.target,
+  ...restProps
+}) {
+  path = path || pathRadialLine({ source, target, x, y });
   return (
     <path
       ref={innerRef}
       className={cx('vx-link', className)}
-      d={link(data)}
-      {...restProps}
+      d={path(data)}
+      {...additionalProps(restProps, data)}
     />
   );
 }

--- a/packages/vx-shape/src/shapes/link/line/LinkVerticalLine.js
+++ b/packages/vx-shape/src/shapes/link/line/LinkVerticalLine.js
@@ -4,21 +4,8 @@ import PropTypes from 'prop-types';
 import { path as d3Path } from 'd3-path';
 import additionalProps from '../../../util/additionalProps';
 
-LinkVerticalLine.propTypes = {
-  innerRef: PropTypes.func
-};
-
-export default function LinkVerticalLine({
-  className,
-  innerRef,
-  data,
-  x = d => d.x,
-  y = d => d.y,
-  source = d => d.source,
-  target = d => d.target,
-  ...restProps
-}) {
-  const link = (data) => {
+export function pathVerticalLine({ source, target, x, y }) {
+  return data => {
     const sourceData = source(data);
     const targetData = target(data);
 
@@ -27,19 +14,41 @@ export default function LinkVerticalLine({
     const tx = x(targetData);
     const ty = y(targetData);
 
-    const path =  d3Path();
-    path.moveTo(sx, sy)
-    path.lineTo(tx, ty)
+    const path = d3Path();
+    path.moveTo(sx, sy);
+    path.lineTo(tx, ty);
 
     return path.toString();
   };
+}
 
+LinkVerticalLine.propTypes = {
+  innerRef: PropTypes.func,
+  path: PropTypes.func,
+  x: PropTypes.func,
+  y: PropTypes.func,
+  source: PropTypes.func,
+  target: PropTypes.func
+};
+
+export default function LinkVerticalLine({
+  className,
+  innerRef,
+  data,
+  path,
+  x = d => d.x,
+  y = d => d.y,
+  source = d => d.source,
+  target = d => d.target,
+  ...restProps
+}) {
+  path = path || pathVerticalLine({ source, target, x, y });
   return (
     <path
       ref={innerRef}
       className={cx('vx-link', className)}
-      d={link(data)}
-      {...restProps}
+      d={path(data)}
+      {...additionalProps(restProps, data)}
     />
   );
 }

--- a/packages/vx-shape/src/shapes/link/step/LinkHorizontalStep.js
+++ b/packages/vx-shape/src/shapes/link/step/LinkHorizontalStep.js
@@ -4,23 +4,8 @@ import PropTypes from 'prop-types';
 import { path as d3Path } from 'd3-path';
 import additionalProps from '../../../util/additionalProps';
 
-LinkHorizontalStep.propTypes = {
-  innerRef: PropTypes.func,
-  percent: PropTypes.number
-};
-
-export default function LinkHorizontalStep({
-  className,
-  innerRef,
-  data,
-  percent = 0.5,
-  x = d => d.y,
-  y = d => d.x,
-  source = d => d.source,
-  target = d => d.target,
-  ...restProps
-}) {
-  const link = (data) => {
+export function pathHorizontalStep({ source, target, x, y, percent }) {
+  return data => {
     const sourceData = source(data);
     const targetData = target(data);
 
@@ -29,21 +14,45 @@ export default function LinkHorizontalStep({
     const tx = x(targetData);
     const ty = y(targetData);
 
-    const path =  d3Path();
-    path.moveTo(sx, sy)
-    path.lineTo(sx + (tx - sx) * percent, sy)
-    path.lineTo(sx + (tx - sx) * percent, ty)
-    path.lineTo(tx, ty)
+    const path = d3Path();
+    path.moveTo(sx, sy);
+    path.lineTo(sx + (tx - sx) * percent, sy);
+    path.lineTo(sx + (tx - sx) * percent, ty);
+    path.lineTo(tx, ty);
 
     return path.toString();
   };
+}
 
+LinkHorizontalStep.propTypes = {
+  innerRef: PropTypes.func,
+  percent: PropTypes.number,
+  x: PropTypes.func,
+  y: PropTypes.func,
+  source: PropTypes.func,
+  target: PropTypes.func,
+  path: PropTypes.func
+};
+
+export default function LinkHorizontalStep({
+  className,
+  innerRef,
+  data,
+  path,
+  percent = 0.5,
+  x = d => d.y,
+  y = d => d.x,
+  source = d => d.source,
+  target = d => d.target,
+  ...restProps
+}) {
+  path = path || pathHorizontalStep({ source, target, x, y, percent });
   return (
     <path
       ref={innerRef}
       className={cx('vx-link', className)}
-      d={link(data)}
-      {...restProps}
+      d={path(data)}
+      {...additionalProps(restProps, data)}
     />
   );
 }

--- a/packages/vx-shape/src/shapes/link/step/LinkRadialStep.js
+++ b/packages/vx-shape/src/shapes/link/step/LinkRadialStep.js
@@ -1,26 +1,10 @@
 import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import { pointRadial } from 'd3-shape';
-import { path as d3Path } from 'd3-path';
 import additionalProps from '../../../util/additionalProps';
 
-LinkRadialStep.propTypes = {
-  innerRef: PropTypes.func
-};
-
-export default function LinkRadialStep({
-  className,
-  innerRef,
-  data,
-  x = d => d.x,
-  y = d => d.y,
-  source = d => d.source,
-  target = d => d.target,
-  ...restProps
-}) {
-  
-  const link = (data) => {
+export function pathRadialStep({ source, target, x, y }) {
+  return data => {
     const sourceData = source(data);
     const targetData = target(data);
 
@@ -45,22 +29,36 @@ export default function LinkRadialStep({
       A${sr},${sr},0,0,${sf ? 1 : 0},${sr * tc},${sr * ts}
       L${tr * tc},${tr * ts}
     `;
-
-    // TODO: Port to d3-path
-    // const path =  d3Path();
-    // path.moveTo(sr * sc, sr * ss)
-    // path.arcTo(/* TODO */);
-    // path.lineTo(tr * tc, tr * ts)
-
-    // return path.toString();
   };
+}
 
+LinkRadialStep.propTypes = {
+  innerRef: PropTypes.func,
+  x: PropTypes.func,
+  y: PropTypes.func,
+  source: PropTypes.func,
+  target: PropTypes.func,
+  path: PropTypes.func
+};
+
+export default function LinkRadialStep({
+  className,
+  innerRef,
+  data,
+  path,
+  x = d => d.x,
+  y = d => d.y,
+  source = d => d.source,
+  target = d => d.target,
+  ...restProps
+}) {
+  path = path || pathRadialStep({ source, target, x, y });
   return (
     <path
       ref={innerRef}
       className={cx('vx-link', className)}
-      d={link(data)}
-      {...restProps}
+      d={path(data)}
+      {...additionalProps(restProps, data)}
     />
   );
 }

--- a/packages/vx-shape/src/shapes/link/step/LinkVerticalStep.js
+++ b/packages/vx-shape/src/shapes/link/step/LinkVerticalStep.js
@@ -4,23 +4,8 @@ import PropTypes from 'prop-types';
 import { path as d3Path } from 'd3-path';
 import additionalProps from '../../../util/additionalProps';
 
-LinkVerticalStep.propTypes = {
-  innerRef: PropTypes.func,
-  percent: PropTypes.number,
-};
-
-export default function LinkVerticalStep({
-  className,
-  innerRef,
-  data,
-  percent = 0.5,
-  x = d => d.x,
-  y = d => d.y,
-  source = d => d.source,
-  target = d => d.target,
-  ...restProps
-}) {
-  const link = (data) => {
+export function pathVerticalStep({ source, target, x, y, percent }) {
+  return data => {
     const sourceData = source(data);
     const targetData = target(data);
 
@@ -29,21 +14,45 @@ export default function LinkVerticalStep({
     const tx = x(targetData);
     const ty = y(targetData);
 
-    const path =  d3Path();
-    path.moveTo(sx, sy)
-    path.lineTo(sx, sy + (ty - sy) * percent)
-    path.lineTo(tx, sy + (ty - sy) * percent)
-    path.lineTo(tx, ty)
+    const path = d3Path();
+    path.moveTo(sx, sy);
+    path.lineTo(sx, sy + (ty - sy) * percent);
+    path.lineTo(tx, sy + (ty - sy) * percent);
+    path.lineTo(tx, ty);
 
     return path.toString();
   };
+}
 
+LinkVerticalStep.propTypes = {
+  innerRef: PropTypes.func,
+  percent: PropTypes.number,
+  x: PropTypes.func,
+  y: PropTypes.func,
+  source: PropTypes.func,
+  target: PropTypes.func,
+  path: PropTypes.func
+};
+
+export default function LinkVerticalStep({
+  className,
+  innerRef,
+  data,
+  path,
+  percent = 0.5,
+  x = d => d.x,
+  y = d => d.y,
+  source = d => d.source,
+  target = d => d.target,
+  ...restProps
+}) {
+  path = path || pathVerticalStep({ source, target, x, y, percent });
   return (
     <path
       ref={innerRef}
       className={cx('vx-link', className)}
-      d={link(data)}
-      {...restProps}
+      d={path(data)}
+      {...additionalProps(restProps, data)}
     />
   );
 }


### PR DESCRIPTION
#### :boom: Breaking Changes

- [shape] `<Link* />` components now use `...additionalProps()` everywhere for consistency. So function props get passed data. example: `onClick={event => // stuff}` becomes `onClick={data => event => // stuff}` and now you can stroke/fill/attr based on data `stroke={({ target }) => target.data.children ? 'yellow' : 'blue' }

<img width="825" alt="screen shot 2018-04-08 at 2 04 07 pm" src="https://user-images.githubusercontent.com/339208/38470801-0a0db41a-3b36-11e8-9cdb-47f2fb5024fc.png">

#### :rocket: Enhancements

- [shape] export link path generators. fixes: https://github.com/hshoff/vx/issues/263