### PR TITLE
[tooltip][TooltipWithBounds] Use integer pixel values for translation

### DIFF
--- a/packages/vx-tooltip/src/tooltips/TooltipWithBounds.js
+++ b/packages/vx-tooltip/src/tooltips/TooltipWithBounds.js
@@ -63,6 +63,9 @@ function TooltipWithBounds({
         : top + offsetTop;
   }
 
+  left = Math.round(left);
+  top = Math.round(top);
+
   return (
     <Tooltip
       style={{ top: 0, transform: `translate(${left}px, ${top}px)`, ...style }}


### PR DESCRIPTION
#### :bug: Bug Fix

- From experiment, it appears that fractional pixel values can sometimes lead to shaky rendering when using Firefox. Fixes #388.