### PR TITLE
Docs:Fixed method signature of Axis tickLabelProps

### DIFF
--- a/packages/vx-axis/docs/docs.md
+++ b/packages/vx-axis/docs/docs.md
@@ -184,7 +184,7 @@ A [d3 formatter](https://github.com/d3/d3-scale/blob/master/README.md#continuous
 
 <a id="#AxisBottom__tickLabelProps" name="AxisBottom__tickLabelProps" href="#AxisBottom__tickLabelProps">#</a> *AxisBottom*.**tickLabelProps**&lt;func&gt; 
 
-A function that returns props for a given tick label. <table><tr><td><strong>Default</strong></td><td>({ tick, index }) => ({
+A function that returns props for a given tick label. <table><tr><td><strong>Default</strong></td><td>(tick, index) => ({
   dy: '0.25em',
   fill: 'black',
   fontFamily: 'Arial',
@@ -256,7 +256,7 @@ A top pixel offset applied to the entire axis.
 
 <a id="#AxisLeft__tickFormat" name="AxisLeft__tickFormat" href="#AxisLeft__tickFormat">#</a> *AxisLeft*.**tickFormat**&lt;func&gt;  
 
-<a id="#AxisLeft__tickLabelProps" name="AxisLeft__tickLabelProps" href="#AxisLeft__tickLabelProps">#</a> *AxisLeft*.**tickLabelProps**&lt;func&gt;  <table><tr><td><strong>Default</strong></td><td>({ tick, index }) => ({
+<a id="#AxisLeft__tickLabelProps" name="AxisLeft__tickLabelProps" href="#AxisLeft__tickLabelProps">#</a> *AxisLeft*.**tickLabelProps**&lt;func&gt;  <table><tr><td><strong>Default</strong></td><td>(tick, index) => ({
   dx: '-0.25em',
   dy: '0.25em',
   fill: 'black',
@@ -319,7 +319,7 @@ A top pixel offset applied to the entire axis.
 
 <a id="#AxisRight__tickFormat" name="AxisRight__tickFormat" href="#AxisRight__tickFormat">#</a> *AxisRight*.**tickFormat**&lt;func&gt;  
 
-<a id="#AxisRight__tickLabelProps" name="AxisRight__tickLabelProps" href="#AxisRight__tickLabelProps">#</a> *AxisRight*.**tickLabelProps**&lt;func&gt;  <table><tr><td><strong>Default</strong></td><td>({ tick, index }) => ({
+<a id="#AxisRight__tickLabelProps" name="AxisRight__tickLabelProps" href="#AxisRight__tickLabelProps">#</a> *AxisRight*.**tickLabelProps**&lt;func&gt;  <table><tr><td><strong>Default</strong></td><td>(tick, index) => ({
   dx: '0.25em',
   dy: '0.25em',
   fill: 'black',
@@ -382,7 +382,7 @@ A top pixel offset applied to the entire axis.
 
 <a id="#AxisTop__tickFormat" name="AxisTop__tickFormat" href="#AxisTop__tickFormat">#</a> *AxisTop*.**tickFormat**&lt;func&gt;  
 
-<a id="#AxisTop__tickLabelProps" name="AxisTop__tickLabelProps" href="#AxisTop__tickLabelProps">#</a> *AxisTop*.**tickLabelProps**&lt;func&gt;  <table><tr><td><strong>Default</strong></td><td>({ tick, index }) => ({
+<a id="#AxisTop__tickLabelProps" name="AxisTop__tickLabelProps" href="#AxisTop__tickLabelProps">#</a> *AxisTop*.**tickLabelProps**&lt;func&gt;  <table><tr><td><strong>Default</strong></td><td>(tick, index) => ({
   dy: '-0.25em',
   fill: 'black',
   fontFamily: 'Arial',


### PR DESCRIPTION
In the Axis docs for AxisLeft, AxisRight and AxisBottom, `tickLabelProps` has a method signature such as:

`tickLabelProps={({ tick, index }) => {...} }`

But it actually is 

`tickLabelProps={(tick, index) => {...} }`

As in, you don't need to destructure the arguments.
This commit fixes this.

#### :memo: Documentation

- Fixed `tickLabelProps` method signature in docs

