### PR TITLE
Rewrite withParentSize using ResizeObserver

### DIFF
--- a/packages/vx-responsive/test/withParentSize.test.js
+++ b/packages/vx-responsive/test/withParentSize.test.js
@@ -23,9 +23,13 @@ describe('withParentSize', () => {
     const Component = props => <div />;
     const HOC = withParentSize(Component);
     const wrapper = mount(<HOC />);
-    const RenderedComponent = wrapper.find(Component);
-    expect(Element.prototype.getBoundingClientRect).toHaveBeenCalled();
-    expect(RenderedComponent.prop('parentWidth')).toBe(220);
-    expect(RenderedComponent.prop('parentHeight')).toBe(120);
+
+    // wait for the resizeObserver to run
+    setTimeout(() => {
+      const RenderedComponent = wrapper.find(Component);
+      expect(Element.prototype.getBoundingClientRect).toHaveBeenCalled();
+      expect(RenderedComponent.prop('parentWidth')).toBe(220);
+      expect(RenderedComponent.prop('parentHeight')).toBe(120);
+    }, 0);
   });
 });


### PR DESCRIPTION
Hey,  I really like that you used the `ResizeObserver` in the component [ParentSize](https://github.com/hshoff/vx/blob/master/packages/vx-responsive/src/components/ParentSize.js) that's really useful! I updated the `withParentSize` decorator to use the same logic.

#### :boom: Breaking Changes

the `windowResizeDebounceTime` prop is now `debounceTime` like in the component `ParentSize` 

#### :rocket: Enhancements

now it updates only if the parent resizes, doesn't care about the window.

#### :memo: Documentation

-

#### :bug: Bug Fix

- 

#### :house: Internal

-
