### PR TITLE
 [shape] pass d3 accessor arguments to the x and y props of LinePath, AreaClosed, and LinePath #295

### DIFF
--- a/packages/vx-shape/Readme.md
+++ b/packages/vx-shape/Readme.md
@@ -30,8 +30,8 @@ AreaClosed is a closed area under a curve.
 
 |      Name       |       Default       |   Type   |                                                 Description                                                 |
 |:--------------- |:------------------- |:-------- |:----------------------------------------------------------------------------------------------------------- |
-| x               |                     | function | A function that takes in a data element and returns the x value.                                            |
-| y               |                     | function | A function that takes in a data element and returns the y value.                                            |
+| x               |                     | function | The d3 [x function](https://github.com/d3/d3-shape#area_x).                                                 |
+| y               |                     | function | The d3 [y1 function](https://github.com/d3/d3-shape#area_y1).                                               |
 | xScale          |                     | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the xs.                  |
 | yScale          |                     | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the ys.                  |
 | data            |                     | array    | An array of x and y data.                                                                                   |
@@ -189,8 +189,8 @@ A more complicated line path. A `<LinePath />` is useful for making line graphs 
 | data            |              | array    | The data in x, y.                                                                                           |
 | xScale          |              | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the xs.                  |
 | yScale          |              | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the ys.                  |
-| x               |              | function | A function that takes in a data element and returns the x value.                                            |
-| y               |              | function | A function that takes in a data element and returns the y value.                                            |
+| x               |              | function | The d3 [x function](https://github.com/d3/d3-shape#line_x).                                                 |
+| y               |              | function | The d3 [y function](https://github.com/d3/d3-shape#line_y).                                                 |
 | defined         |              | function | A [function](https://github.com/d3/d3-shape/blob/master/README.md#line_defined) called by `line.defined()`. |
 | className       |              | string   | The class name for the `path` element.                                                                      |
 | stroke          | steelblue    | string   | The color of the stroke.                                                                                    |
@@ -198,7 +198,7 @@ A more complicated line path. A `<LinePath />` is useful for making line graphs 
 | strokeDasharray |              | array    | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                              |
 | fill            | none         | string   | The color of the fill for the `path` element.                                                               |
 | curve           | Curve.linear | function | The [curve function](https://github.com/hshoff/vx/tree/master/packages/vx-curve)                            |
-| glyph           |              | glyph    | [A glyph](https://github.com/hshoff/vx/tree/master/packages/vx-glyph) to be added to the line.               |
+| glyph           |              | glyph    | [A glyph](https://github.com/hshoff/vx/tree/master/packages/vx-glyph) to be added to the line.              |
 
 ## `<LineRadial />`
 

--- a/packages/vx-shape/src/shapes/Area.js
+++ b/packages/vx-shape/src/shapes/Area.js
@@ -51,12 +51,12 @@ export default function Area({
   ...restProps
 }) {
   const path = area();
-  if (x) path.x(d => xScale(x(d)));
-  if (x0) path.x0(d => xScale(x0(d)));
-  if (x1) path.x1(d => xScale(x1(d)));
-  if (y) path.y(d => yScale(y(d)));
-  if (y0) path.y0(d => yScale(y0(d)));
-  if (y1) path.y1(d => yScale(y1(d)));
+  if (x) path.x((...args) => xScale(x(...args)));
+  if (x0) path.x0((...args) => xScale(x0(...args)));
+  if (x1) path.x1((...args) => xScale(x1(...args)));
+  if (y) path.y((...args) => yScale(y(...args)));
+  if (y0) path.y0((...args) => yScale(y0(...args)));
+  if (y1) path.y1((...args) => yScale(y1(...args)));
   if (defined) path.defined(defined);
   if (curve) path.curve(curve);
   if (children) return children({ path });

--- a/packages/vx-shape/src/shapes/AreaClosed.js
+++ b/packages/vx-shape/src/shapes/AreaClosed.js
@@ -25,9 +25,9 @@ export default function AreaClosed({
   ...restProps
 }) {
   const path = area()
-    .x(d => xScale(x(d)))
+    .x((...args) => xScale(x(...args)))
     .y0(yScale.range()[0])
-    .y1(d => yScale(y(d)))
+    .y1((...args) => yScale(y(...args)))
     .defined(defined);
   if (curve) path.curve(curve);
   return (

--- a/packages/vx-shape/src/shapes/LinePath.js
+++ b/packages/vx-shape/src/shapes/LinePath.js
@@ -39,8 +39,8 @@ export default function LinePath({
   ...restProps
 }) {
   const path = line()
-    .x((d, i) => xScale(x(d, i)))
-    .y((d, i) => yScale(y(d, i)))
+    .x((...args) => xScale(x(...args)))
+    .y((...args) => yScale(y(...args)))
     .defined(defined)
     .curve(curve);
   if (children) return children({ path });


### PR DESCRIPTION
See #295 for an explanation of the issue and some related discussion about the components affected.
#### :rocket: Enhancements

- Updating accessors to pass all the arguments from D3 for LinePath, AreaClosed, and Area.
- Updating documentation for LinePath and AreaClosed to reflect the above changes. 
Note: Area has no current documentation to update.