### PR TITLE
add <Polygon /> to vx-shape

### DIFF
--- a/packages/vx-demo/components/gallery.js
+++ b/packages/vx-demo/components/gallery.js
@@ -5,42 +5,43 @@ import { ParentSize } from '@vx/responsive';
 import { extent, max } from 'd3-array';
 import drawData from './util/drawData';
 
-import Page from '../components/page';
-import Footer from '../components/footer';
+import Page from './page';
+import Footer from './footer';
 
-import Lines from '../components/tiles/lines';
-import Bars from '../components/tiles/bars';
-import Dots from '../components/tiles/dots';
-import Patterns from '../components/tiles/patterns';
-import Gradients from '../components/tiles/gradients';
-import Area from '../components/tiles/area';
-import Stacked from '../components/tiles/stacked';
-import MultiLine from '../components/tiles/multiline';
-import Axis from '../components/tiles/axis';
-import BarGroup from '../components/tiles/bargroup';
-import BarGroupHorizontal from '../components/tiles/bargrouphorizontal';
-import BarStack from '../components/tiles/barstack';
-import BarStackHorizontal from '../components/tiles/barstackhorizontal';
-import Heatmap from '../components/tiles/heatmap';
-import LineRadial from '../components/tiles/lineradial';
-import Pies from '../components/tiles/pie';
-import Trees from '../components/tiles/tree';
-import Cluster from '../components/tiles/dendrogram';
-import Voronoi from '../components/tiles/voronoi';
-import Legends from '../components/tiles/legends';
-import BoxPlot from '../components/tiles/boxplot';
-import GeoMercator from '../components/tiles/geo-mercator';
-import Network from '../components/tiles/network';
-import Streamgraph from '../components/tiles/streamgraph';
-import Pack from '../components/tiles/pack';
-import Treemap from '../components/tiles/treemap';
-import Radar from '../components/tiles/radar';
-import Responsive from '../components/tiles/responsive';
-import DragI from '../components/tiles/drag-i';
-import DragII from '../components/tiles/drag-ii';
-import LinkTypes from '../components/tiles/linkTypes';
-import Threshold from '../components/tiles/threshold';
-import Chord from '../components/tiles/chord';
+import Lines from './tiles/lines';
+import Bars from './tiles/bars';
+import Dots from './tiles/dots';
+import Patterns from './tiles/patterns';
+import Gradients from './tiles/gradients';
+import Area from './tiles/area';
+import Stacked from './tiles/stacked';
+import MultiLine from './tiles/multiline';
+import Axis from './tiles/axis';
+import BarGroup from './tiles/bargroup';
+import BarGroupHorizontal from './tiles/bargrouphorizontal';
+import BarStack from './tiles/barstack';
+import BarStackHorizontal from './tiles/barstackhorizontal';
+import Heatmap from './tiles/heatmap';
+import LineRadial from './tiles/lineradial';
+import Pies from './tiles/pie';
+import Trees from './tiles/tree';
+import Cluster from './tiles/dendrogram';
+import Voronoi from './tiles/voronoi';
+import Legends from './tiles/legends';
+import BoxPlot from './tiles/boxplot';
+import GeoMercator from './tiles/geo-mercator';
+import Network from './tiles/network';
+import Streamgraph from './tiles/streamgraph';
+import Pack from './tiles/pack';
+import Treemap from './tiles/treemap';
+import Radar from './tiles/radar';
+import Responsive from './tiles/responsive';
+import DragI from './tiles/drag-i';
+import DragII from './tiles/drag-ii';
+import LinkTypes from './tiles/linkTypes';
+import Threshold from './tiles/threshold';
+import Chord from './tiles/chord';
+import Polygons from './tiles/polygons';
 
 const items = [
   '#242424',
@@ -54,13 +55,14 @@ const items = [
   '#f4419f',
   '#3130e3',
   '#12122e',
-  '#ff657c'
+  '#ff657c',
 ];
 
 export default class Gallery extends React.Component {
   constructor(props) {
     super(props);
   }
+
   render() {
     const detailsHeight = 76;
     return (
@@ -77,7 +79,7 @@ export default class Gallery extends React.Component {
                 <div className="details">
                   <div className="title">Lines</div>
                   <div className="description">
-                    <pre>{`<Shape.Line />`}</pre>
+                    <pre>{'<Shape.Line />'}</pre>
                   </div>
                 </div>
               </div>
@@ -94,7 +96,7 @@ export default class Gallery extends React.Component {
                 <div className="details color-blue">
                   <div className="title">Bars</div>
                   <div className="description">
-                    <pre>{`<Shape.Bar />`}</pre>
+                    <pre>{'<Shape.Bar />'}</pre>
                   </div>
                 </div>
               </div>
@@ -113,7 +115,7 @@ export default class Gallery extends React.Component {
                           top: 0,
                           left: 0,
                           right: 0,
-                          bottom: 80
+                          bottom: 80,
                         }}
                       />
                     )}
@@ -122,7 +124,7 @@ export default class Gallery extends React.Component {
                 <div className="details color-yellow" style={{ zIndex: 1 }}>
                   <div className="title">Dots</div>
                   <div className="description">
-                    <pre>{`<Glyph.GlyphCircle />`}</pre>
+                    <pre>{'<Glyph.GlyphCircle />'}</pre>
                   </div>
                 </div>
               </div>
@@ -141,7 +143,7 @@ export default class Gallery extends React.Component {
                 <div className="details color-gray">
                   <div className="title">Patterns</div>
                   <div className="description">
-                    <pre>{`<Pattern />`}</pre>
+                    <pre>{'<Pattern />'}</pre>
                   </div>
                 </div>
               </div>
@@ -160,7 +162,7 @@ export default class Gallery extends React.Component {
                           top: 0,
                           left: 0,
                           right: 0,
-                          bottom: 80
+                          bottom: 80,
                         }}
                       />
                     )}
@@ -169,7 +171,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ zIndex: 1 }}>
                   <div className="title">Areas</div>
                   <div className="description">
-                    <pre>{`<Shape.AreaClosed />`}</pre>
+                    <pre>{'<Shape.AreaClosed />'}</pre>
                   </div>
                 </div>
               </div>
@@ -188,7 +190,7 @@ export default class Gallery extends React.Component {
                           top: 0,
                           left: 0,
                           right: 0,
-                          bottom: 80
+                          bottom: 80,
                         }}
                       />
                     )}
@@ -197,7 +199,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: 'rgba(251, 224, 137, 1.000)' }}>
                   <div className="title">Stacked Areas</div>
                   <div className="description">
-                    <pre>{`<Shape.AreaStack />`}</pre>
+                    <pre>{'<Shape.AreaStack />'}</pre>
                   </div>
                 </div>
               </div>
@@ -209,7 +211,7 @@ export default class Gallery extends React.Component {
                 className="gallery-item"
                 style={{
                   background: 'white',
-                  boxShadow: '0 1px 6px rgba(0,0,0,0.1)'
+                  boxShadow: '0 1px 6px rgba(0,0,0,0.1)',
                 }}
               >
                 <div className="image">
@@ -222,7 +224,7 @@ export default class Gallery extends React.Component {
                           top: 0,
                           left: 0,
                           right: 0,
-                          bottom: 80
+                          bottom: 80,
                         }}
                       />
                     )}
@@ -231,7 +233,7 @@ export default class Gallery extends React.Component {
                 <div className="details color-gray">
                   <div className="title">Gradients</div>
                   <div className="description">
-                    <pre>{`<Gradient />`}</pre>
+                    <pre>{'<Gradient />'}</pre>
                   </div>
                 </div>
               </div>
@@ -250,7 +252,7 @@ export default class Gallery extends React.Component {
                           top: 0,
                           left: 0,
                           right: 0,
-                          bottom: 80
+                          bottom: 80,
                         }}
                       />
                     )}
@@ -259,7 +261,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: 'rgba(126, 31, 220, 1.000)' }}>
                   <div className="title">Glyphs</div>
                   <div className="description">
-                    <pre>{`<Glyph.GlyphDot />`}</pre>
+                    <pre>{'<Glyph.GlyphDot />'}</pre>
                   </div>
                 </div>
               </div>
@@ -278,7 +280,7 @@ export default class Gallery extends React.Component {
                           top: 20,
                           left: 60,
                           right: 40,
-                          bottom: 120
+                          bottom: 120,
                         }}
                       />
                     )}
@@ -287,7 +289,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: '#8e205f' }}>
                   <div className="title">Axis</div>
                   <div className="description">
-                    <pre>{`<Axis.AxisLeft /> + <Axis.AxisBottom />`}</pre>
+                    <pre>{'<Axis.AxisLeft /> + <Axis.AxisBottom />'}</pre>
                   </div>
                 </div>
               </div>
@@ -306,7 +308,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: '#e5fd3d' }}>
                   <div className="title">Bar Group</div>
                   <div className="description">
-                    <pre>{`<Shape.BarGroup />`}</pre>
+                    <pre>{'<Shape.BarGroup />'}</pre>
                   </div>
                 </div>
               </div>
@@ -325,7 +327,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: '#a44afe', zIndex: 1 }}>
                   <div className="title">Bar Stack</div>
                   <div className="description">
-                    <pre>{`<Shape.BarStack />`}</pre>
+                    <pre>{'<Shape.BarStack />'}</pre>
                   </div>
                 </div>
               </div>
@@ -344,7 +346,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: 'rgba(255,255,255,0.3)' }}>
                   <div className="title">Heatmaps</div>
                   <div className="description">
-                    <pre>{`<HeatmapCircle /> + <HeatmapRect />`}</pre>
+                    <pre>{'<HeatmapCircle /> + <HeatmapRect />'}</pre>
                   </div>
                 </div>
               </div>
@@ -361,7 +363,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: '#919fe5' }}>
                   <div className="title">Radial Lines</div>
                   <div className="description">
-                    <pre>{`<Shape.LineRadial />`}</pre>
+                    <pre>{'<Shape.LineRadial />'}</pre>
                   </div>
                 </div>
               </div>
@@ -378,7 +380,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: 'white' }}>
                   <div className="title">Pies</div>
                   <div className="description">
-                    <pre>{`<Shape.Pie />`}</pre>
+                    <pre>{'<Shape.Pie />'}</pre>
                   </div>
                 </div>
               </div>
@@ -395,7 +397,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: '#269688' }}>
                   <div className="title">Trees</div>
                   <div className="description">
-                    <pre>{`<Hierarchy.Tree /> + <Shape.LinkHorizontal />`}</pre>
+                    <pre>{'<Hierarchy.Tree /> + <Shape.LinkHorizontal />'}</pre>
                   </div>
                 </div>
               </div>
@@ -414,7 +416,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: '#5dc26f' }}>
                   <div className="title">Dendrograms</div>
                   <div className="description">
-                    <pre>{`<Hierarchy.Cluster /> + <Shape.LinkVertical />`}</pre>
+                    <pre>{'<Hierarchy.Cluster /> + <Shape.LinkVertical />'}</pre>
                   </div>
                 </div>
               </div>
@@ -429,7 +431,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: '#494949' }}>
                   <div className="title">Legends</div>
                   <div className="description">
-                    <pre>{`<Legend />`}</pre>
+                    <pre>{'<Legend />'}</pre>
                   </div>
                 </div>
               </div>
@@ -440,14 +442,14 @@ export default class Gallery extends React.Component {
               <div
                 className="gallery-item"
                 style={{
-                  boxShadow: 'rgba(0, 0, 0, 0.1) 0px 1px 6px'
+                  boxShadow: 'rgba(0, 0, 0, 0.1) 0px 1px 6px',
                 }}
               >
                 <div
                   className="image"
                   style={{
                     backgroundColor: '#eb6d88',
-                    borderRadius: 14
+                    borderRadius: 14,
                   }}
                 >
                   <ParentSize>
@@ -459,7 +461,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: '#F54EA2' }}>
                   <div className="title">Voronoi</div>
                   <div className="description">
-                    <pre>{`<Voronoi.VoronoiPolygon /> `}</pre>
+                    <pre>{'<Voronoi.VoronoiPolygon /> '}</pre>
                   </div>
                 </div>
               </div>
@@ -479,7 +481,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: '#FFFFFF', zIndex: 1 }}>
                   <div className="title">Stats Plots</div>
                   <div className="description">
-                    <pre>{`<BoxPlot /> + <ViolinPlot /> `}</pre>
+                    <pre>{'<BoxPlot /> + <ViolinPlot /> '}</pre>
                   </div>
                 </div>
               </div>
@@ -499,7 +501,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: '#f63a48' }}>
                   <div className="title">Geo</div>
                   <div className="description">
-                    <pre>{`<Geo.Mercator />`}</pre>
+                    <pre>{'<Geo.Mercator />'}</pre>
                   </div>
                 </div>
               </div>
@@ -519,12 +521,12 @@ export default class Gallery extends React.Component {
                 <div
                   className="details"
                   style={{
-                    color: '#ffffff'
+                    color: '#ffffff',
                   }}
                 >
                   <div className="title">Network</div>
                   <div className="description">
-                    <pre>{`<Network.Graph />`}</pre>
+                    <pre>{'<Network.Graph />'}</pre>
                   </div>
                 </div>
               </div>
@@ -544,12 +546,12 @@ export default class Gallery extends React.Component {
                 <div
                   className="details"
                   style={{
-                    color: '#036ecd'
+                    color: '#036ecd',
                   }}
                 >
                   <div className="title">Streamgraph</div>
                   <div className="description">
-                    <pre>{`<Shape.Stack />`}</pre>
+                    <pre>{'<Shape.Stack />'}</pre>
                   </div>
                 </div>
               </div>
@@ -561,7 +563,7 @@ export default class Gallery extends React.Component {
                 className="gallery-item"
                 style={{
                   background: '#ffffff',
-                  boxShadow: 'rgba(0, 0, 0, 0.1) 0px 1px 6px'
+                  boxShadow: 'rgba(0, 0, 0, 0.1) 0px 1px 6px',
                 }}
               >
                 <div className="image">
@@ -572,12 +574,12 @@ export default class Gallery extends React.Component {
                 <div
                   className="details"
                   style={{
-                    color: '#fd6c6f'
+                    color: '#fd6c6f',
                   }}
                 >
                   <div className="title">Pack</div>
                   <div className="description">
-                    <pre>{`<Hierarchy.Pack />`}</pre>
+                    <pre>{'<Hierarchy.Pack />'}</pre>
                   </div>
                 </div>
               </div>
@@ -588,7 +590,7 @@ export default class Gallery extends React.Component {
               <div
                 className="gallery-item"
                 style={{
-                  background: '#3436b8'
+                  background: '#3436b8',
                 }}
               >
                 <div className="image">
@@ -601,12 +603,12 @@ export default class Gallery extends React.Component {
                 <div
                   className="details"
                   style={{
-                    color: '#00ff70'
+                    color: '#00ff70',
                   }}
                 >
                   <div className="title">Treemap</div>
                   <div className="description">
-                    <pre>{`<Hierarchy.Treemap />`}</pre>
+                    <pre>{'<Hierarchy.Treemap />'}</pre>
                   </div>
                 </div>
               </div>
@@ -617,7 +619,7 @@ export default class Gallery extends React.Component {
               <div
                 className="gallery-item"
                 style={{
-                  background: '#FAF7E9'
+                  background: '#FAF7E9',
                 }}
               >
                 <div className="image">
@@ -628,12 +630,12 @@ export default class Gallery extends React.Component {
                 <div
                   className="details"
                   style={{
-                    color: '#f5810c'
+                    color: '#f5810c',
                   }}
                 >
                   <div className="title">Radar</div>
                   <div className="description">
-                    <pre>{`<Shape.Line /> + <Shape.LineRadial />`}</pre>
+                    <pre>{'<Shape.Line /> + <Shape.LineRadial />'}</pre>
                   </div>
                 </div>
               </div>
@@ -644,7 +646,7 @@ export default class Gallery extends React.Component {
               <div
                 className="gallery-item"
                 style={{
-                  background: '#eaedff'
+                  background: '#eaedff',
                 }}
               >
                 <div className="image">
@@ -657,7 +659,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: '#a44afe', zIndex: 1 }}>
                   <div className="title">Bar Stack Horizontal</div>
                   <div className="description">
-                    <pre>{`<Shape.BarStackHorizontal />`}</pre>
+                    <pre>{'<Shape.BarStackHorizontal />'}</pre>
                   </div>
                 </div>
               </div>
@@ -668,13 +670,13 @@ export default class Gallery extends React.Component {
               <div
                 className="gallery-item"
                 style={{
-                  background: 'white'
+                  background: 'white',
                 }}
               >
                 <div className="image">
                   <ParentSize>
                     {({ width, height }) => (
-                      <Responsive width={width} height={height} events={true} />
+                      <Responsive width={width} height={height} events />
                     )}
                   </ParentSize>
                 </div>
@@ -686,12 +688,12 @@ export default class Gallery extends React.Component {
                     border: '1px solid lightgray',
                     borderTop: 'none',
                     borderBottomLeftRadius: '14px',
-                    borderBottomRightRadius: '14px'
+                    borderBottomRightRadius: '14px',
                   }}
                 >
                   <div className="title">Responsive</div>
                   <div className="description">
-                    <pre>{`<Responsive.ParentSize />`}</pre>
+                    <pre>{'<Responsive.ParentSize />'}</pre>
                   </div>
                 </div>
               </div>
@@ -704,7 +706,7 @@ export default class Gallery extends React.Component {
                 style={{
                   background: 'white',
                   border: '1px solid lightgray',
-                  borderRadius: '14px'
+                  borderRadius: '14px',
                 }}
               >
                 <div className="image">
@@ -714,12 +716,12 @@ export default class Gallery extends React.Component {
                   className="details"
                   style={{
                     color: '#232323',
-                    zIndex: 1
+                    zIndex: 1,
                   }}
                 >
                   <div className="title">Text</div>
                   <div className="description">
-                    <pre>{`<Text.Text />`}</pre>
+                    <pre>{'<Text.Text />'}</pre>
                   </div>
                 </div>
               </div>
@@ -731,7 +733,7 @@ export default class Gallery extends React.Component {
                 className="gallery-item"
                 style={{
                   background: '#c4c3cb',
-                  borderRadius: '14px'
+                  borderRadius: '14px',
                 }}
               >
                 <div className="image">
@@ -743,12 +745,12 @@ export default class Gallery extends React.Component {
                   className="details"
                   style={{
                     color: '#6437d6',
-                    zIndex: 1
+                    zIndex: 1,
                   }}
                 >
                   <div className="title">Drag</div>
                   <div className="description">
-                    <pre>{`<Drag.Drag />`}</pre>
+                    <pre>{'<Drag.Drag />'}</pre>
                   </div>
                 </div>
               </div>
@@ -760,7 +762,7 @@ export default class Gallery extends React.Component {
                 className="gallery-item"
                 style={{
                   background: '#04002b',
-                  borderRadius: '14px'
+                  borderRadius: '14px',
                 }}
               >
                 <div className="image">
@@ -774,12 +776,12 @@ export default class Gallery extends React.Component {
                   className="details"
                   style={{
                     color: '#ff614e',
-                    zIndex: 1
+                    zIndex: 1,
                   }}
                 >
                   <div className="title">Drag</div>
                   <div className="description">
-                    <pre>{`<Drag.Drag />`}</pre>
+                    <pre>{'<Drag.Drag />'}</pre>
                   </div>
                 </div>
               </div>
@@ -798,7 +800,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: '#269688' }}>
                   <div className="title">Link Types</div>
                   <div className="description">
-                    <pre>{`<Shape.Link* />`}</pre>
+                    <pre>{'<Shape.Link* />'}</pre>
                   </div>
                 </div>
               </div>
@@ -817,7 +819,7 @@ export default class Gallery extends React.Component {
                           top: 40,
                           left: 40,
                           right: 20,
-                          bottom: 30
+                          bottom: 30,
                         }}
                       />
                     )}
@@ -826,7 +828,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: '#111' }}>
                   <div className="title">Threshold</div>
                   <div className="description">
-                    <pre>{`<Threshold />`}</pre>
+                    <pre>{'<Threshold />'}</pre>
                   </div>
                 </div>
               </div>
@@ -846,7 +848,7 @@ export default class Gallery extends React.Component {
                           top: 0,
                           left: 0,
                           right: 0,
-                          bottom: 30
+                          bottom: 30,
                         }}
                       />
                     )}
@@ -855,7 +857,7 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: '#111' }}>
                   <div className="title">Chords</div>
                   <div className="description">
-                    <pre>{`<Chord.Chord /> + <Chord.Ribbon />`}</pre>
+                    <pre>{'<Chord.Chord /> + <Chord.Ribbon />'}</pre>
                   </div>
                 </div>
               </div>
@@ -874,7 +876,24 @@ export default class Gallery extends React.Component {
                 <div className="details" style={{ color: '#e5fd3d' }}>
                   <div className="title">Bar Group Horizontal</div>
                   <div className="description">
-                    <pre>{`<Shape.BarGroupHorizontal />`}</pre>
+                    <pre>{'<Shape.BarGroupHorizontal />'}</pre>
+                  </div>
+                </div>
+              </div>
+            </Link>
+          </Tilt>
+          <Tilt className="tilt" options={{ max: 8, scale: 1 }}>
+            <Link prefetch href="/polygons">
+              <div className="gallery-item" style={{ background: '#7f82e3' }}>
+                <div className="image">
+                  <ParentSize>
+                    {({ width, height }) => <Polygons width={width} height={height} />}
+                  </ParentSize>
+                </div>
+                <div className="details" style={{ color: 'white' }}>
+                  <div className="title">Polygons</div>
+                  <div className="description">
+                    <pre>{'<Shape.Polygon />'}</pre>
                   </div>
                 </div>
               </div>
@@ -890,7 +909,8 @@ export default class Gallery extends React.Component {
 
         <Footer />
 
-        <style jsx>{`
+        <style jsx>
+          {`
           h3 {
             margin-top: 0;
             margin-left: 40px;
@@ -967,7 +987,8 @@ export default class Gallery extends React.Component {
               min-width: 100%;
             }
           }
-        `}</style>
+        `}
+        </style>
       </div>
     );
   }

--- a/packages/vx-demo/components/tiles/polygons.js
+++ b/packages/vx-demo/components/tiles/polygons.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Polygon } from '@vx/shape';
+import { Group } from '@vx/group';
+import { GradientPinkBlue } from '@vx/gradient';
+
+const additionalProps = [
+  {
+    fill: 'rgb(174, 238, 248)',
+    rotate: 90,
+  },
+  {
+    fill: 'rgb(229, 253, 61)',
+    rotate: 45,
+  },
+  {
+    fill: 'rgb(229, 130, 255)',
+    rotate: 0,
+  },
+  {
+    fill: 'url(#pink)',
+    rotate: 0,
+  },
+];
+
+export default ({ width, height }) => (
+  <svg width={width} height={height}>
+    <GradientPinkBlue id="gradients" />
+    {[3, 4, 6, 8].map((n, i) => (
+      <Group top={i * 70 + 50} left={width / 2}>
+        <Polygon sides={n} size={25} {...additionalProps[i]} />
+      </Group>
+    ))}
+  </svg>
+);

--- a/packages/vx-demo/pages/polygons.js
+++ b/packages/vx-demo/pages/polygons.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import Show from '../components/show';
+import Polygons from '../components/tiles/polygons';
+
+export default () => (
+  <Show component={Polygons} title="Polygons">
+    {`import React from 'react';
+import { Polygon } from '@vx/shape';
+import { Group } from '@vx/group';
+import { GradientPinkBlue } from '@vx/gradient';
+
+const additionalProps = [
+  {
+    fill: 'rgb(174, 238, 248)',
+    rotate: 90
+  },
+  {
+    fill: 'rgb(229, 253, 61)',
+    rotate: 45
+  },
+  {
+    fill: 'rgb(229, 130, 255)',
+    rotate: 0
+  },
+  {
+    fill: 'url(#pink)',
+    rotate: 0
+  }
+];
+
+export default ({ width, height }) => {
+  return (
+    <svg width={width} height={height}>
+      <GradientPinkBlue id="gradients" />
+      {[3, 4, 6, 8].map((n, i) => (
+        <Group top={i * 70 + 50} left={width / 2}>
+          <Polygon sides={n} size={25} {...additionalProps[i]} />
+        </Group>
+      ))}
+    </svg>
+  );
+};
+`}
+  </Show>
+);

--- a/packages/vx-shape/Readme.md
+++ b/packages/vx-shape/Readme.md
@@ -353,10 +353,9 @@ A simple polygon shape. Supply the sides and the length and we will do the rest.
 | Name            | Default                  | Type     | Description                                                                                    |
 | :-------------- | :----------------------- | :------- | :--------------------------------------------------------------------------------------------- |
 | sides           |                          | number   | The number of sides in the polygon.                                                            |
-| size            | 25                       | number   | The length of eacch side of the polygon.                                                       |
+| size            | 25                       | number   | The length of each side of the polygon.                                                       |
 | rotate          | 0                        | number   | The angle in degrees to rotate the polygon.                                                    |
 | center          | new Point({ x: 0 y: 0 }) | Point    | The center of the polygon [point](https://github.com/hshoff/vx/tree/master/packages/vx-point). |
-| clickHandler    |                          | function | Assign a click handler                                                                         |
 | stroke          | black                    | string   | The color of the stroke.                                                                       |
 | strokeWidth     | 1                        | number   | The pixel width of the stroke.                                                                 |
 | strokeDasharray |                          | array    | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                 |

--- a/packages/vx-shape/Readme.md
+++ b/packages/vx-shape/Readme.md
@@ -337,6 +337,31 @@ A more complicated line path. A `<LinePath />` is useful for making line graphs 
 | pieSortValues |         | function | A comparator function which takes two values (as returned from `pieValue`) and returns `-1`, `0` or `+1` to sort arcs.             |
 | centroid      |         | function | A render function which takes a [centroid](https://github.com/d3/d3-shape#arc_centroid) and an `arc` argument called for each arc. |
 
+## `<Polygon />`
+
+A simple polygon shape. Supply the sides and the length and we will do the rest.
+
+### Example
+
+```js
+// hexagon
+<Polygon sides={6} size={25} {...additionalProps[i]} />
+```
+
+### Properties
+
+| Name            | Default                  | Type     | Description                                                                                    |
+| :-------------- | :----------------------- | :------- | :--------------------------------------------------------------------------------------------- |
+| sides           |                          | number   | The number of sides in the polygon.                                                            |
+| size            | 25                       | number   | The length of eacch side of the polygon.                                                       |
+| rotate          | 0                        | number   | The angle in degrees to rotate the polygon.                                                    |
+| center          | new Point({ x: 0 y: 0 }) | Point    | The center of the polygon [point](https://github.com/hshoff/vx/tree/master/packages/vx-point). |
+| clickHandler    |                          | function | Assign a click handler                                                                         |
+| stroke          | black                    | string   | The color of the stroke.                                                                       |
+| strokeWidth     | 1                        | number   | The pixel width of the stroke.                                                                 |
+| strokeDasharray |                          | array    | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                 |
+| className       |                          | string   | The class name for the `line` element.                                                         |
+
 ## Sources For Components
 + [`<AreaClosed />`](https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/AreaClosed.js)
 + [`<AreaStack />`](https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/AreaStack.js)
@@ -347,3 +372,4 @@ A more complicated line path. A `<LinePath />` is useful for making line graphs 
 + [`<LinePath />`](https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/LinePath.js)
 + [`<LineRadial />`](https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/LineRadial.js)
 + [`<Pie />`](https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/Pie.js)
++ [`<Polygon`](https://github.com/hshoff/vx/blob/master/packages/vx-shape/src/shapes/Polygon.js)

--- a/packages/vx-shape/src/index.js
+++ b/packages/vx-shape/src/index.js
@@ -17,28 +17,29 @@ export { default as stackOffset, STACK_OFFSETS, STACK_OFFSET_NAMES } from './uti
 export { default as stackOrder, STACK_ORDERS, STACK_ORDER_NAMES } from './util/stackOrder';
 export {
   default as LinkHorizontal,
-  pathHorizontalDiagonal
+  pathHorizontalDiagonal,
 } from './shapes/link/diagonal/LinkHorizontal';
 export { default as LinkVertical, pathVerticalDiagonal } from './shapes/link/diagonal/LinkVertical';
 export { default as LinkRadial, pathRadialDiagonal } from './shapes/link/diagonal/LinkRadial';
 export {
   default as LinkHorizontalCurve,
-  pathHorizontalCurve
+  pathHorizontalCurve,
 } from './shapes/link/curve/LinkHorizontalCurve';
 export {
   default as LinkVerticalCurve,
-  pathVerticalCurve
+  pathVerticalCurve,
 } from './shapes/link/curve/LinkVerticalCurve';
 export { default as LinkRadialCurve, pathRadialCurve } from './shapes/link/curve/LinkRadialCurve';
 export {
   default as LinkHorizontalLine,
-  pathHorizontalLine
+  pathHorizontalLine,
 } from './shapes/link/line/LinkHorizontalLine';
 export { default as LinkVerticalLine, pathVerticalLine } from './shapes/link/line/LinkVerticalLine';
 export { default as LinkRadialLine, pathRadialLine } from './shapes/link/line/LinkRadialLine';
 export {
   default as LinkHorizontalStep,
-  pathHorizontalStep
+  pathHorizontalStep,
 } from './shapes/link/step/LinkHorizontalStep';
 export { default as LinkVerticalStep, pathVerticalStep } from './shapes/link/step/LinkVerticalStep';
 export { default as LinkRadialStep, pathRadialStep } from './shapes/link/step/LinkRadialStep';
+export { default as Polygon, getPoints, getPoint } from './shapes/Polygon';

--- a/packages/vx-shape/src/index.js
+++ b/packages/vx-shape/src/index.js
@@ -15,6 +15,7 @@ export { default as Stack } from './shapes/Stack';
 export { default as callOrValue } from './util/callOrValue';
 export { default as stackOffset, STACK_OFFSETS, STACK_OFFSET_NAMES } from './util/stackOffset';
 export { default as stackOrder, STACK_ORDERS, STACK_ORDER_NAMES } from './util/stackOrder';
+export { degreesToRadians } from './util/trigonometry';
 export {
   default as LinkHorizontal,
   pathHorizontalDiagonal,

--- a/packages/vx-shape/src/shapes/Polygon.js
+++ b/packages/vx-shape/src/shapes/Polygon.js
@@ -9,7 +9,6 @@ Polygon.propTypes = {
   size: PropTypes.number.isRequired,
   className: PropTypes.string,
   rotate: PropTypes.number,
-  clickHandler: PropTypes.func,
   fill: PropTypes.string,
   strokeDasharray: PropTypes.string,
   strokeWidth: PropTypes.number,
@@ -31,7 +30,11 @@ export const getPoint = ({
 export const getPoints = ({
   sides, size, center, rotate,
 }) => [...Array(sides).keys()].map(side => getPoint({
-  sides, size, center, rotate, side,
+  sides,
+  size,
+  center,
+  rotate,
+  side,
 }));
 
 export default function Polygon({
@@ -48,18 +51,13 @@ export default function Polygon({
   ...restProps
 }) {
   const points = getPoints({
-    sides, size, center, rotate,
+    sides,
+    size,
+    center,
+    rotate,
   })
     .map(p => p.toArray())
     .join(' ');
 
-  return (
-    <polygon
-      points={points}
-      className={className}
-      fill={fill}
-      onClick={clickHandler}
-      {...restProps}
-    />
-  );
+  return <polygon points={points} className={className} fill={fill} {...restProps} />;
 }

--- a/packages/vx-shape/src/shapes/Polygon.js
+++ b/packages/vx-shape/src/shapes/Polygon.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Point } from '@vx/point';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { degreesToRadians } from '../util/trigonometry';
+
+Polygon.propTypes = {
+  sides: PropTypes.number.isRequired,
+  size: PropTypes.number.isRequired,
+  className: PropTypes.string,
+  rotate: PropTypes.number,
+  clickHandler: PropTypes.func,
+  fill: PropTypes.string,
+  strokeDasharray: PropTypes.string,
+  strokeWidth: PropTypes.number,
+  stroke: PropTypes.string,
+};
+
+export const getPoint = ({
+  sides, size, center, rotate, side,
+}) => {
+  const degrees = (360 / sides) * side - rotate;
+  const radians = degreesToRadians(degrees);
+
+  return new Point({
+    x: center.x + size * Math.cos(radians),
+    y: center.y + size * Math.sin(radians),
+  });
+};
+
+export const getPoints = ({
+  sides, size, center, rotate,
+}) => [...Array(sides).keys()].map(side => getPoint({
+  sides, size, center, rotate, side,
+}));
+
+export default function Polygon({
+  sides,
+  size = 25,
+  center = new Point({ x: 0, y: 0 }),
+  rotate = 0,
+  className,
+  clickHandler,
+  fill,
+  strokeDasharray,
+  strokeWidth = 1,
+  stroke = 'black',
+  ...restProps
+}) {
+  const points = getPoints({
+    sides, size, center, rotate,
+  })
+    .map(p => p.toArray())
+    .join(' ');
+
+  return (
+    <polygon
+      points={points}
+      className={className}
+      fill={fill}
+      onClick={clickHandler}
+      {...restProps}
+    />
+  );
+}

--- a/packages/vx-shape/src/util/trigonometry.js
+++ b/packages/vx-shape/src/util/trigonometry.js
@@ -1,0 +1,1 @@
+export const degreesToRadians = degrees => (Math.PI / 180) * degrees;

--- a/packages/vx-shape/test/Polygon.test.js
+++ b/packages/vx-shape/test/Polygon.test.js
@@ -25,14 +25,14 @@ describe('<Polygon />', () => {
     expect(wrapper.prop('className')).toBe('a-polygon');
   });
 
-  it('should add click handler', () => {
+  it('should add onClick handler', () => {
     const fn = jest.fn();
 
     const wrapper = PolygonWrapper({
       sides: 6,
       size: 25,
       className: 'a-polygon',
-      clickHandler: fn,
+      onClick: fn,
     });
 
     wrapper.simulate('click');

--- a/packages/vx-shape/test/Polygon.test.js
+++ b/packages/vx-shape/test/Polygon.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Polygon, getPoint, getPoints } from '../src';
+
+const PolygonWrapper = ({ ...restProps }) => shallow(<Polygon {...restProps} />);
+
+describe('<Polygon />', () => {
+  it('should be defined', () => {
+    expect(Polygon).toBeDefined();
+  });
+
+  it('should render an octagon', () => {
+    const wrapper = PolygonWrapper({ sides: 8, size: 25 });
+
+    const polygon = wrapper.find('polygon');
+
+    const points = polygon.props().points.split(' ');
+
+    expect(points).toHaveLength(8);
+  });
+
+  it('should add classname', () => {
+    const wrapper = PolygonWrapper({ sides: 6, size: 25, className: 'a-polygon' });
+
+    expect(wrapper.prop('className')).toBe('a-polygon');
+  });
+
+  it('should add click handler', () => {
+    const fn = jest.fn();
+
+    const wrapper = PolygonWrapper({
+      sides: 6,
+      size: 25,
+      className: 'a-polygon',
+      clickHandler: fn,
+    });
+
+    wrapper.simulate('click');
+
+    expect(fn).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
#### :rocket: Enhancements

I have added a new simple `<Polygon />` component that takes `sides` and `length` props and does the rest.  I have added it to `vx-shape`
```js
// hexagon
<Polygon sides={6} size={25} {...additionalProps} />
```

-

#### :memo: Documentation
I have added a demo to `vx-demo` and updated the vx-shape README
-
