### PR TITLE
add back genBoxPlot.js to mock-data

### DIFF
--- a/packages/vx-mock-data/src/generators/genBoxPlot.js
+++ b/packages/vx-mock-data/src/generators/genBoxPlot.js
@@ -1,0 +1,21 @@
+export default function genBoxPlot(number) {
+  const data = [];
+  let i;
+  for (i = 0; i < number; i += 1) {
+    const points = [];
+    let j;
+    for (j = 0; j < 5; j += 1) {
+      points.push(Math.random() * 100);
+    }
+    points.sort((a, b) => a - b);
+    data.push({
+      x: `Statistics ${i}`,
+      min: points[0],
+      firstQuartile: points[1],
+      median: points[2],
+      thirdQuartile: points[3],
+      max: points[4]
+    });
+  }
+  return data;
+}


### PR DESCRIPTION
#### :bug: Bug Fix

genBoxPlot was previously added in pull request [#89]: 

- [mock data] add `genBoxPlot()` [#89](https://github.com/hshoff/vx/pull/89)

It's still referenced and required in the boxchart demo `packages/vx-demo/pages/boxplot.js`

Adding it back so it can be imported and avoid the package not-found error on `yarn start` when trying to use the import:

`import { genBoxPlot } from '@vx/mock-data';`