### PR TITLE
Add optional flex prop to LegendLabel

### DIFF
--- a/packages/vx-legend/src/legends/Legend.js
+++ b/packages/vx-legend/src/legends/Legend.js
@@ -13,6 +13,8 @@ Legend.propTypes = {
   shapeWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   shapeHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   shapeMargin: PropTypes.string,
+  labelAlign: PropTypes.string,
+  labelFlex: PropTypes.string,
   labelMargin: PropTypes.string,
   itemMargin: PropTypes.string,
   direction: PropTypes.string,
@@ -42,6 +44,7 @@ export default function Legend({
   shapeHeight = 15,
   shapeMargin = '2px 4px 2px 0',
   labelAlign = 'left',
+  labelFlex = '1',
   labelMargin = '0 4px',
   itemMargin = '0',
   direction = 'column',
@@ -78,7 +81,7 @@ export default function Legend({
               size={size}
               shapeStyle={shapeStyle}
             />
-            <LegendLabel label={text} margin={labelMargin} align={labelAlign} />
+            <LegendLabel label={text} flex={labelFlex} margin={labelMargin} align={labelAlign} />
           </LegendItem>
         );
       })}

--- a/packages/vx-legend/src/legends/LegendLabel.js
+++ b/packages/vx-legend/src/legends/LegendLabel.js
@@ -2,18 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 LegendLabel.propTypes = {
+  align: PropTypes.string.isRequired,
+  flex: PropTypes.string,
   label: PropTypes.string.isRequired,
   margin: PropTypes.string.isRequired
 };
 
-export default function LegendLabel({ label, margin, align }) {
+export default function LegendLabel({ flex = '1', label, margin, align }) {
   return (
     <div
       className="vx-legend-label"
       style={{
         justifyContent: align,
         display: 'flex',
-        flex: '1',
+        flex,
         margin
       }}
     >


### PR DESCRIPTION
#### :rocket: Enhancements

- Add optional `flex` prop for overriding `flex` css property to LegendLabel


#### :bug: Bug Fix

- Allow overriding flex property to fix [IE flexbox bug](https://stackoverflow.com/questions/39192995/flex-container-wont-expand-to-fit-content-in-ie). IE 11 does not seem to expand to minimum content width when flex-basis is 0px (this is the case when using the shorthand `flex: 1`).

I encountered a bug with the LegendLabel layout on IE11, and setting the flex property to `flex: auto` fixed it. I was hesitant to change the style for all usages, so I added an optional `flex` prop to `Legend` and `LegendLabel`.