### PR TITLE
Avoid ResizeObserver loop limit exceeded

### DIFF
--- a/packages/vx-responsive/src/components/ParentSize.js
+++ b/packages/vx-responsive/src/components/ParentSize.js
@@ -9,22 +9,26 @@ export default class ParentSize extends React.Component {
     this.state = { width: 0, height: 0, top: 0, left: 0 };
     this.resize = debounce(this.resize.bind(this), props.debounceTime);
     this.setTarget = this.setTarget.bind(this);
+    this.animationFrameID = null;
   }
   componentDidMount() {
     this.ro = new ResizeObserver((entries, observer) => {
       for (const entry of entries) {
         const { left, top, width, height } = entry.contentRect;
-        this.resize({
-          width,
-          height,
-          top,
-          left
+        this.animationFrameID = window.requestAnimationFrame(() => {
+          this.resize({
+            width,
+            height,
+            top,
+            left
+          });
         });
       }
     });
     this.ro.observe(this.target);
   }
   componentWillUnmount() {
+    window.cancelAnimationFrame(this.animationFrameID);
     this.ro.disconnect();
   }
   resize({ width, height, top, left }) {


### PR DESCRIPTION
#### :bug: Bug Fix

- Avoid `ResizeObserver` loop limit exceeded

> since `ResizeObserver` seems to be firing the callback immediately after `observe()` is called, this causes an infinite loop.

Reference: https://github.com/WICG/ResizeObserver/issues/38

Solution was to wrap the resize call in `requestAnimationFrame` to avoid infinite loop

Reference:
- https://github.com/cerner/terra-core/pull/1647/files
- https://github.com/cerner/terra-core/pull/1658/files