### PR TITLE
[axis] add `AxisRadial` component

### DIFF
--- a/packages/vx-axis/package.json
+++ b/packages/vx-axis/package.json
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/hshoff/vx#readme",
   "dependencies": {
+    "@vx/curve": "0.0.182",
     "@vx/group": "0.0.183",
     "@vx/point": "0.0.182",
     "@vx/shape": "0.0.183",

--- a/packages/vx-axis/src/axis/AxisRadial.js
+++ b/packages/vx-axis/src/axis/AxisRadial.js
@@ -8,6 +8,7 @@ import { Text } from '@vx/text';
 import { curveCardinal } from '@vx/curve';
 
 import ORIENT from '../constants/orientation';
+import polarToCartesian from '../utils/polarToCartesian';
 import radialLabelTransform from '../utils/radialLabelTransform';
 import radialTickLabelTransform from '../utils/radialTickLabelTransform';
 import identity from '../utils/identity';
@@ -42,13 +43,21 @@ const propTypes = {
    */
   labelClassName: PropTypes.string,
   /**
-   * Pixel offset of the axis label (does not include tick length or tick label font size, which is accounted for automatically)
+   * Pixel offset of the axis label (does not include tick length or
+   * tick label font size, which is accounted for automatically)
    */
   labelOffset: PropTypes.number,
   /**
-   * Props applied to the axis label component.
+   * High-leevl positioning of axis label component. Can be
+   * refined or customized further using labelProps.
    */
-  labelOrientation: PropTypes.oneOf(['top', 'right', 'bottom', 'left', 'center']),
+  labelOrientation: PropTypes.oneOf([
+    ORIENT.top,
+    ORIENT.right,
+    ORIENT.bottom,
+    ORIENT.left,
+    ORIENT.center
+  ]),
   /**
    * Props applied to the axis label component.
    */
@@ -106,7 +115,8 @@ const propTypes = {
    */
   tickTransform: PropTypes.string,
   /**
-   * An array of values that determine the number and values of the ticks. Falls back to `scale.ticks()` or `.domain()`.
+   * An array of values that determine the number and values of the ticks.
+   * Falls back to `scale.ticks()` or `.domain()`.
    */
   tickValues: PropTypes.array,
   /**
@@ -120,7 +130,7 @@ const propTypes = {
   /**
    * For more control over rendering or to add event handlers to datum, pass a function as children.
    */
-  children: PropTypes.func,
+  children: PropTypes.func
 };
 
 export default function AxisRadial({
@@ -138,7 +148,7 @@ export default function AxisRadial({
     fontFamily: 'Arial',
     fontSize: 12,
     fontWeight: 'bold',
-    fill: 'black',
+    fill: 'black'
   },
   left = 0,
   numTicks = 10,
@@ -152,14 +162,14 @@ export default function AxisRadial({
   tickLabelProps = (tickValue, index) => ({
     fontFamily: 'Arial',
     fontSize: 10,
-    fill: 'black',
+    fill: 'black'
   }),
   tickLength = 8,
   tickStroke = 'black',
   tickTransform,
   tickValues,
   tickComponent,
-  top = 0,
+  top = 0
 }) {
   let values = scale.ticks ? scale.ticks(numTicks) : scale.domain();
   if (tickValues) values = tickValues;
@@ -176,7 +186,7 @@ export default function AxisRadial({
       const tickFromPoint = new Point(polarToCartesian({ angle, radius }));
       const tickToPoint = new Point(polarToCartesian({ angle, radius: radius + tickLength }));
 
-      const tickOrientationProps = getTickLabelOrientationProps(tickFromPoint, tickToPoint);
+      const tickOrientationProps = radialTickLabelTransform(tickFromPoint, tickToPoint);
       const tickLabelPropsObj = { ...tickOrientationProps, ...tickLabelProps(val, index) };
       tickLabelFontSize = Math.max(tickLabelFontSize, tickLabelPropsObj.fontSize || 0);
 
@@ -198,7 +208,7 @@ export default function AxisRadial({
           radius,
           tickLength,
           tickFormat: format,
-          ticks,
+          ticks
         })}
       </Group>
     );
@@ -212,24 +222,27 @@ export default function AxisRadial({
         const tickAngle = scale(val) - Math.PI / 2; // @TODO why is this off by 45°?
         const tickFromPoint = new Point(polarToCartesian({ angle: tickAngle, radius }));
         const tickToPoint = new Point(
-          polarToCartesian({ angle: tickAngle, radius: radius + tickLength }),
+          polarToCartesian({ angle: tickAngle, radius: radius + tickLength })
         );
 
         const tickOrientationProps = radialTickLabelTransform(tickFromPoint, tickToPoint);
-        const tickLabelPropsObj = { ...tickOrientationProps, ...tickLabelProps(val, index) };
+        const tickLabelPropsObj = {
+          ...tickOrientationProps,
+          ...tickLabelProps(val, index)
+        };
         const formattedValue = format(val, index);
 
         return (
           <Group
             key={`vx-tick-${val}-${index}`}
-            className={cx('vx-radial-axis-tick', tickClassName)}
+            className={cx('vx-axis-tick', tickClassName)}
             transform={tickTransform}
           >
             {!hideTicks && <Line from={tickFromPoint} to={tickToPoint} stroke={tickStroke} />}
             {tickComponent ? (
               tickComponent({
                 formattedValue,
-                ...tickLabelPropsObj,
+                ...tickLabelPropsObj
               })
             ) : (
               <Text {...tickLabelPropsObj}>{formattedValue}</Text>
@@ -240,7 +253,7 @@ export default function AxisRadial({
 
       {!hideAxisLine && (
         <LineRadial
-          className={cx('vx-radial-axis-line', axisLineClassName)}
+          className={cx('vx-axis-line', axisLineClassName)}
           data={axisLineData}
           angle={angle}
           radius={radius}
@@ -253,14 +266,14 @@ export default function AxisRadial({
 
       {label && (
         <Text
-          className={cx('vx-radial-axis-label', labelClassName)}
+          className={cx('vx-axis-label', labelClassName)}
           {...radialLabelTransform({
             labelOffset,
             labelOrientation,
             labelProps,
             radius,
             tickLabelFontSize,
-            tickLength,
+            tickLength
           })}
           {...labelProps}
         >

--- a/packages/vx-axis/src/axis/AxisRadial.js
+++ b/packages/vx-axis/src/axis/AxisRadial.js
@@ -1,0 +1,274 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { Line, LineRadial } from '@vx/shape';
+import { Point } from '@vx/point';
+import { Group } from '@vx/group';
+import { Text } from '@vx/text';
+import { curveCardinal } from '@vx/curve';
+
+import ORIENT from '../constants/orientation';
+import radialLabelTransform from '../utils/radialLabelTransform';
+import radialTickLabelTransform from '../utils/radialTickLabelTransform';
+import identity from '../utils/identity';
+
+const propTypes = {
+  /**
+   * The class name applied to the outermost axis group element.
+   */
+  axisClassName: PropTypes.string,
+  /**
+   * The class name applied to the axis line element.
+   */
+  axisLineClassName: PropTypes.string,
+  /**
+   * If true, will hide the axis line.
+   */
+  hideAxisLine: PropTypes.bool,
+  /**
+   * If true, will hide the ticks (but not the tick labels).
+   */
+  hideTicks: PropTypes.bool,
+  /**
+   * If true, will hide the '0' value tick and tick label.
+   */
+  hideZero: PropTypes.bool,
+  /**
+   * The text for the axis label.
+   */
+  label: PropTypes.string,
+  /**
+   * The class name applied to the axis label text element.
+   */
+  labelClassName: PropTypes.string,
+  /**
+   * Pixel offset of the axis label (does not include tick length or tick label font size, which is accounted for automatically)
+   */
+  labelOffset: PropTypes.number,
+  /**
+   * Props applied to the axis label component.
+   */
+  labelOrientation: PropTypes.oneOf(['top', 'right', 'bottom', 'left', 'center']),
+  /**
+   * Props applied to the axis label component.
+   */
+  labelProps: PropTypes.object,
+  /**
+   * A left pixel offset applied to the entire axis.
+   */
+  left: PropTypes.number,
+  /**
+   * The number of ticks wanted for the axis (note this is approximate due to d3's algorithm)
+   */
+  numTicks: PropTypes.number,
+  /**
+   * The required pixel size of the radius of the radial axis
+   * */
+  radius: PropTypes.number.isRequired,
+  /**
+   * A [d3](https://github.com/d3/d3-scale) or [vx](https://github.com/hshoff/vx/tree/master/packages/vx-scale) scale function.
+   */
+  scale: PropTypes.func.isRequired,
+  /**
+   * The color for the stroke of the lines.
+   */
+  stroke: PropTypes.string,
+  /**
+   * The pixel value for the width of the lines.
+   */
+  strokeWidth: PropTypes.number,
+  /**
+   * The pattern of dashes in the stroke.
+   */
+  strokeDasharray: PropTypes.string,
+  /**
+   * The class name applied to each tick group
+   */
+  tickClassName: PropTypes.string,
+  /**
+   * A [d3 formatter](https://github.com/d3/d3-scale/blob/master/README.md#continuous_tickFormat) for the tick text.
+   */
+  tickFormat: PropTypes.func,
+  /**
+   * A function that returns props for a given tick value and index.
+   */
+  tickLabelProps: PropTypes.func,
+  /**
+   * The length of the tick lines.
+   */
+  tickLength: PropTypes.number,
+  /**
+   * The color for the tick's stroke value.
+   */
+  tickStroke: PropTypes.string,
+  /**
+   * A custom SVG transform value to be applied to each tick group.
+   */
+  tickTransform: PropTypes.string,
+  /**
+   * An array of values that determine the number and values of the ticks. Falls back to `scale.ticks()` or `.domain()`.
+   */
+  tickValues: PropTypes.array,
+  /**
+   * For more control over tick label rendering, pass a function
+   */
+  tickComponent: PropTypes.func,
+  /**
+   * A top pixel offset applied to the entire axis.
+   */
+  top: PropTypes.number,
+  /**
+   * For more control over rendering or to add event handlers to datum, pass a function as children.
+   */
+  children: PropTypes.func,
+};
+
+export default function AxisRadial({
+  children,
+  axisClassName,
+  axisLineClassName,
+  hideAxisLine = false,
+  hideTicks = false,
+  hideZero = false,
+  label = '',
+  labelClassName,
+  labelOffset = 14,
+  labelOrientation = 'top',
+  labelProps = {
+    fontFamily: 'Arial',
+    fontSize: 12,
+    fontWeight: 'bold',
+    fill: 'black',
+  },
+  left = 0,
+  numTicks = 10,
+  radius,
+  scale,
+  stroke = 'black',
+  strokeWidth = 1,
+  strokeDasharray,
+  tickClassName,
+  tickFormat,
+  tickLabelProps = (tickValue, index) => ({
+    fontFamily: 'Arial',
+    fontSize: 10,
+    fill: 'black',
+  }),
+  tickLength = 8,
+  tickStroke = 'black',
+  tickTransform,
+  tickValues,
+  tickComponent,
+  top = 0,
+}) {
+  let values = scale.ticks ? scale.ticks(numTicks) : scale.domain();
+  if (tickValues) values = tickValues;
+  let format = scale.tickFormat ? scale.tickFormat() : identity;
+  if (tickFormat) format = tickFormat;
+
+  let tickLabelFontSize = 10; // track the max tick label size to compute label offset
+
+  const ticks = values
+    .map((val, index) => {
+      if (hideZero && val === 0) return null;
+
+      const angle = scale(val) - Math.PI / 2; // @TODO why is this off by 45°?
+      const tickFromPoint = new Point(polarToCartesian({ angle, radius }));
+      const tickToPoint = new Point(polarToCartesian({ angle, radius: radius + tickLength }));
+
+      const tickOrientationProps = getTickLabelOrientationProps(tickFromPoint, tickToPoint);
+      const tickLabelPropsObj = { ...tickOrientationProps, ...tickLabelProps(val, index) };
+      tickLabelFontSize = Math.max(tickLabelFontSize, tickLabelPropsObj.fontSize || 0);
+
+      return tickLabelPropsObj;
+    })
+    .filter(defined => !!defined);
+
+  const axisLineData = scale.ticks(50);
+  const angle = d => scale(d);
+
+  if (children) {
+    return (
+      <Group className={cx('vx-axis-radial', axisClassName)} top={top} left={left}>
+        {children({
+          angle,
+          axisLineData,
+          numTicks,
+          label,
+          radius,
+          tickLength,
+          tickFormat: format,
+          ticks,
+        })}
+      </Group>
+    );
+  }
+
+  return (
+    <Group className={cx('vx-axis-radial', axisClassName)} top={top} left={left}>
+      {values.map((val, index) => {
+        if (hideZero && val === 0) return null;
+
+        const tickAngle = scale(val) - Math.PI / 2; // @TODO why is this off by 45°?
+        const tickFromPoint = new Point(polarToCartesian({ angle: tickAngle, radius }));
+        const tickToPoint = new Point(
+          polarToCartesian({ angle: tickAngle, radius: radius + tickLength }),
+        );
+
+        const tickOrientationProps = radialTickLabelTransform(tickFromPoint, tickToPoint);
+        const tickLabelPropsObj = { ...tickOrientationProps, ...tickLabelProps(val, index) };
+        const formattedValue = format(val, index);
+
+        return (
+          <Group
+            key={`vx-tick-${val}-${index}`}
+            className={cx('vx-radial-axis-tick', tickClassName)}
+            transform={tickTransform}
+          >
+            {!hideTicks && <Line from={tickFromPoint} to={tickToPoint} stroke={tickStroke} />}
+            {tickComponent ? (
+              tickComponent({
+                formattedValue,
+                ...tickLabelPropsObj,
+              })
+            ) : (
+              <Text {...tickLabelPropsObj}>{formattedValue}</Text>
+            )}
+          </Group>
+        );
+      })}
+
+      {!hideAxisLine && (
+        <LineRadial
+          className={cx('vx-radial-axis-line', axisLineClassName)}
+          data={axisLineData}
+          angle={angle}
+          radius={radius}
+          stroke={stroke}
+          strokeWidth={strokeWidth}
+          strokeDasharray={strokeDasharray}
+          curve={curveCardinal}
+        />
+      )}
+
+      {label && (
+        <Text
+          className={cx('vx-radial-axis-label', labelClassName)}
+          {...radialLabelTransform({
+            labelOffset,
+            labelOrientation,
+            labelProps,
+            radius,
+            tickLabelFontSize,
+            tickLength,
+          })}
+          {...labelProps}
+        >
+          {label}
+        </Text>
+      )}
+    </Group>
+  );
+}
+
+AxisRadial.propTypes = propTypes;

--- a/packages/vx-axis/src/axis/AxisRadial.js
+++ b/packages/vx-axis/src/axis/AxisRadial.js
@@ -182,7 +182,7 @@ export default function AxisRadial({
     .map((val, index) => {
       if (hideZero && val === 0) return null;
 
-      const angle = scale(val) - Math.PI / 2; // @TODO why is this off by 45°?
+      const angle = scale(val) - Math.PI / 2;
       const tickFromPoint = new Point(polarToCartesian({ angle, radius }));
       const tickToPoint = new Point(polarToCartesian({ angle, radius: radius + tickLength }));
 

--- a/packages/vx-axis/src/constants/orientation.js
+++ b/packages/vx-axis/src/constants/orientation.js
@@ -2,5 +2,6 @@ export default {
   top: 'top',
   left: 'left',
   right: 'right',
-  bottom: 'bottom'
+  bottom: 'bottom',
+  center: 'center'
 };

--- a/packages/vx-axis/src/index.js
+++ b/packages/vx-axis/src/index.js
@@ -3,4 +3,5 @@ export { default as AxisLeft } from './axis/AxisLeft';
 export { default as AxisRight } from './axis/AxisRight';
 export { default as AxisTop } from './axis/AxisTop';
 export { default as AxisBottom } from './axis/AxisBottom';
+export { default as AxisRadial } from './axis/AxisRadial';
 export { default as Orientation } from './constants/orientation';

--- a/packages/vx-axis/src/utils/polarToCartesian.js
+++ b/packages/vx-axis/src/utils/polarToCartesian.js
@@ -1,0 +1,6 @@
+export default function polarToCartesian({ radius, angle }) {
+  return {
+      x: radius * Math.cos(angle),
+      y: radius * Math.sin(angle),
+  };
+}

--- a/packages/vx-axis/src/utils/polarToCartesian.js
+++ b/packages/vx-axis/src/utils/polarToCartesian.js
@@ -1,6 +1,6 @@
 export default function polarToCartesian({ radius, angle }) {
   return {
-      x: radius * Math.cos(angle),
-      y: radius * Math.sin(angle),
+    x: radius * Math.cos(angle),
+    y: radius * Math.sin(angle)
   };
 }

--- a/packages/vx-axis/src/utils/radialLabelTransform.js
+++ b/packages/vx-axis/src/utils/radialLabelTransform.js
@@ -1,32 +1,32 @@
 export default function radialLabelTransform({
-    labelOffset,
-    labelOrientation,
-    labelProps,
-    radius,
-    tickLabelFontSize,
-    tickLength,
-  }) {
-    let x = 0;
-    let y = 0;
-    let textAnchor = 'middle';
-  
-    const offset =
-      tickLength +
-      labelOffset +
-      tickLabelFontSize +
-      (labelOrientation === 'bottom' ? labelProps.fontSize : 0);
-  
-    if (labelOrientation === 'top') {
-      y = -radius - offset;
-    } else if (labelOrientation === 'right') {
-      x = radius + offset;
-      textAnchor = 'start';
-    } else if (labelOrientation === 'bottom') {
-      y = radius + offset;
-    } else if (labelOrientation === 'left') {
-      x = -radius - offset;
-      textAnchor = 'end';
-    }
-  
-    return { x, y, textAnchor };
+  labelOffset,
+  labelOrientation,
+  labelProps,
+  radius,
+  tickLabelFontSize,
+  tickLength
+}) {
+  let x = 0;
+  let y = 0;
+  let textAnchor = 'middle';
+
+  const offset =
+    tickLength +
+    labelOffset +
+    tickLabelFontSize +
+    (labelOrientation === 'bottom' ? labelProps.fontSize : 0);
+
+  if (labelOrientation === 'top') {
+    y = -radius - offset;
+  } else if (labelOrientation === 'right') {
+    x = radius + offset;
+    textAnchor = 'start';
+  } else if (labelOrientation === 'bottom') {
+    y = radius + offset;
+  } else if (labelOrientation === 'left') {
+    x = -radius - offset;
+    textAnchor = 'end';
   }
+
+  return { x, y, textAnchor };
+}

--- a/packages/vx-axis/src/utils/radialLabelTransform.js
+++ b/packages/vx-axis/src/utils/radialLabelTransform.js
@@ -1,0 +1,32 @@
+export default function radialLabelTransform({
+    labelOffset,
+    labelOrientation,
+    labelProps,
+    radius,
+    tickLabelFontSize,
+    tickLength,
+  }) {
+    let x = 0;
+    let y = 0;
+    let textAnchor = 'middle';
+  
+    const offset =
+      tickLength +
+      labelOffset +
+      tickLabelFontSize +
+      (labelOrientation === 'bottom' ? labelProps.fontSize : 0);
+  
+    if (labelOrientation === 'top') {
+      y = -radius - offset;
+    } else if (labelOrientation === 'right') {
+      x = radius + offset;
+      textAnchor = 'start';
+    } else if (labelOrientation === 'bottom') {
+      y = radius + offset;
+    } else if (labelOrientation === 'left') {
+      x = -radius - offset;
+      textAnchor = 'end';
+    }
+  
+    return { x, y, textAnchor };
+  }

--- a/packages/vx-axis/src/utils/radialTickLabelTransform.js
+++ b/packages/vx-axis/src/utils/radialTickLabelTransform.js
@@ -1,28 +1,28 @@
 const CENTER_ALIGN_THRESHOLD = 1;
 
-function radialTickLabelTransform(fromPoint, toPoint) {
-    let textAnchor = 'middle';
-    let verticalAnchor = 'middle';
-    const dx = toPoint.x - fromPoint.x;
-    const dy = toPoint.y - fromPoint.y;
-  
-    // offset the label in the same direction as the tick orientation
-    const x = toPoint.x + dx;
-    const y = toPoint.y + dy;
-  
-    // positive dx means tick points right
-    if (dx > CENTER_ALIGN_THRESHOLD) {
-      textAnchor = 'start';
-    } else if (dx < -CENTER_ALIGN_THRESHOLD) {
-      textAnchor = 'end';
-    }
-  
-    // positive dy means tick points up
-    if (dy > CENTER_ALIGN_THRESHOLD) {
-      verticalAnchor = 'start';
-    } else if (dy < -CENTER_ALIGN_THRESHOLD) {
-      verticalAnchor = 'end';
-    }
-  
-    return { textAnchor, verticalAnchor, x, y };
+export default function radialTickLabelTransform(fromPoint, toPoint) {
+  let textAnchor = 'middle';
+  let verticalAnchor = 'middle';
+  const dx = toPoint.x - fromPoint.x;
+  const dy = toPoint.y - fromPoint.y;
+
+  // offset the label in the same direction as the tick orientation
+  const x = toPoint.x + dx;
+  const y = toPoint.y + dy;
+
+  // positive dx means tick points right
+  if (dx > CENTER_ALIGN_THRESHOLD) {
+    textAnchor = 'start';
+  } else if (dx < -CENTER_ALIGN_THRESHOLD) {
+    textAnchor = 'end';
   }
+
+  // positive dy means tick points up
+  if (dy > CENTER_ALIGN_THRESHOLD) {
+    verticalAnchor = 'start';
+  } else if (dy < -CENTER_ALIGN_THRESHOLD) {
+    verticalAnchor = 'end';
+  }
+
+  return { textAnchor, verticalAnchor, x, y };
+}

--- a/packages/vx-axis/src/utils/radialTickLabelTransform.js
+++ b/packages/vx-axis/src/utils/radialTickLabelTransform.js
@@ -1,0 +1,28 @@
+const CENTER_ALIGN_THRESHOLD = 1;
+
+function radialTickLabelTransform(fromPoint, toPoint) {
+    let textAnchor = 'middle';
+    let verticalAnchor = 'middle';
+    const dx = toPoint.x - fromPoint.x;
+    const dy = toPoint.y - fromPoint.y;
+  
+    // offset the label in the same direction as the tick orientation
+    const x = toPoint.x + dx;
+    const y = toPoint.y + dy;
+  
+    // positive dx means tick points right
+    if (dx > CENTER_ALIGN_THRESHOLD) {
+      textAnchor = 'start';
+    } else if (dx < -CENTER_ALIGN_THRESHOLD) {
+      textAnchor = 'end';
+    }
+  
+    // positive dy means tick points up
+    if (dy > CENTER_ALIGN_THRESHOLD) {
+      verticalAnchor = 'start';
+    } else if (dy < -CENTER_ALIGN_THRESHOLD) {
+      verticalAnchor = 'end';
+    }
+  
+    return { textAnchor, verticalAnchor, x, y };
+  }

--- a/packages/vx-axis/src/utils/radialTickLabelTransform.js
+++ b/packages/vx-axis/src/utils/radialTickLabelTransform.js
@@ -7,8 +7,8 @@ export default function radialTickLabelTransform(fromPoint, toPoint) {
   const dy = toPoint.y - fromPoint.y;
 
   // offset the label in the same direction as the tick orientation
-  const x = toPoint.x + dx;
-  const y = toPoint.y + dy;
+  const x = toPoint.x + dx / 2;
+  const y = toPoint.y + dy / 2;
 
   // positive dx means tick points right
   if (dx > CENTER_ALIGN_THRESHOLD) {

--- a/packages/vx-axis/test/AxisRadial.test.js
+++ b/packages/vx-axis/test/AxisRadial.test.js
@@ -1,0 +1,192 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Group } from '@vx/group';
+
+import { AxisRadial } from '../src';
+import { scaleLinear } from '../../vx-scale';
+
+const axisProps = {
+  scale: scaleLinear({
+    rangeRound: [10, 0],
+    domain: [0, 10]
+  })
+};
+
+describe('<AxisRadial />', () => {
+  test('it should be defined', () => {
+    expect(AxisRadial).toBeDefined();
+  });
+
+  test('it should render with class .vx-axis-radial', () => {
+    const wrapper = shallow(<AxisRadial {...axisProps} />);
+    expect(wrapper.find(Group).prop('className')).toEqual('vx-axis-radial');
+  });
+
+  test('it should set user-specified axisClassName, axisLineClassName, labelClassName, and tickClassName', () => {
+    const axisClassName = 'axis-test-class';
+    const axisLineClassName = 'axisline-test-class';
+    const labelClassName = 'label-test-class';
+    const tickClassName = 'tick-test-class';
+
+    const wrapper = shallow(
+      <AxisRadial
+        {...axisProps}
+        axisClassName={axisClassName}
+        axisLineClassName={axisLineClassName}
+        labelClassName={labelClassName}
+        tickClassName={tickClassName}
+      />
+    );
+
+    expect(wrapper.find(`.${axisClassName}`).length).toBe(1);
+    expect(wrapper.find(`.${axisLineClassName}`).length).toBe(1);
+    expect(wrapper.find(`.${labelClassName}`).length).toBe(1);
+    expect(wrapper.find(`.${tickClassName}`).length).toBeGreaterThan(0);
+  });
+
+  test('it should pass the output of tickLabelProps to tick labels', () => {
+    const tickProps = { fontSize: 50, fill: 'magenta' };
+    const wrapper = shallow(<AxisRadial {...axisProps} tickLabelProps={() => tickProps} />);
+
+    const ticks = wrapper.find('.vx-axis-tick');
+    ticks.forEach(tick => {
+      expect(tick.find(Text).props()).toEqual(expect.objectContaining(tickProps));
+    });
+
+    expect.hasAssertions();
+  });
+
+  test('it should call children function with required args', () => {
+    const mockFn = jest.fn();
+    const wrapper = shallow(<AxisRadial {...axisProps}>{mockFn}</AxisRadial>);
+    const args = mockFn.mock.calls[0][0];
+    expect(args.angle).toEqual(expect.any(Function));
+    expect(args.axisLineData).toEqual(expect.any(Array));
+    expect(args.numTicks).toEqual(expect.any(Number));
+    expect(args.label).toBeDefined();
+    expect(args.radius).toEqual(expect.any(Number));
+    expect(args.tickLength).toEqual(expect.any(Number));
+    expect(args.tickFormat).toEqual(expect.any(Function));
+    expect(args.ticks).toEqual(expect.any(Array));
+    expect(Object.keys(args.ticks[0])).toEqual(['x', 'y', 'textAnchor', 'verticalAnchor']);
+  });
+
+  test('it should call the tickLabelProps func with the signature (tickValue, index)', () => {
+    const wrapper = shallow(
+      <AxisRadial
+        {...axisProps}
+        tickLabelProps={(value, index) => {
+          expect(value).toEqual(expect.any(Number));
+          expect(index).toBeGreaterThan(-1);
+          return {};
+        }}
+      />
+    );
+
+    expect.hasAssertions();
+  });
+
+  test('it should pass labelProps to the axis label', () => {
+    const labelProps = { fontSize: 50, fill: 'magenta' };
+    const wrapper = shallow(<AxisRadial {...axisProps} labelProps={labelProps} />);
+
+    const label = wrapper.find('.vx-axis-label');
+    expect(label.find(Text).props()).toEqual(expect.objectContaining(labelProps));
+  });
+
+  test('it should render the 0th tick if hideZero is false', () => {
+    const wrapper = shallow(<AxisRadial {...axisProps} hideZero={false} />);
+    expect(
+      wrapper
+        .find('.vx-axis-tick')
+        .at(0)
+        .key()
+    ).toBe('vx-tick-0-0');
+  });
+
+  test('it should not show 0th tick if hideZero is true', () => {
+    const wrapper = shallow(<AxisRadial {...axisProps} hideZero />);
+    expect(
+      wrapper
+        .find('.vx-axis-tick')
+        .at(0)
+        .key()
+    ).toBe('vx-tick-1-1');
+  });
+
+  test('it should SHOW an axis line if hideAxisLine is false', () => {
+    const wrapper = shallow(<AxisRadial {...axisProps} hideAxisLine={false} />);
+    expect(
+      wrapper
+        .children()
+        .not('.vx-axis-tick')
+        .find('.vx-axis-line').length
+    ).toBe(1);
+  });
+
+  test('it should HIDE an axis line if hideAxisLine is true', () => {
+    const wrapper = shallow(<AxisRadial {...axisProps} hideAxisLine />);
+    expect(
+      wrapper
+        .children()
+        .not('.vx-axis-tick')
+        .find('Line').length
+    ).toBe(0);
+  });
+
+  test('it should SHOW ticks if hideTicks is false', () => {
+    const wrapper = shallow(<AxisRadial {...axisProps} hideTicks={false} />);
+    expect(wrapper.children().find('.vx-axis-tick').length).toBeGreaterThan(0);
+  });
+
+  test('it should HIDE ticks if hideTicks is true', () => {
+    const wrapper = shallow(<AxisRadial {...axisProps} hideTicks />);
+    expect(
+      wrapper
+        .children()
+        .find('.vx-axis-tick')
+        .find('Line').length
+    ).toBe(0);
+  });
+
+  test('it should render one tick for each value specified in tickValues', () => {
+    let wrapper = shallow(<AxisRadial {...axisProps} tickValues={[]} />);
+    expect(
+      wrapper
+        .children()
+        .find('.vx-axis-tick')
+        .not('.vx-axis-line')
+        .find('Line').length
+    ).toBe(0);
+
+    wrapper = shallow(<AxisRadial {...axisProps} tickValues={[2]} />);
+    expect(wrapper.children().find('.vx-axis-tick').length).toBe(1);
+
+    wrapper = shallow(<AxisRadial {...axisProps} tickValues={[0, 1, 2, 3, 4, 5, 6]} />);
+    expect(wrapper.children().find('.vx-axis-tick').length).toBe(7);
+  });
+
+  test('it should use tickFormat to format ticks if passed', () => {
+    const wrapper = shallow(
+      <AxisRadial {...axisProps} tickValues={[0]} tickFormat={(val, i) => 'test!!!'} />
+    );
+    expect(
+      wrapper
+        .children()
+        .find('.vx-axis-tick')
+        .find(Text)
+        .prop('children')
+    ).toBe('test!!!');
+  });
+
+  test('tickFormat should have access to tick index', () => {
+    const wrapper = shallow(<AxisRadial {...axisProps} tickValues={[9]} tickFormat={(val, i) => i} />);
+    expect(
+      wrapper
+        .children()
+        .find('.vx-axis-tick')
+        .find(Text)
+        .prop('children')
+    ).toBe(0);
+  });
+});

--- a/packages/vx-axis/test/AxisRadial.test.js
+++ b/packages/vx-axis/test/AxisRadial.test.js
@@ -1,15 +1,18 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Group } from '@vx/group';
+import { Text } from '@vx/text';
 
 import { AxisRadial } from '../src';
 import { scaleLinear } from '../../vx-scale';
 
 const axisProps = {
   scale: scaleLinear({
-    rangeRound: [10, 0],
-    domain: [0, 10]
-  })
+    domain: [0, 10],
+    range: [0, 2 * Math.PI]
+  }),
+  radius: 100,
+  label: 'Radial axis label'
 };
 
 describe('<AxisRadial />', () => {
@@ -19,7 +22,12 @@ describe('<AxisRadial />', () => {
 
   test('it should render with class .vx-axis-radial', () => {
     const wrapper = shallow(<AxisRadial {...axisProps} />);
-    expect(wrapper.find(Group).prop('className')).toEqual('vx-axis-radial');
+    expect(
+      wrapper
+        .find(Group)
+        .first()
+        .prop('className')
+    ).toEqual('vx-axis-radial');
   });
 
   test('it should set user-specified axisClassName, axisLineClassName, labelClassName, and tickClassName', () => {
@@ -68,7 +76,10 @@ describe('<AxisRadial />', () => {
     expect(args.tickLength).toEqual(expect.any(Number));
     expect(args.tickFormat).toEqual(expect.any(Function));
     expect(args.ticks).toEqual(expect.any(Array));
-    expect(Object.keys(args.ticks[0])).toEqual(['x', 'y', 'textAnchor', 'verticalAnchor']);
+
+    expect(Object.keys(args.ticks[0])).toEqual(
+      expect.arrayContaining(['x', 'y', 'textAnchor', 'verticalAnchor'])
+    );
   });
 
   test('it should call the tickLabelProps func with the signature (tickValue, index)', () => {
@@ -180,7 +191,9 @@ describe('<AxisRadial />', () => {
   });
 
   test('tickFormat should have access to tick index', () => {
-    const wrapper = shallow(<AxisRadial {...axisProps} tickValues={[9]} tickFormat={(val, i) => i} />);
+    const wrapper = shallow(
+      <AxisRadial {...axisProps} tickValues={[9]} tickFormat={(val, i) => i} />
+    );
     expect(
       wrapper
         .children()

--- a/packages/vx-demo/components/tiles/lineradial.js
+++ b/packages/vx-demo/components/tiles/lineradial.js
@@ -1,4 +1,7 @@
 import React from 'react';
+import { timeFormat } from 'd3-time-format';
+
+import { AxisRadial } from '@vx/axis';
 import { Group } from '@vx/group';
 import { LineRadial } from '@vx/shape';
 import { scaleTime, scaleLog } from '@vx/scale';
@@ -10,12 +13,15 @@ const green = '#e5fd3d';
 const blue = '#aeeef8';
 const darkgreen = '#dff84d';
 const bg = '#744cca';
+const bgdark = '#5430a1';
 
 // utils
 const extent = (data, value = d => d) => [
   Math.min(...data.map(value)),
   Math.max(...data.map(value))
 ];
+
+const formatDate = timeFormat('%Y');
 
 // accessors
 const date = d => new Date(d.date);
@@ -39,16 +45,26 @@ const lastPoint = appleStock[appleStock.length - 1];
 export default ({ width, height }) => {
   if (width < 10) return null;
 
-  yScale.range([0, height / 2 - 20]);
+  const visRadius = height / 2 - 20;
+  yScale.range([0, visRadius]);
 
   return (
     <svg width={width} height={height}>
       <LinearGradient from={green} to={blue} id="line-gradient" />
       <rect width={width} height={height} fill={bg} rx={14} />
       <Group top={height / 2} left={width / 2}>
+        <AxisRadial
+          scale={xScale}
+          radius={visRadius}
+          numTicks={15}
+          stroke={bgdark}
+          tickStroke={bgdark}
+          tickFormat={val => (val.getUTCMonth() !== 0 ? '' : formatDate(val))}
+          tickLabelProps={() => ({ fill: blue, fontSize: 10 })}
+        />
         {yScale.ticks().map((tick, i) => {
           const y = yScale(tick);
-          const opacity = 1 / (i + 1) - 1 / i * 0.2;
+          const opacity = 1 / (i + 1) - (1 / i) * 0.2;
           return (
             <g key={`radial-grid-${i}`}>
               <circle
@@ -61,7 +77,7 @@ export default ({ width, height }) => {
               />
               <text
                 y={-y}
-                dy={'-.33em'}
+                dy="-.33em"
                 fontSize={8}
                 fill={blue}
                 fillOpacity={0.6}
@@ -84,7 +100,7 @@ export default ({ width, height }) => {
           curve={curveBasisOpen}
         />
         {[firstPoint, lastPoint].map((d, i) => {
-          const cx = xScale(date(d)) * Math.PI / 180;
+          const cx = (xScale(date(d)) * Math.PI) / 180;
           const cy = -yScale(close(d));
           return <circle key={`line-cap-${i}`} cx={cx} cy={cy} fill={darkgreen} r={3} />;
         })}


### PR DESCRIPTION
#### :rocket: Enhancements

This PR 
- adds a new `<AxisRadial />`  component to the `@vx/axis` package
- adds `propType` descriptions and tests for `<AxisRadial />`
- updates the `LineRadial` demo tile to also include the `<AxisRadial />` component:

<img width="1668" src="https://user-images.githubusercontent.com/4496521/50789083-146f8200-1270-11e9-9d4d-10bc41128405.png">


