### PR TITLE
<Pie /> Allow null sort callbacks

### DIFF
--- a/packages/vx-shape/src/shapes/Pie.js
+++ b/packages/vx-shape/src/shapes/Pie.js
@@ -29,8 +29,8 @@ export default function Pie({
   if (cornerRadius) path.cornerRadius(cornerRadius);
   if (padRadius) path.padRadius(padRadius);
   const pie = d3Pie();
-  if (pieSort) pie.sort(pieSort);
-  if (pieSortValues) pie.sortValues(pieSortValues);
+  if (pieSort !== undefined) pie.sort(pieSort);
+  if (pieSortValues !== undefined) pie.sortValues(pieSortValues);
   if (pieValue) pie.value(pieValue);
   if (padAngle != null) pie.padAngle(padAngle);
   if (startAngle != null) pie.startAngle(startAngle);
@@ -50,7 +50,7 @@ export default function Pie({
     generateCentroid: arc => centroid && centroid(path.centroid(arc), arc)
   };
   return (
-    <Group className='vx-pie-arcs-group' top={top} left={left}>
+    <Group className="vx-pie-arcs-group" top={top} left={left}>
       {children
         ? children(renderFunctionArg)
         : arcs.map((arc, i) => {

--- a/packages/vx-shape/test/Pie.test.js
+++ b/packages/vx-shape/test/Pie.test.js
@@ -16,6 +16,27 @@ describe('<Pie />', () => {
     }).not.toThrow();
   });
 
+  test('it should accept null sort callbacks', () => {
+    expect.assertions(3);
+
+    expect(() => {
+      PieWrapper({ pieSort: null, pieSortValues: null });
+    }).not.toThrow();
+
+    // Should sort the arcs the same order as the input data
+    // The default pieSortValues sorts data by descending values
+    const A = 1;
+    const B = 20;
+    shallow(
+      <Pie data={[A, B]} pieSortValues={null}>
+        {({ arcs }) => {
+          expect(arcs[0]).toMatchObject({ value: A, index: 0 });
+          expect(arcs[1]).toMatchObject({ value: B, index: 1 });
+        }}
+      </Pie>
+    );
+  });
+
   test('it should break on invalid sort callbacks', () => {
     expect(() => PieWrapper({ pieSort: 12 })).toThrow();
     expect(() => PieWrapper({ pieSortValues: 12 })).toThrow();


### PR DESCRIPTION
[`pie.sortValues(null)`](https://github.com/d3/d3-shape#pie_sortValues) turns off the default sorting, but before this PR `pie.sort` was never called with a `null` value. Hopefully this isn't a breaking change.

#### :bug: Bug Fix

- `<Pie pieSort={null} pieSortValues={null} />` isn't ignored

