### PR TITLE
[grid] include `build/` dir in package

### DIFF
--- a/packages/vx-grid/package.json
+++ b/packages/vx-grid/package.json
@@ -6,7 +6,8 @@
   "main": "dist/vx-grid.umd.js",
   "module": "dist/vx-grid.es.js",
   "files": [
-    "dist"
+    "dist",
+    "build"
   ],
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",


### PR DESCRIPTION
#### :bug: Bug Fix
I was updating all of the `@data-ui` deps to use the new build and encountered an issue with deep-importing from `@vx/grid` because the `build` directory was missing, I think due to it not being included under `files` in the `package.json`.

I looked in all of the other packages and didn't see `build` missing so this is probably the only case 👍 