### PR TITLE
Adding the Natural Earth projection

### DIFF
--- a/packages/vx-geo/Readme.md
+++ b/packages/vx-geo/Readme.md
@@ -97,3 +97,28 @@ Same properties as Mercator.
 |      Name       |       Default       |   Type   |                                                 Description                                                 |
 |:--------------- |:------------------- |:-------- |:----------------------------------------------------------------------------------------------------------- |
 | className       | `vx-albers`         | string   | The class name for the `path` element.                                                                      |
+
+## `<NaturalEarth />`
+
+The Natural Earth projection.
+
+### Example
+
+```js
+<NaturalEarth
+  data={myData}
+  scale={myScale}
+  translate={[width / 2, height / 2]}
+  fill={(feature) => '#aaaaaa'}
+  onClick={data => event => {
+    alert(`Clicked!`);
+  }}
+/>
+```
+
+### Properties
+Same properties as Mercator.
+
+|      Name       |       Default                 |   Type   |                                                 Description                                                 |
+|:--------------- |:----------------------------- |:-------- |:----------------------------------------------------------------------------------------------------------- |
+| className       | `vx-geo-naturalEarth`         | string   | The class name for the `path` element. 

--- a/packages/vx-geo/src/index.js
+++ b/packages/vx-geo/src/index.js
@@ -1,3 +1,4 @@
 export { default as Albers } from './projections/Albers';
 export { default as Mercator } from './projections/Mercator';
 export { default as Orthographic } from './projections/Orthographic';
+export { default as NaturalEarth } from './projections/NaturalEarth';

--- a/packages/vx-geo/src/projections/NaturalEarth.js
+++ b/packages/vx-geo/src/projections/NaturalEarth.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import Projection from './Projection';
+
+export default function NaturalEarth(props) {
+  return <Projection projection="naturalEarth" {...props} />;
+}

--- a/packages/vx-geo/src/projections/Projection.js
+++ b/packages/vx-geo/src/projections/Projection.js
@@ -4,13 +4,14 @@ import cx from 'classnames';
 import { Group } from '@vx/group';
 import additionalProps from '../util/additionalProps';
 import Graticule from '../graticule/Graticule';
-import { geoOrthographic, geoAlbers, geoMercator, geoPath } from 'd3-geo';
+import { geoOrthographic, geoAlbers, geoMercator, geoNaturalEarth1, geoPath } from 'd3-geo';
 
 // TODO: Implement all projections of d3-geo
 const projectionMapping = {
   orthographic: () => geoOrthographic(),
   albers: () => geoAlbers(),
-  mercator: () => geoMercator()
+  mercator: () => geoMercator(),
+  naturalEarth: () => geoNaturalEarth1()
 };
 
 /**


### PR DESCRIPTION
#### :boom: Breaking Changes

- No breaking changes

#### :rocket: Enhancements

- Adding the Natural Earth (1) projection from https://github.com/d3/d3-geo

#### :memo: Documentation

> The Natural Earth projection is a pseudocylindrical projection designed by Tom Patterson. It is neither conformal nor equal-area, but appealing to the eye for small-scale maps of the whole world.


