### PR TITLE
Cleanup DragII Demo

### DIFF
--- a/packages/vx-demo/pages/drag-ii.js
+++ b/packages/vx-demo/pages/drag-ii.js
@@ -7,7 +7,6 @@ export default () => {
     <Show component={DragII} title="Drag II">
       {`import React from 'react';
 import { LinePath } from '@vx/shape';
-import { localPoint } from '@vx/event';
 import { Drag } from '@vx/drag';
 import { curveBasis } from '@vx/curve';
 import { LinearGradient } from '@vx/gradient';
@@ -43,8 +42,6 @@ export default class DragII extends React.Component {
                 curve={curveBasis}
                 x={d => d.x}
                 y={d => d.y}
-                xScale={d => d}
-                yScale={d => d}
               />
             );
           })}


### PR DESCRIPTION
#### :memo: Documentation
- Remove unused localPoint import
- Remove xScale and yScale props from the LinePath. Using them on the current implementation of the line path throws the error shown below and they are no longer part of the [props](https://github.com/hshoff/vx/blob/master/packages/vx-shape/Readme.md#linepath-) of the LinePath in the current implementation.
<img width="296" alt="screenshot 2019-02-14 at 22 37 57" src="https://user-images.githubusercontent.com/13004199/52813011-db65d100-30a9-11e9-9766-97bebeadcada.png">


