### PR TITLE
Fix label transform computation

### DIFF
--- a/packages/vx-axis/src/utils/labelTransform.js
+++ b/packages/vx-axis/src/utils/labelTransform.js
@@ -14,7 +14,7 @@ export default function labelTransform({
     y,
     transform = null;
   if (orientation === ORIENT.top || orientation === ORIENT.bottom) {
-    x = Math.max(...range) / 2;
+    x = (range[0] + range[range.length - 1]) / 2;
     y =
       sign *
       (tickLength +
@@ -22,7 +22,7 @@ export default function labelTransform({
         tickLabelFontSize +
         (orientation === ORIENT.bottom ? labelProps.fontSize : 0));
   } else {
-    x = sign * (Math.max(...range) / 2);
+    x = sign * ((range[0] + range[range.length - 1]) / 2);
     y = -(tickLength + labelOffset);
     transform = `rotate(${sign * 90})`;
   }


### PR DESCRIPTION
#### :bug: Bug Fix

- Fix `labelTransform` function in *@vx/axis* to correctly align the axis label when different values for the scale's *range* are specified, in particular when it does not start (or end) with a 0.


To give a visual example, take a scale defined as below(same as [this](https://github.com/hshoff/vx/blob/master/packages/vx-demo/components/tiles/axis.js#L43#L47), but with a slightly different range): 

```
const yScale = scaleLinear({
    range: [yMax, yMax / 2],
    domain: [0, max(data, y)],
    nice: true
  });
```
this is what we get with the current code(which basically uses a `Math.max(...range) / 2` to compute the center):  
<img width="828" alt="screen shot 2018-09-06 at 21 46 29" src="https://user-images.githubusercontent.com/4623726/45182925-ee36c880-b222-11e8-8f79-f95f508b8179.png">

while this is the same example with the fix: 
<img width="826" alt="screen shot 2018-09-06 at 21 51 14" src="https://user-images.githubusercontent.com/4623726/45183132-82a12b00-b223-11e8-8fd6-26eacdb38c57.png">
