### PR TITLE
fix: tickLabelProps dy and dx work again

### DIFF
--- a/packages/vx-text/src/Text.js
+++ b/packages/vx-text/src/Text.js
@@ -138,22 +138,20 @@ class Text extends Component {
     }
 
     return (
-      <text
-        {...textProps}
-        textAnchor={textAnchor}
-        style={{
-          transform: `translate(${dx}, ${dy})`,
-          ...textProps.style
-        }}
-      >
-        {
-        wordsByLines.map((line, index) => (
-          <tspan x={x} dy={index === 0 ? startDy : lineHeight} key={index}>
-            {line.words.join(' ')}
-          </tspan>
-        ))
-      }
-      </text>
+      <svg x={dx} y={dy} fontSize={textProps.fontSize} style={{ overflow: 'visible' }}>
+        <text
+          {...textProps}
+          textAnchor={textAnchor}
+        >
+          {
+          wordsByLines.map((line, index) => (
+            <tspan x={x} dy={index === 0 ? startDy : lineHeight} key={index}>
+              {line.words.join(' ')}
+            </tspan>
+          ))
+        }
+        </text>
+      </svg>
     );
   }
 }

--- a/packages/vx-text/src/Text.js
+++ b/packages/vx-text/src/Text.js
@@ -103,8 +103,8 @@ class Text extends Component {
     } = this.props;
     const { wordsByLines } = this.state;
 
-    const x = textProps.x + dx;
-    const y = textProps.y + dy;
+    const x = textProps.x;
+    const y = textProps.y;
 
     let startDy;
     switch (verticalAnchor) {
@@ -139,10 +139,12 @@ class Text extends Component {
 
     return (
       <text
-        x={x}
-        y={y}
-        textAnchor={textAnchor}
         {...textProps}
+        textAnchor={textAnchor}
+        style={{
+          transform: `translate(${dx}, ${dy})`,
+          ...textProps.style
+        }}
       >
         {
         wordsByLines.map((line, index) => (


### PR DESCRIPTION
This should fix the bug mentioned in https://github.com/hshoff/vx/issues/267.
I had several problems with this which made me come to the solution of using transforms for this bug fix.  

1. `px` values for `dx` and `dy` were fine and worked.
2. `em` values were fine as long as `fontSize` was explicitly provided for `<Text />`. Without `fontSize` there is no value to use for the transformation from `em -> px` without accessing the DOM.
3. `rem` units had the same problem that there is no way of transforming to `px` without the DOM.
4. I couldn't do `<text dy="1em">...</text>` because the child `<tspan>` defines a `dy` value that overwrites the one from `<text>`. I'm not quite sure why. [example](https://codepen.io/anon/pen/QmexEp)

In the end setting a CSS transform seemed like the easiest solution and has the nice benefit of supporting `rem`.

If there is a better solution please let me know, this took longer than I want to admit 😅.

#### :bug: Bug Fix

- `@vx/text` support `dx` and `dy` again