### PR TITLE
[grid] Add tickValues prop

### DIFF
--- a/packages/vx-grid/Readme.md
+++ b/packages/vx-grid/Readme.md
@@ -28,48 +28,52 @@ const grid = (<Grid
 
 ## `<Grid />`
 
-|      Name       | Default |   Type   |                                        Description                                         |
-|:--------------- |:------- |:-------- |:------------------------------------------------------------------------------------------ |
-| top             |         | number   | The top margin in pixels.                                                                  |
-| left            |         | number   | The left margin in pixels.                                                                 |
-| xScale          |         | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the xs. |
-| yScale          |         | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the ys. |
-| width           |         | number   | The pixel width of the grid.                                                               |
-| height          |         | number   | The pixel height of the grid.                                                              |
-| className       |         | string   | The class name for the Group element.                                                      |
-| stroke          |         | string   | The color for the stroke of the grid.                                                      |
-| strokeWidth     |         | number   | The width of the lines in the stroke.                                                      |
-| strokeDasharray |         | array    | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                             |
-| numTicksRows    |         | number   | The number of row lines.                                                                   |
-| numTicksColumns |         | number   | The number of column lines.                                                                |
+|      Name        | Default |   Type   |                                        Description                                                              |
+|:---------------  |:------- |:-------- |:--------------------------------------------------------------------------------------------------------------- |
+| top              |         | number   | The top margin in pixels.                                                                                       |
+| left             |         | number   | The left margin in pixels.                                                                                      |
+| xScale           |         | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the xs.                      |
+| yScale           |         | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the ys.                      |
+| width            |         | number   | The pixel width of the grid.                                                                                    |
+| height           |         | number   | The pixel height of the grid.                                                                                   |
+| className        |         | string   | The class name for the Group element.                                                                           |
+| stroke           |         | string   | The color for the stroke of the grid.                                                                           |
+| strokeWidth      |         | number   | The width of the lines in the stroke.                                                                           |
+| strokeDasharray  |         | array    | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
+| numTicksRows     |         | number   | The number of row lines.                                                                                        |
+| numTicksColumns  |         | number   | The number of column lines.                                                                                     |
+| rowTickValues    |         | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
+| columnTickValues |         | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
 
 ## `<Rows />`
 
-|      Name       | Default |   Type   |                                         Description                                          |
-|:--------------- |:------- |:-------- |:-------------------------------------------------------------------------------------------- |
-| top             |         | number   | The top margin in pixels.                                                                    |
-| left            |         | number   | The left margin in pixels.                                                                   |
-| scale           |         | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the rows. |
-| width           |         | number   | The pixel width of the grid.                                                                 |
-| stroke          | #eaf0f6 | string   | The color for the stroke of the lines.                                                       |
-| strokeWidth     | 1       | number   | The width of the lines in the stroke.                                                        |
-| strokeDasharray |         |          | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                               |
-| className       |         |          | The class name for the Group element.                                                        |
-| numTicks        | 10      | number   | The number of row lines.                                                                     |
+|      Name       | Default |   Type   |                                         Description                                                             |
+|:--------------- |:------- |:-------- |:--------------------------------------------------------------------------------------------------------------- |
+| top             |         | number   | The top margin in pixels.                                                                                       |
+| left            |         | number   | The left margin in pixels.                                                                                      |
+| scale           |         | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the rows.                    |
+| width           |         | number   | The pixel width of the grid.                                                                                    |
+| stroke          | #eaf0f6 | string   | The color for the stroke of the lines.                                                                          |
+| strokeWidth     | 1       | number   | The width of the lines in the stroke.                                                                           |
+| strokeDasharray |         |          | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
+| className       |         |          | The class name for the Group element.                                                                           |
+| numTicks        | 10      | number   | The number of row lines.                                                                                        |
+| tickValues      |         | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
 
 ## `<Columns />`
 
-|      Name       | Default |   Type   |                                         Description                                          |
-|:--------------- |:------- |:-------- |:-------------------------------------------------------------------------------------------- |
-| top             |         | number   | The top margin in pixels.                                                                    |
-| left            |         | number   | The left margin in pixels.                                                                   |
-| scale           |         | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the rows. |
-| height          |         | number   | The pixel height of the grid.                                                                |
-| stroke          | #eaf0f6 | string   | The color for the stroke of the lines.                                                       |
-| strokeWidth     | 1       | number   | The width of the lines in the stroke.                                                        |
-| strokeDasharray |         |          | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                               |
-| className       |         |          | The class name for the Group element.                                                        |
-| numTicks        | 10      | number   | The number of row lines.                                                                     |
+|      Name       | Default |   Type   |                                         Description                                                             |
+|:--------------- |:------- |:-------- |:--------------------------------------------------------------------------------------------------------------- |
+| top             |         | number   | The top margin in pixels.                                                                                       |
+| left            |         | number   | The left margin in pixels.                                                                                      |
+| scale           |         | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the rows.                    |
+| height          |         | number   | The pixel height of the grid.                                                                                   |
+| stroke          | #eaf0f6 | string   | The color for the stroke of the lines.                                                                          |
+| strokeWidth     | 1       | number   | The width of the lines in the stroke.                                                                           |
+| strokeDasharray |         |          | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
+| className       |         |          | The class name for the Group element.                                                                           |
+| numTicks        | 10      | number   | The number of row lines.                                                                                        |
+| tickValues      |         | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
 
 
 ## Source For Components

--- a/packages/vx-grid/src/grids/Columns.js
+++ b/packages/vx-grid/src/grids/Columns.js
@@ -16,7 +16,8 @@ Columns.propTypes = {
   lineStyle: PropTypes.object,
   offset: PropTypes.number,
   scale: PropTypes.func.isRequired,
-  height: PropTypes.number.isRequired
+  height: PropTypes.number.isRequired,
+  tickValues: PropTypes.array
 };
 
 export default function Columns({
@@ -31,9 +32,11 @@ export default function Columns({
   numTicks = 10,
   lineStyle,
   offset,
+  tickValues,
   ...restProps
 }) {
-  const ticks = scale.ticks ? scale.ticks(numTicks) : scale.domain();
+  let ticks = scale.ticks ? scale.ticks(numTicks) : scale.domain();
+  if (tickValues) ticks = tickValues;
   return (
     <Group className={cx('vx-columns', className)} top={top} left={left}>
       {ticks.map((d, i) => {

--- a/packages/vx-grid/src/grids/Grid.js
+++ b/packages/vx-grid/src/grids/Grid.js
@@ -21,7 +21,9 @@ Grid.propTypes = {
   xScale: PropTypes.func.isRequired,
   yScale: PropTypes.func.isRequired,
   height: PropTypes.number.isRequired,
-  width: PropTypes.number.isRequired
+  width: PropTypes.number.isRequired,
+  rowTickValues: PropTypes.array,
+  columnTickValues: PropTypes.array
 };
 
 export default function Grid({
@@ -41,6 +43,8 @@ export default function Grid({
   columnLineStyle,
   xOffset,
   yOffset,
+  rowTickValues,
+  columnTickValues,
   ...restProps
 }) {
   return (
@@ -55,6 +59,7 @@ export default function Grid({
         numTicks={numTicksRows}
         style={rowLineStyle}
         offset={yOffset}
+        tickValues={rowTickValues}
         {...restProps}
       />
       <Columns
@@ -67,6 +72,7 @@ export default function Grid({
         numTicks={numTicksColumns}
         style={columnLineStyle}
         offset={xOffset}
+        tickValues={columnTickValues}
         {...restProps}
       />
     </Group>

--- a/packages/vx-grid/src/grids/Rows.js
+++ b/packages/vx-grid/src/grids/Rows.js
@@ -16,7 +16,8 @@ Rows.propTypes = {
   lineStyle: PropTypes.object,
   offset: PropTypes.number,
   scale: PropTypes.func.isRequired,
-  width: PropTypes.number.isRequired
+  width: PropTypes.number.isRequired,
+  tickValues: PropTypes.array
 };
 
 export default function Rows({
@@ -31,9 +32,11 @@ export default function Rows({
   numTicks = 10,
   lineStyle,
   offset,
+  tickValues,
   ...restProps
 }) {
-  const ticks = scale.ticks ? scale.ticks(numTicks) : scale.domain();
+  let ticks = scale.ticks ? scale.ticks(numTicks) : scale.domain();
+  if (tickValues) ticks = tickValues;
   return (
     <Group className={cx('vx-rows', className)} top={top} left={left}>
       {ticks.map((d, i) => {


### PR DESCRIPTION
#### :rocket: Enhancements

- Allow passing in tickValues prop to both Columns and Rows, to render grid lines at specific values.
- Allow passing in rowTickValues prop and columnTickValues prop to Grid
- Update vx-grid's Readme.md to reflect the changes above

One of the benefits of this feature is that it allows the alignment of grid lines to the tickValues passed into Axis components.