### PR TITLE
add display:none to getStringWidth svg

### DIFF
--- a/packages/vx-text/src/util/getStringWidth.js
+++ b/packages/vx-text/src/util/getStringWidth.js
@@ -10,6 +10,7 @@ function getStringWidth(str, style) {
       const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
       svg.style.width = 0;
       svg.style.height = 0;
+      svg.style.display = 'none';
       textEl = document.createElementNS('http://www.w3.org/2000/svg', 'text');
       textEl.setAttribute('id', MEASUREMENT_ELEMENT_ID);
       svg.appendChild(textEl);


### PR DESCRIPTION
fixes document height issues

#### :memo: Documentation

- measurement svg is now hidden from view to avoid document sizing issues

#### :bug: Bug Fix

- #356 
