### PR TITLE
Let y0 use the same way as y

### DIFF
--- a/packages/vx-shape/src/shapes/AreaClosed.js
+++ b/packages/vx-shape/src/shapes/AreaClosed.js
@@ -27,7 +27,7 @@ export default function AreaClosed({
 }) {
   const path = area()
     .x((...args) => xScale(x(...args)))
-    .y0(y0 || yScale.range()[0])
+    .y0(y0 ? (...args) => xScale(y0(...args)) : yScale.range()[0])
     .y1((...args) => yScale(y(...args)))
     .defined(defined);
   if (curve) path.curve(curve);


### PR DESCRIPTION
change
```
<AreaClosed y={d => d.a} y0={d => yScale(d.b})/>
```
to

```
<AreaClosed y={d => d.a} y0={d => d.b}/>
```

#### :boom: Breaking Changes

- 

#### :rocket: Enhancements

-

#### :memo: Documentation

-

#### :bug: Bug Fix

- 

#### :house: Internal

-
