### PR TITLE
Parity/shape pie

### DIFF
--- a/packages/vx-shape/src/shapes/Pie.js
+++ b/packages/vx-shape/src/shapes/Pie.js
@@ -31,7 +31,9 @@ export default function Pie({
   if (pieSort) pie.sort(pieSort);
   if (pieSortValues) pie.sortValues(pieSortValues);
   if (pieValue) pie.value(pieValue);
-  if (padAngle) pie.padAngle(padAngle);
+  if (padAngle != null) pie.padAngle(padAngle);
+  if (startAngle != null) pie.startAngle(startAngle);
+  if (endAngle != null) pie.endAngle(endAngle);
   const arcs = pie(data);
   return (
     <Group className="vx-pie-arcs-group" top={top} left={left}>

--- a/packages/vx-shape/src/shapes/Pie.js
+++ b/packages/vx-shape/src/shapes/Pie.js
@@ -18,6 +18,7 @@ export default function Pie({
   padAngle,
   padRadius,
   pieSort,
+  pieSortValues,
   pieValue,
   ...restProps
 }) {
@@ -28,6 +29,7 @@ export default function Pie({
   if (padRadius) path.padRadius(padRadius);
   const pie = d3Pie();
   if (pieSort) pie.sort(pieSort);
+  if (pieSortValues) pie.sortValues(pieSortValues);
   if (pieValue) pie.value(pieValue);
   if (padAngle) pie.padAngle(padAngle);
   const arcs = pie(data);

--- a/packages/vx-shape/test/Pie.test.js
+++ b/packages/vx-shape/test/Pie.test.js
@@ -10,6 +10,17 @@ describe('<Pie />', () => {
     expect(Pie).toBeDefined();
   });
 
+  test('it should not break on sort callbacks', () => {
+    expect(() => {
+      PieWrapper({ pieSort: () => 0, pieSortValues: () => 0 });
+    }).not.toThrow();
+  });
+
+  test('it should not break on invalid sort callbacks', () => {
+    expect(() => PieWrapper({ pieSort: 12 })).toThrow();
+    expect(() => PieWrapper({ pieSortValues: 12 })).toThrow();
+  });
+
   test('it should have the .vx-pie-arcs-group class', () => {
     expect(PieWrapper().prop('className')).toBe('vx-pie-arcs-group');
   });


### PR DESCRIPTION
#### :boom: Breaking Changes

No breaking change.

#### :rocket: Enhancements

- Add support for `startAngle` and `endAngle` props in the `Pie` component.
- Add support for `pieSortValues` prop which maps to D3’s `pie.sortValues()` which let the developer sort by extracted values instead of data.

#### :memo: Documentation

- No documentation change required since the `Pie` component is not documented at all!

#### :bug: Bug Fix

- Add _actual_ support for `startAngle` and `endAngle` props in the `Pie` component.
- Check for `!= null` for numeric props in `Pie` component. (See commit message)

#### ✅ Tests

- Add tests for sort callbacks in the `Pie` component.
