### PR TITLE
[grid] allow number `strokeWidth`s

### DIFF
--- a/packages/vx-grid/Readme.md
+++ b/packages/vx-grid/Readme.md
@@ -16,68 +16,70 @@ import { Grid } from '@vx/grid';
 // import * as Grid from '@vx/grid';
 // <Grid.Grid />
 
-const grid = (<Grid
-  xScale={xScale}
-  yScale={yScale}
-  width={xMax}
-  height={yMax}
-  numTicksRows={numTicksForHeight(height)}
-  numTicksColumns={numTicksForWidth(width)}
-/>);
+const grid = (
+  <Grid
+    xScale={xScale}
+    yScale={yScale}
+    width={xMax}
+    height={yMax}
+    numTicksRows={numTicksForHeight(height)}
+    numTicksColumns={numTicksForWidth(width)}
+  />
+);
 ```
 
 ## `<Grid />`
 
-|      Name        | Default |   Type   |                                        Description                                                              |
-|:---------------  |:------- |:-------- |:--------------------------------------------------------------------------------------------------------------- |
-| top              |         | number   | The top margin in pixels.                                                                                       |
-| left             |         | number   | The left margin in pixels.                                                                                      |
-| xScale           |         | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the xs.                      |
-| yScale           |         | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the ys.                      |
-| width            |         | number   | The pixel width of the grid.                                                                                    |
-| height           |         | number   | The pixel height of the grid.                                                                                   |
-| className        |         | string   | The class name for the Group element.                                                                           |
-| stroke           |         | string   | The color for the stroke of the grid.                                                                           |
-| strokeWidth      |         | number   | The width of the lines in the stroke.                                                                           |
-| strokeDasharray  |         | array    | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
-| numTicksRows     |         | number   | The number of row lines.                                                                                        |
-| numTicksColumns  |         | number   | The number of column lines.                                                                                     |
-| rowTickValues    |         | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
-| columnTickValues |         | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
+|      Name        | Default |   Type        |                                        Description                                                              |
+|:---------------  |:------- |:------------- |:--------------------------------------------------------------------------------------------------------------- |
+| top              |         | number        | The top margin in pixels.                                                                                       |
+| left             |         | number        | The left margin in pixels.                                                                                      |
+| xScale           |         | function      | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the xs.                      |
+| yScale           |         | function      | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the ys.                      |
+| width            |         | number        | The pixel width of the grid.                                                                                    |
+| height           |         | number        | The pixel height of the grid.                                                                                   |
+| className        |         | string        | The class name for the Group element.                                                                           |
+| stroke           |         | string        | The color for the stroke of the grid.                                                                           |
+| strokeWidth      |         | string|number | The width of the lines in the stroke.                                                                           |
+| strokeDasharray  |         | array         | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
+| numTicksRows     |         | number        | The number of row lines.                                                                                        |
+| numTicksColumns  |         | number        | The number of column lines.                                                                                     |
+| rowTickValues    |         | Array         | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
+| columnTickValues |         | Array         | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
 
-## `<Rows />`
+## `<GridRows />`
 
-|      Name       | Default |   Type   |                                         Description                                                             |
-|:--------------- |:------- |:-------- |:--------------------------------------------------------------------------------------------------------------- |
-| top             |         | number   | The top margin in pixels.                                                                                       |
-| left            |         | number   | The left margin in pixels.                                                                                      |
-| scale           |         | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the rows.                    |
-| width           |         | number   | The pixel width of the grid.                                                                                    |
-| stroke          | #eaf0f6 | string   | The color for the stroke of the lines.                                                                          |
-| strokeWidth     | 1       | number   | The width of the lines in the stroke.                                                                           |
-| strokeDasharray |         |          | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
-| className       |         |          | The class name for the Group element.                                                                           |
-| numTicks        | 10      | number   | The number of row lines.                                                                                        |
-| tickValues      |         | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
+|      Name       | Default |   Type        |                                         Description                                                             |
+|:--------------- |:------- |:------------- |:--------------------------------------------------------------------------------------------------------------- |
+| top             |         | number        | The top margin in pixels.                                                                                       |
+| left            |         | number        | The left margin in pixels.                                                                                      |
+| scale           |         | function      | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the rows.                    |
+| width           |         | number        | The pixel width of the grid.                                                                                    |
+| stroke          | #eaf0f6 | string        | The color for the stroke of the lines.                                                                          |
+| strokeWidth     | 1       | string|number | The width of the lines in the stroke.                                                                           |
+| strokeDasharray |         |               | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
+| className       |         |               | The class name for the Group element.                                                                           |
+| numTicks        | 10      | number        | The number of row lines.                                                                                        |
+| tickValues      |         | Array         | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
 
-## `<Columns />`
+## `<GridColumns />`
 
-|      Name       | Default |   Type   |                                         Description                                                             |
-|:--------------- |:------- |:-------- |:--------------------------------------------------------------------------------------------------------------- |
-| top             |         | number   | The top margin in pixels.                                                                                       |
-| left            |         | number   | The left margin in pixels.                                                                                      |
-| scale           |         | function | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the rows.                    |
-| height          |         | number   | The pixel height of the grid.                                                                                   |
-| stroke          | #eaf0f6 | string   | The color for the stroke of the lines.                                                                          |
-| strokeWidth     | 1       | number   | The width of the lines in the stroke.                                                                           |
-| strokeDasharray |         |          | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
-| className       |         |          | The class name for the Group element.                                                                           |
-| numTicks        | 10      | number   | The number of row lines.                                                                                        |
-| tickValues      |         | Array    | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
+|      Name       | Default |   Type        |                                         Description                                                             |
+|:--------------- |:------- |:------------- |:--------------------------------------------------------------------------------------------------------------- |
+| top             |         | number        | The top margin in pixels.                                                                                       |
+| left            |         | number        | The left margin in pixels.                                                                                      |
+| scale           |         | function      | A [scale function](https://github.com/hshoff/vx/tree/master/packages/vx-scale) for the rows.                    |
+| height          |         | number        | The pixel height of the grid.                                                                                   |
+| stroke          | #eaf0f6 | string        | The color for the stroke of the lines.                                                                          |
+| strokeWidth     | 1       | string|number | The width of the lines in the stroke.                                                                           |
+| strokeDasharray |         |               | The [pattern of dashes](https://mzl.la/1l7EiTQ) in the stroke.                                                  |
+| className       |         |               | The class name for the Group element.                                                                           |
+| numTicks        | 10      | number        | The number of row lines.                                                                                        |
+| tickValues      |         | Array         | An array of values that determine the number and values of the ticks. Falls back to scale.ticks() or .domain(). |
 
 
 ## Source For Components
 
 + [`<Grid />`](https://github.com/hshoff/vx/blob/master/packages/vx-grid/src/grids/Grid.js)
-+ [`<Rows />`](https://github.com/hshoff/vx/blob/master/packages/vx-grid/src/grids/Rows.js)
-+ [`<Columns />`](https://github.com/hshoff/vx/blob/master/packages/vx-grid/src/grids/Columns.js)
++ [`<GridRows />`](https://github.com/hshoff/vx/blob/master/packages/vx-grid/src/grids/Rows.js)
++ [`<GridColumns />`](https://github.com/hshoff/vx/blob/master/packages/vx-grid/src/grids/Columns.js)

--- a/packages/vx-grid/src/grids/Columns.js
+++ b/packages/vx-grid/src/grids/Columns.js
@@ -10,7 +10,7 @@ Columns.propTypes = {
   left: PropTypes.number,
   className: PropTypes.string,
   stroke: PropTypes.string,
-  strokeWidth: PropTypes.string,
+  strokeWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   strokeDasharray: PropTypes.string,
   numTicks: PropTypes.number,
   lineStyle: PropTypes.object,

--- a/packages/vx-grid/src/grids/Grid.js
+++ b/packages/vx-grid/src/grids/Grid.js
@@ -10,7 +10,7 @@ Grid.propTypes = {
   left: PropTypes.number,
   className: PropTypes.string,
   stroke: PropTypes.string,
-  strokeWidth: PropTypes.string,
+  strokeWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   strokeDasharray: PropTypes.string,
   numTicksRows: PropTypes.number,
   numTicksColumns: PropTypes.number,

--- a/packages/vx-grid/src/grids/Rows.js
+++ b/packages/vx-grid/src/grids/Rows.js
@@ -10,7 +10,7 @@ Rows.propTypes = {
   left: PropTypes.number,
   className: PropTypes.string,
   stroke: PropTypes.string,
-  strokeWidth: PropTypes.string,
+  strokeWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   strokeDasharray: PropTypes.string,
   numTicks: PropTypes.number,
   lineStyle: PropTypes.object,


### PR DESCRIPTION
#### :bug: Bug Fix

This PR
- updates `strokeWidth` `propTypes` in the `@vx/grid` components to allow numbers in addition to strings. 
- updates the readme and changes component names to reflect the component names exported in the package `index.js`