### PR TITLE
use getDerivedStateFromProps in vx/text to stop strict warnings 

### DIFF
--- a/packages/vx-text/src/Text.js
+++ b/packages/vx-text/src/Text.js
@@ -9,13 +9,11 @@ class Text extends Component {
     this.state = {
       wordsByLines: []
     };
-  }
 
-  componentWillMount() {
     this.updateWordsByLines(this.props, true);
   }
 
-  componentWillReceiveProps(nextProps) {
+  static getDerivedStateFromProps(nextProps) {
     const needCalculate =
       this.props.children !== nextProps.children || this.props.style !== nextProps.style;
     this.updateWordsByLines(nextProps, needCalculate);


### PR DESCRIPTION
#### :rocket: Enhancements
vx/text gives the following warning when running in a strict react 16 build:

>main.js:10481 Warning: Unsafe lifecycle methods were found within a strict-mode tree:
    in StrictMode
    in Unknown

> componentWillMount: Please update the following components to use componentDidMount instead: Text

> componentWillReceiveProps: Please update the following components to use static getDerivedStateFromProps instead: Text

> Learn more about this warning here:
-

I've moved the initial call to `updateWordsByLines` into the constructor and used `getDerivedStateFromProps` instead of `componentWillReceiveProps`