### PR TITLE
Fix proptype for LinePath 'defined' prop

### DIFF
--- a/packages/vx-shape/src/shapes/LinePath.js
+++ b/packages/vx-shape/src/shapes/LinePath.js
@@ -7,7 +7,7 @@ LinePath.propTypes = {
   innerRef: PropTypes.func,
   data: PropTypes.array,
   curve: PropTypes.func,
-  defined: PropTypes.oneOf([PropTypes.func, PropTypes.bool]),
+  defined: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
   x: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
   y: PropTypes.oneOfType([PropTypes.func, PropTypes.number])
 };


### PR DESCRIPTION
#### :bug: Bug Fix

- Fixes a proptype for the LinePath `defined` prop. Should use `oneOfType` rather than `oneOf`.