### PR TITLE
refactor @vx/text unsfafe CWM => CDM, CWP => CDU

### DIFF
--- a/packages/vx-text/package.json
+++ b/packages/vx-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vx/text",
-  "version": "0.0.182",
+  "version": "0.1.0",
   "description": "vx text",
   "sideEffects": false,
   "main": "dist/vx-text.umd.js",

--- a/packages/vx-text/src/Text.js
+++ b/packages/vx-text/src/Text.js
@@ -11,38 +11,50 @@ class Text extends Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.updateWordsByLines(this.props, true);
   }
 
-  componentWillReceiveProps(nextProps) {
-    const needCalculate =
-      this.props.children !== nextProps.children || this.props.style !== nextProps.style;
-    this.updateWordsByLines(nextProps, needCalculate);
+  componentDidUpdate(nextProps) {
+    const { width, scaleToFit, children } = this.props;
+
+    if (width || scaleToFit) {
+      if (width === nextProps.width && scaleToFit === nextProps.scaleToFit) {
+        return;
+      }
+
+      const needCalculate =
+        this.props.children !== nextProps.children || this.props.style !== nextProps.style;
+
+      this.updateWordsByLines(nextProps, needCalculate);
+
+      return;
+    }
+
+    if (nextProps.children === children) {
+      return;
+    }
+
+    this.updateWordsWithoutCalculate(nextProps);
   }
 
   updateWordsByLines(props, needCalculate) {
-    // Only perform calculations if using features that require them (multiline, scaleToFit)
-    if (props.width || props.scaleToFit) {
-      if (needCalculate) {
-        const words = props.children ? props.children.toString().split(/\s+/) : [];
+    if (needCalculate) {
+      const words = props.children ? props.children.toString().split(/\s+/) : [];
 
-        this.wordsWithComputedWidth = words.map(word => ({
-          word,
-          width: getStringWidth(word, props.style)
-        }));
-        this.spaceWidth = getStringWidth('\u00A0', props.style);
-      }
-
-      const wordsByLines = this.calculateWordsByLines(
-        this.wordsWithComputedWidth,
-        this.spaceWidth,
-        props.width
-      );
-      this.setState({ wordsByLines });
-    } else {
-      this.updateWordsWithoutCalculate(props);
+      this.wordsWithComputedWidth = words.map(word => ({
+        word,
+        width: getStringWidth(word, props.style)
+      }));
+      this.spaceWidth = getStringWidth('\u00A0', props.style);
     }
+
+    const wordsByLines = this.calculateWordsByLines(
+      this.wordsWithComputedWidth,
+      this.spaceWidth,
+      props.width
+    );
+    this.setState({ wordsByLines });
   }
 
   updateWordsWithoutCalculate(props) {


### PR DESCRIPTION
#### :boom: Breaking Changes

I am trying to use @vx/text in Rect strict mode and it has flagged the `componentWillMount` and `componentWillReceiveProps` methods as soon to be deprecated.

This PR changes `componentWIllMount`:

```js
  componentDidMount() {
    this.updateWordsByLines(this.props, true);
  }
```

And `componentWillReceiveProps` to `componentDidUpdate`:

```js
componentDidUpdate(nextProps) {
    const { width, scaleToFit, children } = this.props;

    if (width || scaleToFit) {
      if (width === nextProps.width && scaleToFit === nextProps.scaleToFit) {
        return;
      }

      const needCalculate =
        this.props.children !== nextProps.children || this.props.style !== nextProps.style;

      this.updateWordsByLines(nextProps, needCalculate);

      return;
    }

    if (nextProps.children === children) {
      return;
    }

    this.updateWordsWithoutCalculate(nextProps);
  }
```

There are no tests due to jsDom limitations so really hard to say if this has broken anything.