### PR TITLE
add innerRef prop to ScaleSVG in @vx/responsive

### DIFF
--- a/packages/vx-responsive/src/components/ScaleSVG.js
+++ b/packages/vx-responsive/src/components/ScaleSVG.js
@@ -7,7 +7,8 @@ ResponsiveSVG.propTypes = {
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   xOrigin: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   yOrigin: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  preserveAspectRatio: PropTypes.string
+  preserveAspectRatio: PropTypes.string,
+  innerRef: PropTypes.func
 };
 
 export default function ResponsiveSVG({
@@ -16,7 +17,8 @@ export default function ResponsiveSVG({
   height,
   xOrigin = 0,
   yOrigin = 0,
-  preserveAspectRatio = 'xMinYMin meet'
+  preserveAspectRatio = 'xMinYMin meet',
+  innerRef
 }) {
   return (
     <div
@@ -31,6 +33,7 @@ export default function ResponsiveSVG({
       <svg
         preserveAspectRatio={preserveAspectRatio}
         viewBox={`${xOrigin} ${yOrigin} ${width} ${height}`}
+        ref={innerRef}
       >
         {children}
       </svg>

--- a/packages/vx-responsive/test/ScaleSVG.test.js
+++ b/packages/vx-responsive/test/ScaleSVG.test.js
@@ -1,7 +1,18 @@
+import React from 'react';
 import { ScaleSVG } from '../src';
+import { shallow, mount } from 'enzyme';
 
 describe('<ScaleSVG />', () => {
   test('it should be defined', () => {
     expect(ScaleSVG).toBeDefined();
+  });
+
+  test('it should expose its ref via an innerRef prop', done => {
+    const refCallback = n => {
+      expect(n.tagName).toEqual('svg');
+      done();
+    };
+
+    mount(<ScaleSVG innerRef={refCallback} />);
   });
 });


### PR DESCRIPTION
#### :rocket: Enhancements

add the ability to add a ref to `ScaleSVG`

I currently need a ref in the svg rendered from `ScaleSVG`.

```
<svg
  preserveAspectRatio={preserveAspectRatio}
  viewBox={`${xOrigin} ${yOrigin} ${width} ${height}`}
  ref={innerRef}
>
  {children}
</svg>
```