### PR TITLE
[shape] Add <BarGroupHorizontal /> component

### DIFF
--- a/packages/vx-demo/components/gallery.js
+++ b/packages/vx-demo/components/gallery.js
@@ -18,6 +18,7 @@ import Stacked from '../components/tiles/stacked';
 import MultiLine from '../components/tiles/multiline';
 import Axis from '../components/tiles/axis';
 import BarGroup from '../components/tiles/bargroup';
+import BarGroupHorizontal from '../components/tiles/bargrouphorizontal';
 import BarStack from '../components/tiles/barstack';
 import BarStackHorizontal from '../components/tiles/barstackhorizontal';
 import Heatmap from '../components/tiles/heatmap';
@@ -860,7 +861,27 @@ export default class Gallery extends React.Component {
               </div>
             </Link>
           </Tilt>
-          {false && <div className="gallery-item placeholder" />}
+          <Tilt className="tilt" options={{ max: 8, scale: 1 }}>
+            <Link prefetch href="/bargrouphorizontal">
+              <div className="gallery-item" style={{ background: '#612efb' }}>
+                <div className="image">
+                  <ParentSize>
+                    {({ width, height }) => (
+                      <BarGroupHorizontal width={width} height={height + detailsHeight} />
+                    )}
+                  </ParentSize>
+                </div>
+                <div className="details" style={{ color: '#e5fd3d' }}>
+                  <div className="title">Bar Group Horizontal</div>
+                  <div className="description">
+                    <pre>{`<Shape.BarGroupHorizontal />`}</pre>
+                  </div>
+                </div>
+              </div>
+            </Link>
+          </Tilt>
+          <div className="gallery-item placeholder" />
+          <div className="gallery-item placeholder" />
         </div>
 
         <div>

--- a/packages/vx-demo/components/tiles/bargrouphorizontal.js
+++ b/packages/vx-demo/components/tiles/bargrouphorizontal.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import { BarGroupHorizontal } from '@vx/shape';
+import { Group } from '@vx/group';
+import { AxisLeft } from '@vx/axis';
+import { cityTemperature } from '@vx/mock-data';
+import { scaleBand, scaleLinear, scaleOrdinal } from '@vx/scale';
+import { timeParse, timeFormat } from 'd3-time-format';
+import { extent, max } from 'd3-array';
+
+const data = cityTemperature.slice(0, 4);
+const keys = Object.keys(data[0]).filter(d => d !== 'date');
+const parseDate = timeParse('%Y%m%d');
+const format = timeFormat('%b %d');
+const formatDate = date => format(parseDate(date));
+
+// accessors
+const y0 = d => d.date;
+const x = d => d.value;
+
+export default ({
+  width,
+  height,
+  events = false,
+  margin = {
+    top: 20,
+    left: 50,
+    right: 10,
+    bottom: 0
+  }
+}) => {
+  if (width < 10) return null;
+
+  // bounds
+  const xMax = width - margin.left - margin.right;
+  const yMax = height - 100;
+
+  // // scales
+  const y0Scale = scaleBand({
+    rangeRound: [0, yMax],
+    domain: data.map(y0),
+    padding: 0.2,
+    tickFormat: () => val => formatDate(val)
+  });
+
+  const y1Scale = scaleBand({
+    rangeRound: [0, y0Scale.bandwidth()],
+    domain: keys,
+    padding: 0.1
+  });
+
+  const xScale = scaleLinear({
+    rangeRound: [xMax, 0],
+    domain: [
+      0,
+      max(data, d => {
+        return max(keys, key => d[key]);
+      })
+    ]
+  });
+
+  const zScale = scaleOrdinal({
+    domain: keys,
+    range: ['#aeeef8', '#e5fd3d', '#9caff6']
+  });
+
+  return (
+    <svg width={width} height={height}>
+      <rect x={0} y={0} width={width} height={height} fill="#612efb" rx={14} />
+      <Group top={margin.top} left={margin.left}>
+        <BarGroupHorizontal
+          data={data}
+          keys={keys}
+          width={xMax}
+          y0={y0}
+          y0Scale={y0Scale}
+          y1Scale={y1Scale}
+          xScale={xScale}
+          zScale={zScale}
+          rx={4}
+          onClick={data => event => {
+            if (!events) return;
+            alert(`clicked: ${JSON.stringify(data)}`);
+          }}
+        />
+        <AxisLeft
+          scale={y0Scale}
+          stroke="#e5fd3d"
+          tickStroke="#e5fd3d"
+          hideAxisLine
+          tickLabelProps={(value, index) => ({
+            fill: '#e5fd3d',
+            fontSize: 11,
+            textAnchor: 'end',
+            dy: '0.33em'
+          })}
+        />
+      </Group>
+    </svg>
+  );
+};

--- a/packages/vx-demo/pages/bargrouphorizontal.js
+++ b/packages/vx-demo/pages/bargrouphorizontal.js
@@ -1,0 +1,116 @@
+import React from 'react';
+import Show from '../components/show';
+import BarGroupHorizontal from '../components/tiles/bargrouphorizontal';
+
+export default () => {
+  return (
+    <Show
+      events={true}
+      margin={{ top: 45, left: 60, right: 20, bottom: 0 }}
+      component={BarGroupHorizontal}
+      title="Bar Group Horizontal"
+    >
+      {`import React from 'react';
+import { BarGroupHorizontal } from '@vx/shape';
+import { Group } from '@vx/group';
+import { AxisLeft } from '@vx/axis';
+import { cityTemperature } from '@vx/mock-data';
+import { scaleBand, scaleLinear, scaleOrdinal } from '@vx/scale';
+import { timeParse, timeFormat } from 'd3-time-format';
+import { extent, max } from 'd3-array';
+
+const data = cityTemperature.slice(0, 4);
+const keys = Object.keys(data[0]).filter(d => d !== 'date');
+const parseDate = timeParse('%Y%m%d');
+const format = timeFormat('%b %d');
+const formatDate = date => format(parseDate(date));
+
+// accessors
+const y0 = d => d.date;
+const x = d => d.value;
+
+export default ({
+  width,
+  height,
+  events = false,
+  margin = {
+    top: 20,
+    left: 50,
+    right: 10,
+    bottom: 0
+  },
+}) => {
+  if (width < 10) return null;
+
+  // bounds
+  const xMax = width - margin.left - margin.right;
+  const yMax = height - 100
+
+  // // scales
+  const y0Scale = scaleBand({
+    rangeRound: [0, yMax],
+    domain: data.map(y0),
+    padding: 0.2,
+    tickFormat: () => val => formatDate(val)
+  });
+
+  const y1Scale = scaleBand({
+    rangeRound: [0, y0Scale.bandwidth()],
+    domain: keys,
+    padding: 0.1
+  });
+
+  const xScale = scaleLinear({
+    rangeRound: [xMax, 0],
+    domain: [
+      0,
+      max(data, d => {
+        return max(keys, key => d[key]);
+      })
+    ]
+  });
+
+  const zScale = scaleOrdinal({
+    domain: keys,
+    range: ['#aeeef8', '#e5fd3d', '#9caff6']
+  });
+
+  return (
+    <svg width={width} height={height}>
+      <rect x={0} y={0} width={width} height={height} fill='#612efb' rx={14} />
+      <Group top={margin.top} left={margin.left}>
+        <BarGroupHorizontal
+          data={data}
+          keys={keys}
+          width={xMax}
+          y0={y0}
+          y0Scale={y0Scale}
+          y1Scale={y1Scale}
+          xScale={xScale}
+          zScale={zScale}
+          rx={4}
+          onClick={data => event => {
+            if (!events) return;
+            alert(\`clicked: \${JSON.stringify(data)}\`);
+          }}
+        />
+        <AxisLeft
+          scale={y0Scale}
+          stroke="#e5fd3d"
+          tickStroke="#e5fd3d"
+          hideAxisLine
+          tickLabelProps={(value, index) => ({
+            fill: '#e5fd3d',
+            fontSize: 11,
+            textAnchor: 'end',
+            dy: '0.33em'
+          })}
+        />
+      </Group>
+    </svg>
+  );
+};
+`}
+    </Show>
+  );
+};

--- a/packages/vx-shape/Readme.md
+++ b/packages/vx-shape/Readme.md
@@ -136,6 +136,73 @@ A simple rectangle (a `<rect>` element) to use in your graphs.
 | strokeMiterlimit |           | number | The svg [Miterlimit](https://mzl.la/2pLVE13) of the stroke.    |
 | strokeOpacity    |           | number | The svg opacity.                                               |
 
+## `<BarGroup />`
+
+![BarGroup Example](https://i.imgur.com/Ef9fVqe.png)
+
+```js
+<BarGroup
+  data={data}
+  keys={keys}
+  height={yMax}
+  x0={x0}
+  x0Scale={x0Scale}
+  x1Scale={x1Scale}
+  yScale={yScale}
+  zScale={zScale}
+  rx={4}
+/>
+```
+
+### Properties
+|       Name       |  Default  |  Type    | Description                                                                                                                     |
+|:---------------- |:--------- |:-------- |:------------------------------------------------------------------------------------------------------------------------------- |
+| data             |           | array    | An array of data elements.                                                                                                      |
+| className        |           | string   | The class name for the `path` element.                                                                                          |
+| top              |           | number   | The margin on top.                                                                                                              |
+| left             |           | number   | The margin on the left.                                                                                                         |
+| x0               |           | function | xs accessor function.                                                                                                           |
+| x0Scale          |           | function | A [scale band function](https://github.com/hshoff/vx/tree/master/packages/vx-scale#band-scaling) for the bar group.             |
+| x1Scale          |           | function | A [scale band function](https://github.com/hshoff/vx/tree/master/packages/vx-scale#band-scaling) for each bar within the group. |
+| yScale           |           | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the ys.                                      |
+| zScale           |           | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the keys.                                    |
+| keys             |           | array    | A list of data keys                                                                                                             |
+| height           |           | number   | The pixel height of the bar group.                                                                                              |
+
+
+## `<BarGroupHorizontal />`
+
+![BarGroupHorizontal Example](https://i.imgur.com/RDBJewO.png)
+
+```js
+<BarGroupHorizontal
+  data={data}
+  keys={keys}
+  width={xMax}
+  y0={y0}
+  y0Scale={y0Scale}
+  y1Scale={y1Scale}
+  xScale={xScale}
+  zScale={zScale}
+  rx={4}
+/>
+```
+
+### Properties
+|       Name       |  Default  |  Type    | Description                                                                                                                     |
+|:---------------- |:--------- |:-------- |:------------------------------------------------------------------------------------------------------------------------------- |
+| data             |           | array    | An array of data elements.                                                                                                      |
+| className        |           | string   | The class name for the `path` element.                                                                                          |
+| top              |           | number   | The margin on top.                                                                                                              |
+| left             |           | number   | The margin on the left.                                                                                                         |
+| y0               |           | function | ys accessor function.                                                                                                           |
+| y0Scale          |           | function | A [scale band function](https://github.com/hshoff/vx/tree/master/packages/vx-scale#band-scaling) for the bar group.             |
+| y1Scale          |           | function | A [scale band function](https://github.com/hshoff/vx/tree/master/packages/vx-scale#band-scaling) for each bar within the group. |
+| xScale           |           | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the xs.                                      |
+| zScale           |           | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the keys.                                    |
+| keys             |           | array    | A list of data keys                                                                                                             |
+| height           |           | number   | The pixel height of the bar group.                                                                                              |
+
 ## `<Line />`
 
 A simple line. Good for drawing in the sand.
@@ -274,6 +341,8 @@ A more complicated line path. A `<LinePath />` is useful for making line graphs 
 + [`<AreaClosed />`](https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/AreaClosed.js)
 + [`<AreaStack />`](https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/AreaStack.js)
 + [`<Bar />`](https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/Bar.js)
++ [`<BarGroup />`](https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/BarGroup.js)
++ [`<BarGroupHorizontal />`](https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/BarGroupHorizontal.js)
 + [`<Line />`](https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/Line.js)
 + [`<LinePath />`](https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/LinePath.js)
 + [`<LineRadial />`](https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/LineRadial.js)

--- a/packages/vx-shape/src/index.js
+++ b/packages/vx-shape/src/index.js
@@ -8,6 +8,7 @@ export { default as AreaClosed } from './shapes/AreaClosed';
 export { default as AreaStack } from './shapes/AreaStack';
 export { default as Bar } from './shapes/Bar';
 export { default as BarGroup } from './shapes/BarGroup';
+export { default as BarGroupHorizontal } from './shapes/BarGroupHorizontal';
 export { default as BarStack } from './shapes/BarStack';
 export { default as BarStackHorizontal } from './shapes/BarStackHorizontal';
 export { default as Stack } from './shapes/Stack';

--- a/packages/vx-shape/src/shapes/BarGroupHorizontal.js
+++ b/packages/vx-shape/src/shapes/BarGroupHorizontal.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { Group } from '@vx/group';
+import Bar from './Bar';
+import additionalProps from '../util/additionalProps';
+
+export default function BarGroupHorizontal({
+  data,
+  className,
+  top,
+  left,
+  y0,
+  y0Scale,
+  y1Scale,
+  xScale,
+  zScale,
+  keys,
+  width,
+  ...restProps
+}) {
+  const format = y0Scale.tickFormat ? y0Scale.tickFormat() : d => d;
+  return (
+    <Group className={cx('vx-bar-group-horizontal', className)} top={top} left={left}>
+      {data &&
+        data.map((d, i) => {
+          return (
+            <Group key={`bar-group-${i}-${y0(d)}`} top={y0Scale(y0(d))}>
+              {keys &&
+                keys.map((key, i) => {
+                  const value = d[key];
+                  return (
+                    <Bar
+                      key={`bar-group-bar-${i}-${value}-${key}`}
+                      x={0}
+                      y={y1Scale(key)}
+                      width={width - xScale(value)}
+                      height={y1Scale.bandwidth()}
+                      fill={zScale(key)}
+                      data={{
+                        key,
+                        value,
+                        y: format(y0(d)),
+                        data: d
+                      }}
+                      {...restProps}
+                    />
+                  );
+                })}
+            </Group>
+          );
+        })}
+    </Group>
+  );
+}
+
+BarGroupHorizontal.propTypes = {
+  data: PropTypes.array.isRequired,
+  y0: PropTypes.func.isRequired,
+  y0Scale: PropTypes.func.isRequired,
+  y1Scale: PropTypes.func.isRequired,
+  xScale: PropTypes.func.isRequired,
+  zScale: PropTypes.func.isRequired,
+  keys: PropTypes.array.isRequired,
+  width: PropTypes.number.isRequired,
+  className: PropTypes.string,
+  top: PropTypes.number,
+  left: PropTypes.number
+};

--- a/packages/vx-shape/test/BarGroupHorizontal.test.js
+++ b/packages/vx-shape/test/BarGroupHorizontal.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { BarGroupHorizontal } from '../src';
+import { shallow, mount } from 'enzyme';
+
+describe('<BarGroupHorizontal />', () => {
+  beforeEach(() => {
+    global.console.error = jest.fn();
+  });
+
+  test('it should be defined', () => {
+    expect(BarGroupHorizontal).toBeDefined();
+  });
+
+  test('it should have className .vx-bar-group-horizontal', () => {
+    const wrapper = shallow(<BarGroupHorizontal y0Scale={() => {}} data={[]} />);
+    expect(wrapper.prop('className')).toEqual('vx-bar-group-horizontal');
+  });
+
+  test('it should set className prop', () => {
+    const wrapper = shallow(<BarGroupHorizontal y0Scale={() => {}} className="test" data={[]} />);
+    expect(wrapper.prop('className')).toEqual('vx-bar-group-horizontal test');
+  });
+
+  test('it should require a data prop', () => {
+    const wrapper = shallow(<BarGroupHorizontal y0Scale={() => {}} />);
+    expect(console.error).toBeCalled();
+    expect(console.error.mock.calls[0][0]).toEqual(
+      'Warning: Failed prop type: The prop `data` is marked as required in `BarGroupHorizontal`, but its value is `undefined`.\n    in BarGroupHorizontal'
+    );
+  });
+
+  test('it should set top & left props', () => {
+    const wrapper = shallow(
+      <BarGroupHorizontal y0Scale={() => {}} className="test" data={[]} top={2} left={3} />
+    );
+    expect(wrapper.prop('top')).toEqual(2);
+    expect(wrapper.prop('left')).toEqual(3);
+  });
+});


### PR DESCRIPTION
Been using this library a little while now and really enjoying it, thank you! I needed this twist on the `BarGroup` component and wanted to contribute back.

#### :rocket: Enhancements

- [shape] adds `<BarGroupHorizontal />` component

![BarGroupHorizontal Example](https://i.imgur.com/RDBJewO.png)

#### :memo: Documentation

- Adds documentation for `<BarGroup />` and `<BarGroupHorizontal />`
