### PR TITLE
remove external-helpers plugin from babel:build, export getStringWidth() util. fixes #300

### DIFF
--- a/packages/vx-annotation/package.json
+++ b/packages/vx-annotation/package.json
@@ -5,14 +5,12 @@
   "sideEffects": false,
   "main": "dist/vx-annotation.umd.js",
   "module": "dist/vx-annotation.es.js",
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
@@ -20,13 +18,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -70,9 +62,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-axis/package.json
+++ b/packages/vx-axis/package.json
@@ -8,25 +8,17 @@
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -71,9 +63,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-bounds/package.json
+++ b/packages/vx-bounds/package.json
@@ -8,24 +8,17 @@
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "visualizations", "charts"],
   "author": "Chris Williams @williaster",
   "license": "MIT",
   "bugs": {
@@ -66,9 +59,6 @@
     "react-dom": "^15.0.0-0 || ^16.0.0-0"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-boxplot/package.json
+++ b/packages/vx-boxplot/package.json
@@ -5,14 +5,12 @@
   "sideEffects": false,
   "main": "dist/vx-boxplot.umd.js",
   "module": "dist/vx-boxplot.es.js",
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
@@ -20,13 +18,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@conglei",
   "license": "MIT",
   "bugs": {
@@ -67,9 +59,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-brush/package.json
+++ b/packages/vx-brush/package.json
@@ -8,25 +8,17 @@
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "d3",
-    "react",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "d3", "react", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -67,9 +59,6 @@
     "recompose": "^0.23.1"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-clip-path/package.json
+++ b/packages/vx-clip-path/package.json
@@ -8,26 +8,17 @@
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts",
-    "svg"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts", "svg"],
   "author": "Chris Williams @williaster",
   "license": "MIT",
   "bugs": {
@@ -64,9 +55,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-curve/package.json
+++ b/packages/vx-curve/package.json
@@ -6,24 +6,16 @@
   "main": "dist/vx-curve.umd.js",
   "module": "dist/vx-curve.es.js",
   "repository": "https://github.com/hshoff/vx",
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualization",
-    "chart"
-  ],
+  "keywords": ["vx", "react", "d3", "visualization", "chart"],
   "author": "@hshoff",
   "license": "MIT",
   "dependencies": {
@@ -56,9 +48,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-drag/package.json
+++ b/packages/vx-drag/package.json
@@ -8,25 +8,17 @@
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -63,10 +55,7 @@
     "react": "^15.0.0-0 || ^16.0.0-0"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   },
   "dependencies": {
     "@vx/event": "0.0.165-beta.0",

--- a/packages/vx-event/package.json
+++ b/packages/vx-event/package.json
@@ -8,25 +8,17 @@
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "d3",
-    "react",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "d3", "react", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -63,9 +55,6 @@
     "@vx/point": "0.0.165-beta.0"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-geo/package.json
+++ b/packages/vx-geo/package.json
@@ -5,14 +5,12 @@
   "sideEffects": false,
   "main": "dist/vx-geo.umd.js",
   "module": "dist/vx-geo.es.js",
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
@@ -20,14 +18,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts",
-    "geo"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts", "geo"],
   "author": "@nschnierer",
   "license": "MIT",
   "bugs": {
@@ -71,9 +62,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-glyph/package.json
+++ b/packages/vx-glyph/package.json
@@ -8,25 +8,17 @@
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -68,9 +60,6 @@
     "d3-shape": "^1.2.0"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-gradient/package.json
+++ b/packages/vx-gradient/package.json
@@ -9,24 +9,16 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -67,9 +59,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-grid/package.json
+++ b/packages/vx-grid/package.json
@@ -5,13 +5,12 @@
   "sideEffects": false,
   "main": "dist/vx-grid.umd.js",
   "module": "dist/vx-grid.es.js",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
@@ -19,13 +18,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -68,9 +61,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-group/package.json
+++ b/packages/vx-group/package.json
@@ -8,26 +8,17 @@
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts",
-    "svg"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts", "svg"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -67,9 +58,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-heatmap/package.json
+++ b/packages/vx-heatmap/package.json
@@ -9,24 +9,16 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -67,9 +59,6 @@
     "classnames": "^2.2.5"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-hierarchy/package.json
+++ b/packages/vx-hierarchy/package.json
@@ -5,14 +5,12 @@
   "sideEffects": false,
   "main": "dist/vx-hierarchy.umd.js",
   "module": "dist/vx-hierarchy.es.js",
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
@@ -20,13 +18,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "d3",
-    "react",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "d3", "react", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -69,9 +61,6 @@
     "react": "^15.0.0-0 || ^16.0.0-0"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-legend/package.json
+++ b/packages/vx-legend/package.json
@@ -5,14 +5,12 @@
   "sideEffects": false,
   "main": "dist/vx-legend.umd.js",
   "module": "dist/vx-legend.es.js",
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
@@ -20,13 +18,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -68,9 +60,6 @@
     "prop-types": "^15.5.10"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-marker/package.json
+++ b/packages/vx-marker/package.json
@@ -5,14 +5,12 @@
   "sideEffects": false,
   "main": "dist/vx-marker.umd.js",
   "module": "dist/vx-marker.es.js",
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
@@ -20,13 +18,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -68,9 +60,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-mock-data/package.json
+++ b/packages/vx-mock-data/package.json
@@ -8,25 +8,17 @@
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -63,9 +55,6 @@
     "d3-random": "^1.0.3"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-network/package.json
+++ b/packages/vx-network/package.json
@@ -6,23 +6,16 @@
   "main": "dist/vx-network.umd.js",
   "module": "dist/vx-network.es.js",
   "repository": "https://github.com/hshoff/vx",
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "keywords": [
-    "vx",
-    "data",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "data", "visualizations", "charts"],
   "author": "@andyfang_dz",
   "license": "MIT",
   "devDependencies": {
@@ -60,9 +53,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-pattern/package.json
+++ b/packages/vx-pattern/package.json
@@ -5,14 +5,12 @@
   "sideEffects": false,
   "main": "dist/vx-pattern.umd.js",
   "module": "dist/vx-pattern.es.js",
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
@@ -20,13 +18,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualization",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualization", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -67,9 +59,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-point/package.json
+++ b/packages/vx-point/package.json
@@ -6,23 +6,16 @@
   "main": "dist/vx-point.umd.js",
   "module": "dist/vx-point.es.js",
   "repository": "https://github.com/hshoff/vx",
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "keywords": [
-    "vx",
-    "data",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "data", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "devDependencies": {
@@ -52,9 +45,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-responsive/package.json
+++ b/packages/vx-responsive/package.json
@@ -5,14 +5,12 @@
   "sideEffects": false,
   "main": "dist/vx-responsive.umd.js",
   "module": "dist/vx-responsive.es.js",
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins lodash,external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins lodash",
     "prepublish": "npm run build",
     "test": "jest"
   },
@@ -20,13 +18,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -69,9 +61,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-scale/package.json
+++ b/packages/vx-scale/package.json
@@ -8,25 +8,17 @@
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -63,9 +55,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-shape/package.json
+++ b/packages/vx-shape/package.json
@@ -6,24 +6,16 @@
   "main": "dist/vx-shape.umd.js",
   "module": "dist/vx-shape.es.js",
   "repository": "https://github.com/hshoff/vx",
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "dependencies": {
@@ -67,9 +59,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-stats/package.json
+++ b/packages/vx-stats/package.json
@@ -5,14 +5,12 @@
   "sideEffects": false,
   "main": "dist/vx-stats.umd.js",
   "module": "dist/vx-stats.es.js",
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
@@ -20,13 +18,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@conglei",
   "license": "MIT",
   "bugs": {
@@ -69,9 +61,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-text/package.json
+++ b/packages/vx-text/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins lodash,external-helpers",
+    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins lodash",
     "prepublish": "npm run build",
     "test": "jest"
   },

--- a/packages/vx-text/src/index.js
+++ b/packages/vx-text/src/index.js
@@ -1,1 +1,2 @@
 export { default as Text } from './Text';
+export { default as getStringWidth } from './util/getStringWidth';

--- a/packages/vx-text/test/Text.test.js
+++ b/packages/vx-text/test/Text.test.js
@@ -1,6 +1,11 @@
 import React from 'react';
-import { shallow, render } from 'enzyme';
-import { Text } from '../src';
+import { Text, getStringWidth } from '../src';
+
+describe('getStringWidth()', () => {
+  it('should be defined', () => {
+    expect(getStringWidth).toBeDefined();
+  });
+});
 
 // TODO: Fix tests (jsdom does not support getComputedTextLength() or getBoundingClientRect()).  Maybe use puppeteer
 

--- a/packages/vx-threshold/package.json
+++ b/packages/vx-threshold/package.json
@@ -6,24 +6,16 @@
   "main": "dist/vx-threshold.umd.js",
   "module": "dist/vx-threshold.es.js",
   "repository": "https://github.com/hshoff/vx",
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "dependencies": {
@@ -62,9 +54,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-tooltip/package.json
+++ b/packages/vx-tooltip/package.json
@@ -5,14 +5,12 @@
   "sideEffects": false,
   "main": "dist/vx-tooltip.umd.js",
   "module": "dist/vx-tooltip.es.js",
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
@@ -20,13 +18,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -68,9 +60,6 @@
     "access": "public"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-voronoi/package.json
+++ b/packages/vx-voronoi/package.json
@@ -8,25 +8,17 @@
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "Chris Williams @williaster",
   "license": "MIT",
   "bugs": {
@@ -69,9 +61,6 @@
     "react": "^15.0.0-0 || ^16.0.0-0"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-vx/package.json
+++ b/packages/vx-vx/package.json
@@ -5,14 +5,12 @@
   "sideEffects": false,
   "main": "dist/vx-vx.umd.js",
   "module": "dist/vx-vx.es.js",
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
@@ -20,13 +18,7 @@
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -94,9 +86,6 @@
     "@vx/zoom": "0.0.165-beta.0"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }

--- a/packages/vx-zoom/package.json
+++ b/packages/vx-zoom/package.json
@@ -8,25 +8,17 @@
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env --plugins external-helpers",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets stage-0,react,env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -60,9 +52,6 @@
     "rollup-plugin-uglify": "^4.0.0"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/enzyme-setup.js"
-    ]
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/enzyme-setup.js"]
   }
 }


### PR DESCRIPTION
fixes #300

#### :rocket: Enhancements

- [text] export getStringWidth() util

#### :house: Internal

- [build] remove external-helpers plugin from babel:build
