### PR TITLE
[shape/BarGroupHorizontal] Remove unnecessary destructuring of props in demo code

### DIFF
--- a/packages/vx-demo/pages/bargrouphorizontal.js
+++ b/packages/vx-demo/pages/bargrouphorizontal.js
@@ -80,7 +80,7 @@ export default ({
           xScale={xScale}
           color={color}
         >
-          {({ barGroups }) => {
+          {barGroups => {
             return barGroups.map(barGroup => {
               return (
                 <Group


### PR DESCRIPTION
#### :boom: Breaking Changes

- None, only updated string value.

#### :rocket: Enhancements

- N/A

#### :memo: Documentation

- No need to update any additional documentation

#### :bug: Bug Fix

- As a d3 first-timer and react long-timer, I was excited to dip my toes in with vx. I followed the demo code, however I was struck with an angry error screen:

<img width="576" alt="screen shot 2019-01-09 at 1 58 28 pm" src="https://user-images.githubusercontent.com/15201381/50921736-bd57e180-1416-11e9-9a17-b54486ee5134.png">

After a bit of debugging I realized the issue lay with the demo code. The `children` fn parameter in the demo code was expecting an argument to destructure and then map over the resulting `barGroups` value. However in the BarGroupHorizontal component in `vx/packages/vx-shape/src/shapes/BarGroupHorizontal.js` on line 66 it was only ever being passed one argument of type array. Therefore, removing the unnecessary destructuring of `barGroups` resolved the issue.

#### :house: Internal

- N/A
