### PR TITLE
Fix-VX-Responsive-ScaleSVG-PropTypes

### DIFF
--- a/packages/vx-responsive/docs/api.md
+++ b/packages/vx-responsive/docs/api.md
@@ -12,7 +12,7 @@
 
 
 
-<a id="#ScaleSVG__children" name="ScaleSVG__children" href="#ScaleSVG__children">#</a> *ScaleSVG*.**children**&lt;func&gt;  
+<a id="#ScaleSVG__children" name="ScaleSVG__children" href="#ScaleSVG__children">#</a> *ScaleSVG*.**children**&lt;any&gt;  
 
 <a id="#ScaleSVG__height" name="ScaleSVG__height" href="#ScaleSVG__height">#</a> *ScaleSVG*.**height**&lt;union(number|string)&gt;  
 

--- a/packages/vx-responsive/docs/docs.md
+++ b/packages/vx-responsive/docs/docs.md
@@ -138,7 +138,7 @@ npm install --save @vx/responsive
 
 
 
-<a id="#ScaleSVG__children" name="ScaleSVG__children" href="#ScaleSVG__children">#</a> *ScaleSVG*.**children**&lt;func&gt;  
+<a id="#ScaleSVG__children" name="ScaleSVG__children" href="#ScaleSVG__children">#</a> *ScaleSVG*.**children**&lt;any&gt;  
 
 <a id="#ScaleSVG__height" name="ScaleSVG__height" href="#ScaleSVG__height">#</a> *ScaleSVG*.**height**&lt;union(number|string)&gt;  
 

--- a/packages/vx-responsive/src/components/ScaleSVG.js
+++ b/packages/vx-responsive/src/components/ScaleSVG.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 ResponsiveSVG.propTypes = {
-  children: PropTypes.func,
+  children: PropTypes.any,
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   xOrigin: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),


### PR DESCRIPTION
#### :bug: Bug Fix

I got warning with **ScaleSVG** component:

```javascript
import { ScaleSVG } from "@vx/responsive";
...
      <ScaleSVG width={400} height={200}>
        <LineRadial width={500} height={200} />
      </ScaleSVG>
...
```

[![Edit 98yx2qvryp](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/98yx2qvryp)

```
Warning: Failed prop type: Invalid prop `children` of type `object` supplied to `n`, expected `function`.
```

So I suppose it should be **PropTypes.any** for **ScaleSVG** component