### PR TITLE
Cleaned up and simplified heatmaps

### DIFF
--- a/packages/vx-demo/components/tiles/heatmap.js
+++ b/packages/vx-demo/components/tiles/heatmap.js
@@ -21,29 +21,29 @@ export default ({
     left: 20,
     right: 20,
     bottom: 110
-  }
+  },
+  separation = 20
 }) => {
   if (width < 10) return null;
 
   // bounds
-  const size = width > margin.left + margin.right ? width - margin.left - margin.right : width;
+  const size =
+    width > margin.left + margin.right ? width - margin.left - margin.right - separation : width;
   const xMax = size / 2;
-  const yMax = height - margin.bottom;
-  const dMin = min(data, d => min(y(d), x));
-  const dMax = max(data, d => max(y(d), x));
-  const dStep = dMax / data[0].bins.length;
+  const yMax = height - margin.bottom - margin.top;
+  const maxBucketSize = max(data, d => y(d).length);
   const bWidth = xMax / data.length;
-  const bHeight = yMax / data[0].bins.length;
+  const bHeight = yMax / maxBucketSize;
   const colorMax = max(data, d => max(y(d), z));
 
   // scales
   const xScale = scaleLinear({
     range: [0, xMax],
-    domain: extent(data, x)
+    domain: [0, data.length]
   });
   const yScale = scaleLinear({
     range: [yMax, 0],
-    domain: [dMin, dMax]
+    domain: [0, maxBucketSize]
   });
   const colorScale = scaleLinear({
     range: ['#77312f', '#f33d15'],
@@ -61,15 +61,14 @@ export default ({
   return (
     <svg width={width} height={height}>
       <rect x={0} y={0} width={width} height={height} rx={14} fill="#28272c" />
-      <Group top={margin.top} left={5}>
+      <Group top={margin.top} left={margin.left}>
         <HeatmapCircle
           data={data}
           xScale={xScale}
           yScale={yScale}
           colorScale={colorScale}
           opacityScale={opacityScale}
-          radius={(bWidth + 4) / 2}
-          step={dStep}
+          radius={min([bWidth, bHeight]) / 2}
           gap={4}
           onClick={data => event => {
             if (!events) return;
@@ -77,7 +76,7 @@ export default ({
           }}
         />
       </Group>
-      <Group top={margin.top} left={xMax + margin.left}>
+      <Group top={margin.top} left={xMax + margin.left + separation}>
         <HeatmapRect
           data={data}
           xScale={xScale}
@@ -86,8 +85,7 @@ export default ({
           opacityScale={opacityScale}
           binWidth={bWidth}
           binHeight={bWidth}
-          step={dStep}
-          gap={0}
+          gap={2}
           onClick={data => event => {
             if (!events) return;
             alert(`clicked: ${JSON.stringify(data.bin)}`);

--- a/packages/vx-demo/components/tiles/heatmap.js
+++ b/packages/vx-demo/components/tiles/heatmap.js
@@ -69,7 +69,7 @@ export default ({
           colorScale={colorScale}
           opacityScale={opacityScale}
           radius={min([bWidth, bHeight]) / 2}
-          gap={4}
+          gap={2}
           onClick={data => event => {
             if (!events) return;
             alert(`clicked: ${JSON.stringify(data.bin)}`);

--- a/packages/vx-heatmap/src/heatmaps/circle.js
+++ b/packages/vx-heatmap/src/heatmaps/circle.js
@@ -7,14 +7,11 @@ import additionalProps from '../util/additionalProps';
 HeatmapCircle.propTypes = {
   data: PropTypes.array,
   gap: PropTypes.number,
-  step: PropTypes.number,
   radius: PropTypes.number,
   xScale: PropTypes.func,
   yScale: PropTypes.func,
   colorScale: PropTypes.func,
   opacityScale: PropTypes.func,
-  yBin: PropTypes.func,
-  bin: PropTypes.func,
   bins: PropTypes.func,
   count: PropTypes.func
 };
@@ -23,26 +20,22 @@ export default function HeatmapCircle({
   className,
   data,
   gap = 1,
-  step = 0,
   radius = 6,
   xScale,
   yScale,
   colorScale,
   opacityScale = d => 1,
-  yBin,
-  bin = (d, i) => d.bin,
-  bins = (d, i) => d.bins,
+  bins = d => d.bins,
   count = d => d.count,
   ...restProps
 }) {
-  yBin = yBin || bin;
   const r = radius - gap;
   return (
     <Group>
       {data.map((d, i) => {
         return (
-          <Group key={`heatmap-${i}`} className="vx-heatmap-column" left={xScale(bin(d, i))}>
-            {bins(d, i).map((b, j) => {
+          <Group key={`heatmap-${i}`} className="vx-heatmap-column" left={xScale(i)}>
+            {bins(d).map((b, j) => {
               return (
                 <circle
                   key={`heatmap-tile-circle-${j}`}
@@ -50,7 +43,7 @@ export default function HeatmapCircle({
                   fill={colorScale(count(b))}
                   r={r}
                   cx={radius}
-                  cy={yScale(yBin(b, j) + step) + radius}
+                  cy={yScale(j) + gap + radius}
                   fillOpacity={opacityScale(count(b))}
                   {...additionalProps(restProps, {
                     bin: b,

--- a/packages/vx-heatmap/src/heatmaps/rect.js
+++ b/packages/vx-heatmap/src/heatmaps/rect.js
@@ -10,13 +10,10 @@ HeatmapRect.propTypes = {
   binHeight: PropTypes.number,
   x: PropTypes.number,
   gap: PropTypes.number,
-  step: PropTypes.number,
   xScale: PropTypes.func,
   yScale: PropTypes.func,
   colorScale: PropTypes.func,
   opacityScale: PropTypes.func,
-  yBin: PropTypes.func,
-  bin: PropTypes.func,
   bins: PropTypes.func,
   count: PropTypes.func
 };
@@ -28,26 +25,22 @@ export default function HeatmapRect({
   binHeight,
   x = 0,
   gap = 1,
-  step = 0,
   xScale,
   yScale,
   colorScale,
   opacityScale = d => 1,
-  yBin,
-  bin = (d, i) => d.bin,
-  bins = (d, i) => d.bins,
+  bins = d => d.bins,
   count = d => d.count,
   ...restProps
 }) {
-  yBin = yBin || bin;
   const width = binWidth - gap;
   const height = binHeight - gap;
   return (
     <Group>
       {data.map((d, i) => {
         return (
-          <Group key={`heatmap-${i}`} className="vx-heatmap-column" left={xScale(bin(d, i))}>
-            {bins(d, i).map((b, j) => {
+          <Group key={`heatmap-${i}`} className="vx-heatmap-column" left={xScale(i)}>
+            {bins(d).map((b, j) => {
               return (
                 <rect
                   key={`heatmap-tile-rect-${j}`}
@@ -56,7 +49,7 @@ export default function HeatmapRect({
                   width={width}
                   height={height}
                   x={x}
-                  y={yScale(yBin(b, j) + step) + gap}
+                  y={yScale(j) + gap}
                   fillOpacity={opacityScale(count(b))}
                   {...additionalProps(restProps, {
                     bin: b,


### PR DESCRIPTION
The heatmap demo overflows on the top (see the white half circle):
![white circle](https://user-images.githubusercontent.com/5368029/43923768-f74ffa6a-9c22-11e8-9717-41883170f91a.jpg)

This is due to the way the y-positions of the heatmap elements are calculated. This can be simplified by using the array lengths to calculate the positions (imho the cleaner way).

This is what the updated Heatmap demo looks like:

![heatmap updated](https://user-images.githubusercontent.com/5368029/43924341-ac40a2f2-9c24-11e8-9d7d-dbff252ab624.jpg)


----

#### :boom: Breaking Changes

- Different `vx-heatmap` API

#### :rocket: Enhancements

- Cleaner `vx-heatmap` API, better Heatmap layout
- Adds a separation attribute (margin between the two heatmaps) to the heatmap demo
- Removes usage of `data[0].bins.length` as reference bins length, calculates maximum

#### :bug: Bug Fix

- Fixes broken Heatmap demoo
- Removes hardcoded left margin of 5