### PR TITLE
[tooltip][TooltipWithBounds] don't pass getRects to Tooltip

### DIFF
--- a/packages/vx-tooltip/src/tooltips/TooltipWithBounds.js
+++ b/packages/vx-tooltip/src/tooltips/TooltipWithBounds.js
@@ -21,6 +21,7 @@ function TooltipWithBounds({
   offsetTop = 10,
   rect,
   parentRect,
+  getRects,
   children,
   style,
   ...otherProps


### PR DESCRIPTION
#### :bug: Bug Fix
Fixes #289 by not passing the `getRects` func prop from `withBoundingRects` to `Tooltip`. 

Tested locally to ensure we no longer get the React error reported (`React does not recognize the 'getRects' prop on a DOM element`)

cc @emepyc