### PR TITLE
[area-closed] add optional y0 for custom area fills

### DIFF
--- a/packages/vx-shape/src/shapes/AreaClosed.js
+++ b/packages/vx-shape/src/shapes/AreaClosed.js
@@ -11,6 +11,7 @@ AreaClosed.propTypes = {
 export default function AreaClosed({
   x,
   y,
+  y0,
   xScale,
   yScale,
   data,
@@ -26,7 +27,7 @@ export default function AreaClosed({
 }) {
   const path = area()
     .x((...args) => xScale(x(...args)))
-    .y0(yScale.range()[0])
+    .y0(y0 || yScale.range()[0])
     .y1((...args) => yScale(y(...args)))
     .defined(defined);
   if (curve) path.curve(curve);


### PR DESCRIPTION
#### :rocket: Enhancements

- Adds optional y0 for custom area fills
- Primary Example: show negative area as integral
- I know typical pattern is for y0 to be an accessor passed to yScale, which isn't flexible enough in this case. Interested to hear thoughts and happy to refactor to fit project patterns.

```
const stock = appleStock.slice(800).map((val, index) => ( index < 250
  ? val
  : { ...val, close: -val.close })
);

....

<AreaClosed
   data={stock}
   xScale={xScale}
   yScale={yScale}
   x={xStock}
   y={yStock}
   y0={Math.min(yScale(0), yScale.range()[0])}
   strokeWidth={1}
   stroke={'url(#gradient)'}
   fill={'url(#gradient)'}
/>
```

![negativeasintegral](https://user-images.githubusercontent.com/3825178/42525045-0bea3918-8427-11e8-8fbe-2506c0945513.gif)


