### PR TITLE
[demo] add AxisRight to axis demo

### DIFF
--- a/packages/vx-demo/components/tiles/axis.js
+++ b/packages/vx-demo/components/tiles/axis.js
@@ -88,95 +88,97 @@ export default ({ width, height, margin }) => {
           curve={curveBasis}
         />
       </Group>
-      <AxisLeft
-        top={margin.top}
-        left={margin.left}
-        scale={yScale}
-        hideZero
-        numTicks={numTicksForHeight(height)}
-        label="Axis Left Label"
-        labelProps={{
-          fill: '#8e205f',
-          textAnchor: 'middle',
-          fontSize: 12,
-          fontFamily: 'Arial'
-        }}
-        stroke="#1b1a1e"
-        tickStroke="#8e205f"
-        tickLabelProps={(value, index) => ({
-          fill: '#8e205f',
-          textAnchor: 'end',
-          fontSize: 10,
-          fontFamily: 'Arial',
-          dx: '-0.25em',
-          dy: '0.25em'
-        })}
-        tickComponent={({ formattedValue, ...tickProps }) => (
-          <text {...tickProps}>{formattedValue}</text>
-        )}
-      />
-      <AxisRight
-        top={margin.top}
-        left={xMax + margin.left}
-        scale={yScale}
-        hideZero
-        numTicks={numTicksForHeight(height)}
-        label="Axis Right Label"
-        labelProps={{
-          fill: '#8e205f',
-          textAnchor: 'middle',
-          fontSize: 12,
-          fontFamily: 'Arial'
-        }}
-        stroke="#1b1a1e"
-        tickStroke="#8e205f"
-        tickLabelProps={(value, index) => ({
-          fill: '#8e205f',
-          textAnchor: 'start',
-          fontSize: 10,
-          fontFamily: 'Arial',
-          dx: '0.25em',
-          dy: '0.25em'
-        })}
-      />
-      <AxisBottom
-        top={height - margin.bottom}
-        left={margin.left}
-        scale={xScale}
-        numTicks={numTicksForWidth(width)}
-        label="Time"
-      >
-        {props => {
-          const tickLabelSize = 10;
-          const tickRotate = 45;
-          const tickColor = '#8e205f';
-          const axisCenter = (props.axisToPoint.x - props.axisFromPoint.x) / 2;
-          return (
-            <g className="my-custom-bottom-axis">
-              {props.ticks.map((tick, i) => {
-                const tickX = tick.to.x;
-                const tickY = tick.to.y + tickLabelSize + props.tickLength;
-                return (
-                  <Group key={`vx-tick-${tick.value}-${i}`} className={'vx-axis-tick'}>
-                    <Line from={tick.from} to={tick.to} stroke={tickColor} />
-                    <text
-                      transform={`translate(${tickX}, ${tickY}) rotate(${tickRotate})`}
-                      fontSize={tickLabelSize}
-                      textAnchor="middle"
-                      fill={tickColor}
-                    >
-                      {tick.formattedValue}
-                    </text>
-                  </Group>
-                );
-              })}
-              <text textAnchor="middle" transform={`translate(${axisCenter}, 50)`} fontSize="8">
-                {props.label}
-              </text>
-            </g>
-          );
-        }}
-      </AxisBottom>
+      <Group left={margin.left}>
+        <AxisLeft
+          top={margin.top}
+          left={0}
+          scale={yScale}
+          hideZero
+          numTicks={numTicksForHeight(height)}
+          label="Axis Left Label"
+          labelProps={{
+            fill: '#8e205f',
+            textAnchor: 'middle',
+            fontSize: 12,
+            fontFamily: 'Arial'
+          }}
+          stroke="#1b1a1e"
+          tickStroke="#8e205f"
+          tickLabelProps={(value, index) => ({
+            fill: '#8e205f',
+            textAnchor: 'end',
+            fontSize: 10,
+            fontFamily: 'Arial',
+            dx: '-0.25em',
+            dy: '0.25em'
+          })}
+          tickComponent={({ formattedValue, ...tickProps }) => (
+            <text {...tickProps}>{formattedValue}</text>
+          )}
+        />
+        <AxisRight
+          top={margin.top}
+          left={xMax}
+          scale={yScale}
+          hideZero
+          numTicks={numTicksForHeight(height)}
+          label="Axis Right Label"
+          labelProps={{
+            fill: '#8e205f',
+            textAnchor: 'middle',
+            fontSize: 12,
+            fontFamily: 'Arial'
+          }}
+          stroke="#1b1a1e"
+          tickStroke="#8e205f"
+          tickLabelProps={(value, index) => ({
+            fill: '#8e205f',
+            textAnchor: 'start',
+            fontSize: 10,
+            fontFamily: 'Arial',
+            dx: '0.25em',
+            dy: '0.25em'
+          })}
+        />
+        <AxisBottom
+          top={height - margin.bottom}
+          left={0}
+          scale={xScale}
+          numTicks={numTicksForWidth(width)}
+          label="Time"
+        >
+          {props => {
+            const tickLabelSize = 10;
+            const tickRotate = 45;
+            const tickColor = '#8e205f';
+            const axisCenter = (props.axisToPoint.x - props.axisFromPoint.x) / 2;
+            return (
+              <g className="my-custom-bottom-axis">
+                {props.ticks.map((tick, i) => {
+                  const tickX = tick.to.x;
+                  const tickY = tick.to.y + tickLabelSize + props.tickLength;
+                  return (
+                    <Group key={`vx-tick-${tick.value}-${i}`} className={'vx-axis-tick'}>
+                      <Line from={tick.from} to={tick.to} stroke={tickColor} />
+                      <text
+                        transform={`translate(${tickX}, ${tickY}) rotate(${tickRotate})`}
+                        fontSize={tickLabelSize}
+                        textAnchor="middle"
+                        fill={tickColor}
+                      >
+                        {tick.formattedValue}
+                      </text>
+                    </Group>
+                  );
+                })}
+                <text textAnchor="middle" transform={`translate(${axisCenter}, 50)`} fontSize="8">
+                  {props.label}
+                </text>
+              </g>
+            );
+          }}
+        </AxisBottom>
+      </Group>
     </svg>
   );
 };

--- a/packages/vx-demo/components/tiles/axis.js
+++ b/packages/vx-demo/components/tiles/axis.js
@@ -4,7 +4,7 @@ import { Group } from '@vx/group';
 import { curveBasis } from '@vx/curve';
 import { GradientOrangeRed } from '@vx/gradient';
 import { genDateValue } from '@vx/mock-data';
-import { AxisLeft, AxisBottom } from '@vx/axis';
+import { AxisLeft, AxisRight, AxisBottom } from '@vx/axis';
 import { AreaClosed, LinePath, Line } from '@vx/shape';
 import { scaleTime, scaleLinear } from '@vx/scale';
 import { extent, max } from 'd3-array';
@@ -94,7 +94,7 @@ export default ({ width, height, margin }) => {
         scale={yScale}
         hideZero
         numTicks={numTicksForHeight(height)}
-        label="value"
+        label="Axis Left Label"
         labelProps={{
           fill: '#8e205f',
           textAnchor: 'middle',
@@ -115,12 +115,36 @@ export default ({ width, height, margin }) => {
           <text {...tickProps}>{formattedValue}</text>
         )}
       />
+      <AxisRight
+        top={margin.top}
+        left={xMax + margin.left}
+        scale={yScale}
+        hideZero
+        numTicks={numTicksForHeight(height)}
+        label="Axis Right Label"
+        labelProps={{
+          fill: '#8e205f',
+          textAnchor: 'middle',
+          fontSize: 12,
+          fontFamily: 'Arial'
+        }}
+        stroke="#1b1a1e"
+        tickStroke="#8e205f"
+        tickLabelProps={(value, index) => ({
+          fill: '#8e205f',
+          textAnchor: 'start',
+          fontSize: 10,
+          fontFamily: 'Arial',
+          dx: '0.25em',
+          dy: '0.25em'
+        })}
+      />
       <AxisBottom
         top={height - margin.bottom}
         left={margin.left}
         scale={xScale}
         numTicks={numTicksForWidth(width)}
-        label="time"
+        label="Time"
       >
         {props => {
           const tickLabelSize = 10;

--- a/packages/vx-demo/pages/axis.js
+++ b/packages/vx-demo/pages/axis.js
@@ -104,95 +104,97 @@ export default ({ width, height, margin }) => {
           curve={curveBasis}
         />
       </Group>
-      <AxisLeft
-        top={margin.top}
-        left={margin.left}
-        scale={yScale}
-        hideZero
-        numTicks={numTicksForHeight(height)}
-        label="Axis Left Label"
-        labelProps={{
-          fill: '#8e205f',
-          textAnchor: 'middle',
-          fontSize: 12,
-          fontFamily: 'Arial'
-        }}
-        stroke="#1b1a1e"
-        tickStroke="#8e205f"
-        tickLabelProps={(value, index) => ({
-          fill: '#8e205f',
-          textAnchor: 'end',
-          fontSize: 10,
-          fontFamily: 'Arial',
-          dx: '-0.25em',
-          dy: '0.25em'
-        })}
-        tickComponent={({ formattedValue, ...tickProps }) => (
-          <text {...tickProps}>{formattedValue}</text>
-        )}
-      />
-      <AxisRight
-        top={margin.top}
-        left={xMax + margin.left}
-        scale={yScale}
-        hideZero
-        numTicks={numTicksForHeight(height)}
-        label="Axis Right Label"
-        labelProps={{
-          fill: '#8e205f',
-          textAnchor: 'middle',
-          fontSize: 12,
-          fontFamily: 'Arial'
-        }}
-        stroke="#1b1a1e"
-        tickStroke="#8e205f"
-        tickLabelProps={(value, index) => ({
-          fill: '#8e205f',
-          textAnchor: 'start',
-          fontSize: 10,
-          fontFamily: 'Arial',
-          dx: '0.25em',
-          dy: '0.25em'
-        })}
-      />
-      <AxisBottom
-        top={height - margin.bottom}
-        left={margin.left}
-        scale={xScale}
-        numTicks={numTicksForWidth(width)}
-        label="Time"
-      >
-        {props => {
-          const tickLabelSize = 10;
-          const tickRotate = 45;
-          const tickColor = '#8e205f';
-          const axisCenter = (props.axisToPoint.x - props.axisFromPoint.x) / 2;
-          return (
-            <g className="my-custom-bottom-axis">
-              {props.ticks.map((tick, i) => {
-                const tickX = tick.to.x;
-                const tickY = tick.to.y + tickLabelSize + props.tickLength;
-                return (
-                  <Group key={\`vx-tick-\${tick.value}-\${i}\`} className={'vx-axis-tick'}>
-                    <Line from={tick.from} to={tick.to} stroke={tickColor} />
-                    <text
-                      transform={\`translate(\${tickX}, \${tickY}) rotate(\${tickRotate})\`}
-                      fontSize={tickLabelSize}
-                      textAnchor="middle"
-                      fill={tickColor}
-                    >
-                      {tick.formattedValue}
-                    </text>
-                  </Group>
-                );
-              })}
-              <text textAnchor="middle" transform={\`translate(\${axisCenter}, 50)\`} fontSize="8">
-                {props.label}
-              </text>
-            </g>
-          );
-        }}
-      </AxisBottom>
+      <Group left={margin.left}>
+        <AxisLeft
+          top={margin.top}
+          left={0}
+          scale={yScale}
+          hideZero
+          numTicks={numTicksForHeight(height)}
+          label="Axis Left Label"
+          labelProps={{
+            fill: '#8e205f',
+            textAnchor: 'middle',
+            fontSize: 12,
+            fontFamily: 'Arial'
+          }}
+          stroke="#1b1a1e"
+          tickStroke="#8e205f"
+          tickLabelProps={(value, index) => ({
+            fill: '#8e205f',
+            textAnchor: 'end',
+            fontSize: 10,
+            fontFamily: 'Arial',
+            dx: '-0.25em',
+            dy: '0.25em'
+          })}
+          tickComponent={({ formattedValue, ...tickProps }) => (
+            <text {...tickProps}>{formattedValue}</text>
+          )}
+        />
+        <AxisRight
+          top={margin.top}
+          left={xMax}
+          scale={yScale}
+          hideZero
+          numTicks={numTicksForHeight(height)}
+          label="Axis Right Label"
+          labelProps={{
+            fill: '#8e205f',
+            textAnchor: 'middle',
+            fontSize: 12,
+            fontFamily: 'Arial'
+          }}
+          stroke="#1b1a1e"
+          tickStroke="#8e205f"
+          tickLabelProps={(value, index) => ({
+            fill: '#8e205f',
+            textAnchor: 'start',
+            fontSize: 10,
+            fontFamily: 'Arial',
+            dx: '0.25em',
+            dy: '0.25em'
+          })}
+        />
+        <AxisBottom
+          top={height - margin.bottom}
+          left={0}
+          scale={xScale}
+          numTicks={numTicksForWidth(width)}
+          label="Time"
+        >
+          {props => {
+            const tickLabelSize = 10;
+            const tickRotate = 45;
+            const tickColor = '#8e205f';
+            const axisCenter = (props.axisToPoint.x - props.axisFromPoint.x) / 2;
+            return (
+              <g className="my-custom-bottom-axis">
+                {props.ticks.map((tick, i) => {
+                  const tickX = tick.to.x;
+                  const tickY = tick.to.y + tickLabelSize + props.tickLength;
+                  return (
+                    <Group key={\`vx-tick-\${tick.value}-\${i}\`} className={'vx-axis-tick'}>
+                      <Line from={tick.from} to={tick.to} stroke={tickColor} />
+                      <text
+                        transform={\`translate(\${tickX}, \${tickY}) rotate(\${tickRotate})\`}
+                        fontSize={tickLabelSize}
+                        textAnchor="middle"
+                        fill={tickColor}
+                      >
+                        {tick.formattedValue}
+                      </text>
+                    </Group>
+                  );
+                })}
+                <text textAnchor="middle" transform={\`translate(\${axisCenter}, 50)\`} fontSize="8">
+                  {props.label}
+                </text>
+              </g>
+            );
+          }}
+        </AxisBottom>
+      </Group>
     </svg>
   );
 };`}

--- a/packages/vx-demo/pages/axis.js
+++ b/packages/vx-demo/pages/axis.js
@@ -9,8 +9,8 @@ export default () => {
       title="Axis"
       margin={{
         top: 20,
-        left: 60,
-        right: 40,
+        left: 70,
+        right: 70,
         bottom: 60
       }}
     >
@@ -20,7 +20,7 @@ import { Group } from '@vx/group';
 import { curveBasis } from '@vx/curve';
 import { GradientOrangeRed } from '@vx/gradient';
 import { genDateValue } from '@vx/mock-data';
-import { AxisLeft, AxisBottom } from '@vx/axis';
+import { AxisLeft, AxisRight, AxisBottom } from '@vx/axis';
 import { AreaClosed, LinePath, Line } from '@vx/shape';
 import { scaleTime, scaleLinear } from '@vx/scale';
 import { extent, max } from 'd3-array';
@@ -54,12 +54,12 @@ export default ({ width, height, margin }) => {
   // scales
   const xScale = scaleTime({
     range: [0, xMax],
-    domain: extent(data, x),
+    domain: extent(data, x)
   });
   const yScale = scaleLinear({
     range: [yMax, 0],
     domain: [0, max(data, y)],
-    nice: true,
+    nice: true
   });
 
   // scale tick formats
@@ -68,20 +68,8 @@ export default ({ width, height, margin }) => {
 
   return (
     <svg width={width} height={height}>
-      <GradientOrangeRed
-        id="linear"
-        vertical={false}
-        fromOpacity={0.8}
-        toOpacity={0.3}
-      />
-      <rect
-        x={0}
-        y={0}
-        width={width}
-        height={height}
-        fill="#f4419f"
-        rx={14}
-      />
+      <GradientOrangeRed id="linear" vertical={false} fromOpacity={0.8} toOpacity={0.3} />
+      <rect x={0} y={0} width={width} height={height} fill="#f4419f" rx={14} />
       <Grid
         top={margin.top}
         left={margin.left}
@@ -122,12 +110,12 @@ export default ({ width, height, margin }) => {
         scale={yScale}
         hideZero
         numTicks={numTicksForHeight(height)}
-        label="value"
+        label="Axis Left Label"
         labelProps={{
           fill: '#8e205f',
           textAnchor: 'middle',
           fontSize: 12,
-          fontFamily: 'Arial',
+          fontFamily: 'Arial'
         }}
         stroke="#1b1a1e"
         tickStroke="#8e205f"
@@ -137,41 +125,56 @@ export default ({ width, height, margin }) => {
           fontSize: 10,
           fontFamily: 'Arial',
           dx: '-0.25em',
-          dy: '0.25em',
+          dy: '0.25em'
         })}
-        tickComponent={({ formattedValue, ...tickProps}) => (
+        tickComponent={({ formattedValue, ...tickProps }) => (
           <text {...tickProps}>{formattedValue}</text>
         )}
+      />
+      <AxisRight
+        top={margin.top}
+        left={xMax + margin.left}
+        scale={yScale}
+        hideZero
+        numTicks={numTicksForHeight(height)}
+        label="Axis Right Label"
+        labelProps={{
+          fill: '#8e205f',
+          textAnchor: 'middle',
+          fontSize: 12,
+          fontFamily: 'Arial'
+        }}
+        stroke="#1b1a1e"
+        tickStroke="#8e205f"
+        tickLabelProps={(value, index) => ({
+          fill: '#8e205f',
+          textAnchor: 'start',
+          fontSize: 10,
+          fontFamily: 'Arial',
+          dx: '0.25em',
+          dy: '0.25em'
+        })}
       />
       <AxisBottom
         top={height - margin.bottom}
         left={margin.left}
         scale={xScale}
         numTicks={numTicksForWidth(width)}
-        label="time"
+        label="Time"
       >
         {props => {
           const tickLabelSize = 10;
           const tickRotate = 45;
           const tickColor = '#8e205f';
-          const axisCenter =
-            (props.axisToPoint.x - props.axisFromPoint.x) / 2;
+          const axisCenter = (props.axisToPoint.x - props.axisFromPoint.x) / 2;
           return (
             <g className="my-custom-bottom-axis">
               {props.ticks.map((tick, i) => {
                 const tickX = tick.to.x;
-                const tickY =
-                  tick.to.y + tickLabelSize + props.tickLength;
+                const tickY = tick.to.y + tickLabelSize + props.tickLength;
                 return (
-                  <Group
-                    key={\`vx-tick-\${tick.value}-\${i}\`}
-                    className={'vx-axis-tick'}
-                  >
-                    <Line
-                      from={tick.from}
-                      to={tick.to}
-                      stroke={tickColor}
-                    />
+                  <Group key={\`vx-tick-\${tick.value}-\${i}\`} className={'vx-axis-tick'}>
+                    <Line from={tick.from} to={tick.to} stroke={tickColor} />
                     <text
                       transform={\`translate(\${tickX}, \${tickY}) rotate(\${tickRotate})\`}
                       fontSize={tickLabelSize}
@@ -183,11 +186,7 @@ export default ({ width, height, margin }) => {
                   </Group>
                 );
               })}
-              <text
-                textAnchor="middle"
-                transform={\`translate(\${axisCenter}, 50)\`}
-                fontSize="8"
-              >
+              <text textAnchor="middle" transform={\`translate(\${axisCenter}, 50)\`} fontSize="8">
                 {props.label}
               </text>
             </g>


### PR DESCRIPTION
#### :memo: Documentation

- [demo] add `<AxisRight />` to /axis demo tile

<img width="839" alt="screen shot 2018-04-28 at 1 22 52 pm" src="https://user-images.githubusercontent.com/339208/39399188-65d80d7a-4ae7-11e8-9711-b86280d7fcb4.png">

Confirmed fixes for: https://github.com/hshoff/vx/issues/276 + https://github.com/hshoff/vx/issues/267