### PR TITLE
add scale type

### DIFF
--- a/packages/vx-scale/src/scales/band.js
+++ b/packages/vx-scale/src/scales/band.js
@@ -11,6 +11,7 @@ export default ({
   tickFormat
 }) => {
   const scale = scaleBand();
+  scale.type = 'band';
 
   if (range) scale.range(range);
   if (rangeRound) scale.rangeRound(rangeRound);

--- a/packages/vx-scale/src/scales/linear.js
+++ b/packages/vx-scale/src/scales/linear.js
@@ -2,6 +2,7 @@ import { scaleLinear } from 'd3-scale';
 
 export default ({ range, rangeRound, domain, nice = false, clamp = false }) => {
   const scale = scaleLinear();
+  scale.type = 'linear';
 
   if (range) scale.range(range);
   if (rangeRound) scale.rangeRound(rangeRound);

--- a/packages/vx-scale/src/scales/log.js
+++ b/packages/vx-scale/src/scales/log.js
@@ -2,6 +2,7 @@ import { scaleLog } from 'd3-scale';
 
 export default ({ range, rangeRound, domain, base, nice = false, clamp = false }) => {
   const scale = scaleLog();
+  scale.type = 'log';
 
   if (range) scale.range(range);
   if (rangeRound) scale.rangeRound(rangeRound);

--- a/packages/vx-scale/src/scales/ordinal.js
+++ b/packages/vx-scale/src/scales/ordinal.js
@@ -2,6 +2,7 @@ import { scaleOrdinal } from 'd3-scale';
 
 export default ({ range, domain, unknown }) => {
   const scale = scaleOrdinal();
+  scale.type = 'ordinal';
 
   if (range) scale.range(range);
   if (domain) scale.domain(domain);

--- a/packages/vx-scale/src/scales/point.js
+++ b/packages/vx-scale/src/scales/point.js
@@ -2,6 +2,7 @@ import { scalePoint } from 'd3-scale';
 
 export default ({ range, rangeRound, domain, padding, align, nice = false }) => {
   const scale = scalePoint();
+  scale.type = 'point';
 
   if (range) scale.range(range);
   if (rangeRound) scale.rangeRound(rangeRound);

--- a/packages/vx-scale/src/scales/power.js
+++ b/packages/vx-scale/src/scales/power.js
@@ -2,6 +2,7 @@ import { scalePow } from 'd3-scale';
 
 export default ({ range, rangeRound, domain, exponent, nice = false, clamp = false }) => {
   const scale = scalePow();
+  scale.type = 'power';
 
   if (range) scale.range(range);
   if (rangeRound) scale.rangeRound(rangeRound);

--- a/packages/vx-scale/src/scales/quantile.js
+++ b/packages/vx-scale/src/scales/quantile.js
@@ -2,6 +2,7 @@ import { scaleQuantile } from 'd3-scale';
 
 export default ({ range, domain }) => {
   const scale = scaleQuantile();
+  scale.type = 'quantile';
 
   if (range) scale.range(range);
   if (domain) scale.domain(domain);

--- a/packages/vx-scale/src/scales/quantize.js
+++ b/packages/vx-scale/src/scales/quantize.js
@@ -2,6 +2,7 @@ import { scaleQuantize } from 'd3-scale';
 
 export default ({ range, domain, ticks, tickFormat, nice = false }) => {
   const scale = scaleQuantize();
+  scale.type = 'quantize';
 
   if (range) scale.range(range);
   if (domain) scale.domain(domain);

--- a/packages/vx-scale/src/scales/threshold.js
+++ b/packages/vx-scale/src/scales/threshold.js
@@ -2,6 +2,7 @@ import { scaleThreshold } from 'd3-scale';
 
 export default ({ range, domain }) => {
   const scale = scaleThreshold();
+  scale.type = 'threshold';
 
   if (range) scale.range(range);
   if (domain) scale.domain(domain);

--- a/packages/vx-scale/src/scales/time.js
+++ b/packages/vx-scale/src/scales/time.js
@@ -2,6 +2,7 @@ import { scaleTime } from 'd3-scale';
 
 export default ({ range, rangeRound, domain, nice = false, clamp = false }) => {
   const scale = scaleTime();
+  scale.type = 'time';
 
   if (range) scale.range(range);
   if (rangeRound) scale.rangeRound(rangeRound);

--- a/packages/vx-scale/src/scales/utc.js
+++ b/packages/vx-scale/src/scales/utc.js
@@ -2,6 +2,7 @@ import { scaleUtc } from 'd3-scale';
 
 export default ({ range, rangeRound, domain, nice = false, clamp = false }) => {
   const scale = scaleUtc();
+  scale.type = 'utc';
 
   if (range) scale.range(range);
   if (rangeRound) scale.rangeRound(rangeRound);


### PR DESCRIPTION
#### :rocket: Enhancements

- Add `type` property as utility to scales to do specific actions or use specific interfaces from "agnostic" contexts.