### PR TITLE
Fixed broken BarStacks example

### DIFF
--- a/packages/vx-demo/pages/barstack.js
+++ b/packages/vx-demo/pages/barstack.js
@@ -94,7 +94,7 @@ export default withTooltip(
           />
           <Group top={margin.top}>
             <BarStack data={data} keys={keys} x={x} xScale={xScale} yScale={yScale} color={color}>
-              {({ barStacks }) => {
+              {barStacks => {
                 return barStacks.map(barStack => {
                   return barStack.bars.map(bar => {
                     return (


### PR DESCRIPTION

#### :memo: Documentation

- fixed broken BarStacks example. Bar Stack Horizontal example works correct, but BarStack for some reason uses `({ barStacks })` instead of `barStacks`

