### PR TITLE
Add vx text truncation

### DIFF
--- a/packages/vx-text/Readme.md
+++ b/packages/vx-text/Readme.md
@@ -10,6 +10,7 @@ The `@vx/text` provides a better SVG `<Text>` component with the following featu
 * Vertical alignment (`verticalAnchor` prop)
 * Rotation (`angle` prop)
 * Scale-to-fit text (`scaleToFit` prop)
+* Multiline text truncation (`lineClamp` prop)
 
 ## Example
 
@@ -63,6 +64,8 @@ npm install --save @vx/text
 
 <a id="#Text__innerRef" name="Text__innerRef" href="#Text__innerRef">#</a> *Text*.**innerRef**&lt;union(func|object)&gt;  
 
+<a id="#Text__lineClamp" name="Text__lineClamp" href="#Text__lineClamp">#</a> *Text*.**lineClamp**&lt;number&gt;
+
 <a id="#Text__lineHeight" name="Text__lineHeight" href="#Text__lineHeight">#</a> *Text*.**lineHeight**&lt;union(number|string)&gt;  <table><tr><td><strong>Default</strong></td><td>'1em'</td></td></table>
 
 <a id="#Text__scaleToFit" name="Text__scaleToFit" href="#Text__scaleToFit">#</a> *Text*.**scaleToFit**&lt;bool&gt;  <table><tr><td><strong>Default</strong></td><td>false</td></td></table>
@@ -70,6 +73,8 @@ npm install --save @vx/text
 <a id="#Text__style" name="Text__style" href="#Text__style">#</a> *Text*.**style**&lt;object&gt;  
 
 <a id="#Text__textAnchor" name="Text__textAnchor" href="#Text__textAnchor">#</a> *Text*.**textAnchor**&lt;enum('start'|'middle'|'end'|'inherit')&gt;  <table><tr><td><strong>Default</strong></td><td>'start'</td></td></table>
+
+<a id="#Text__truncateText" name="Text__truncateText" href="#Text__truncateText">#</a> *Text*.**truncateText**&lt;string&gt;  <table><tr><td><strong>Default</strong></td><td>&hellip;</td></td></table>
 
 <a id="#Text__verticalAnchor" name="Text__verticalAnchor" href="#Text__verticalAnchor">#</a> *Text*.**verticalAnchor**&lt;enum('start'|'middle'|'end')&gt;  <table><tr><td><strong>Default</strong></td><td>'end'</td></td></table>
 

--- a/packages/vx-text/docs/api.md
+++ b/packages/vx-text/docs/api.md
@@ -14,6 +14,8 @@
 
 <a id="#Text__innerRef" name="Text__innerRef" href="#Text__innerRef">#</a> *Text*.**innerRef**&lt;union(func|object)&gt;  
 
+<a id="#Text__lineClamp" name="Text__lineClamp" href="#Text__lineClamp">#</a> *Text*.**lineClamp**&lt;number&gt;
+
 <a id="#Text__lineHeight" name="Text__lineHeight" href="#Text__lineHeight">#</a> *Text*.**lineHeight**&lt;union(number|string)&gt;  <table><tr><td><strong>Default</strong></td><td>'1em'</td></td></table>
 
 <a id="#Text__scaleToFit" name="Text__scaleToFit" href="#Text__scaleToFit">#</a> *Text*.**scaleToFit**&lt;bool&gt;  <table><tr><td><strong>Default</strong></td><td>false</td></td></table>
@@ -21,6 +23,8 @@
 <a id="#Text__style" name="Text__style" href="#Text__style">#</a> *Text*.**style**&lt;object&gt;  
 
 <a id="#Text__textAnchor" name="Text__textAnchor" href="#Text__textAnchor">#</a> *Text*.**textAnchor**&lt;enum('start'|'middle'|'end'|'inherit')&gt;  <table><tr><td><strong>Default</strong></td><td>'start'</td></td></table>
+
+<a id="#Text__truncateText" name="Text__truncateText" href="#Text__truncateText">#</a> *Text*.**truncateText**&lt;string&gt;  <table><tr><td><strong>Default</strong></td><td>&hellip;</td></td></table>
 
 <a id="#Text__verticalAnchor" name="Text__verticalAnchor" href="#Text__verticalAnchor">#</a> *Text*.**verticalAnchor**&lt;enum('start'|'middle'|'end')&gt;  <table><tr><td><strong>Default</strong></td><td>'end'</td></td></table>
 

--- a/packages/vx-text/docs/description.md
+++ b/packages/vx-text/docs/description.md
@@ -10,6 +10,7 @@ The `@vx/text` provides a better SVG `<Text>` component with the following featu
 * Vertical alignment (`verticalAnchor` prop)
 * Rotation (`angle` prop)
 * Scale-to-fit text (`scaleToFit` prop)
+* Multiline text truncation (`lineClamp` prop)
 
 ## Example
 

--- a/packages/vx-text/docs/docs.md
+++ b/packages/vx-text/docs/docs.md
@@ -10,6 +10,7 @@ The `@vx/text` provides a better SVG `<Text>` component with the following featu
 * Vertical alignment (`verticalAnchor` prop)
 * Rotation (`angle` prop)
 * Scale-to-fit text (`scaleToFit` prop)
+* Multiline text truncation (`lineClamp` prop)
 
 ## Example
 
@@ -63,6 +64,8 @@ npm install --save @vx/text
 
 <a id="#Text__innerRef" name="Text__innerRef" href="#Text__innerRef">#</a> *Text*.**innerRef**&lt;union(func|object)&gt;  
 
+<a id="#Text__lineClamp" name="Text__lineClamp" href="#Text__lineClamp">#</a> *Text*.**lineClamp**&lt;number&gt;
+
 <a id="#Text__lineHeight" name="Text__lineHeight" href="#Text__lineHeight">#</a> *Text*.**lineHeight**&lt;union(number|string)&gt;  <table><tr><td><strong>Default</strong></td><td>'1em'</td></td></table>
 
 <a id="#Text__scaleToFit" name="Text__scaleToFit" href="#Text__scaleToFit">#</a> *Text*.**scaleToFit**&lt;bool&gt;  <table><tr><td><strong>Default</strong></td><td>false</td></td></table>
@@ -70,6 +73,8 @@ npm install --save @vx/text
 <a id="#Text__style" name="Text__style" href="#Text__style">#</a> *Text*.**style**&lt;object&gt;  
 
 <a id="#Text__textAnchor" name="Text__textAnchor" href="#Text__textAnchor">#</a> *Text*.**textAnchor**&lt;enum('start'|'middle'|'end'|'inherit')&gt;  <table><tr><td><strong>Default</strong></td><td>'start'</td></td></table>
+
+<a id="#Text__truncateText" name="Text__truncateText" href="#Text__truncateText">#</a> *Text*.**truncateText**&lt;string&gt;  <table><tr><td><strong>Default</strong></td><td>&hellip;</td></td></table>
 
 <a id="#Text__verticalAnchor" name="Text__verticalAnchor" href="#Text__verticalAnchor">#</a> *Text*.**verticalAnchor**&lt;enum('start'|'middle'|'end')&gt;  <table><tr><td><strong>Default</strong></td><td>'end'</td></td></table>
 

--- a/packages/vx-text/src/util/truncateWord.ts
+++ b/packages/vx-text/src/util/truncateWord.ts
@@ -1,0 +1,27 @@
+import getStringWidth from './getStringWidth';
+
+const truncateWordToLength = (
+  word: string,
+  width: number,
+  truncateText: string,
+  style?: object,
+) => {
+  const truncateTextWidth = getStringWidth(truncateText, style);
+  const truncatedResult = word.split('').reduce(
+    (result, char) => {
+      const charWidth = getStringWidth(char, style);
+      if (result.width + charWidth + truncateTextWidth < width) {
+        result.word += char;
+        result.width += charWidth;
+      }
+      return result;
+    },
+    { word: '', width: 0 },
+  );
+
+  truncatedResult.word += truncateText;
+  truncatedResult.width += truncateTextWidth;
+  return truncatedResult;
+};
+
+export default truncateWordToLength;


### PR DESCRIPTION
#### :rocket: Enhancements
I have a use case where I needed to restrict some text labels to a maximum number of lines.

Adds lineClamp and truncateText props to vx/text.
lineClamp restricts the number of lines of the rendered text. When the lineClamp is exceeded, the text is truncated with the truncateText which by default is '...'

Here's an example:
https://codesandbox.io/s/3v3rn68mj6