### PR TITLE
[zoom] make wheel event active by default. fixes #455

### DIFF
--- a/packages/vx-demo/components/tiles/zoom-i.js
+++ b/packages/vx-demo/components/tiles/zoom-i.js
@@ -83,7 +83,6 @@ export default class ZoomI extends React.Component {
                     height={height}
                     rx={14}
                     fill="transparent"
-                    onWheel={zoom.handleWheel}
                     onTouchStart={zoom.dragStart}
                     onTouchMove={zoom.dragMove}
                     onTouchEnd={zoom.dragEnd}

--- a/packages/vx-demo/static/docs/vx-zoom.html
+++ b/packages/vx-demo/static/docs/vx-zoom.html
@@ -49,6 +49,7 @@
 
 
 <p><a id="#Zoom__children" name="Zoom__children" href="#Zoom__children">#</a> <em>Zoom</em>.<strong>children</strong>&lt;func&gt; <code>required</code> </p>
+<p><a id="#Zoom__className" name="Zoom__className" href="#Zoom__className">#</a> <em>Zoom</em>.<strong>className</strong>&lt;string&gt;  <table><tr><td><strong>Default</strong></td><td>undefined</td></td></table></p>
 <p><a id="#Zoom__constrain" name="Zoom__constrain" href="#Zoom__constrain">#</a> <em>Zoom</em>.<strong>constrain</strong>&lt;func&gt; </p>
 <p>By default constrain() will only constrain scale values. To change
 constraints you can pass in your own constrain function as a prop.</p>
@@ -69,10 +70,18 @@ constraints you can pass in your own constrain function as a prop.</p>
 @param {matrix} prevTransformMatrix
 @returns {martix} </p>
 <p><a id="#Zoom__height" name="Zoom__height" href="#Zoom__height">#</a> <em>Zoom</em>.<strong>height</strong>&lt;number&gt; <code>required</code> </p>
+<p><a id="#Zoom__passive" name="Zoom__passive" href="#Zoom__passive">#</a> <em>Zoom</em>.<strong>passive</strong>&lt;bool&gt; </p>
+<p>By default passive is <code>false</code>. This will wrap <Zoom> children in a <div> and add an active wheel
+event listener (handleWheel). <code>handleWheel()</code> will call <code>event.preventDefault()</code> before other
+execution. This prevents an outer parent from scrolling when the mouse wheel is used to zoom.</p>
+<p>When passive is <code>true</code> it is required to add <code>&lt;MyComponent onWheel={zoom.handleWheel} /&gt;</code> to handle
+wheel events. <strong>Note:</strong> By default you do not need to add <code>&lt;MyComponent onWheel={zoom.handleWheel} /&gt;</code>.
+This is only necessary when <code>&lt;Zoom passive={true} /&gt;</code>. <table><tr><td><strong>Default</strong></td><td>false</td></td></table></p>
 <p><a id="#Zoom__scaleXMax" name="Zoom__scaleXMax" href="#Zoom__scaleXMax">#</a> <em>Zoom</em>.<strong>scaleXMax</strong>&lt;number&gt;  <table><tr><td><strong>Default</strong></td><td>Infinity</td></td></table></p>
 <p><a id="#Zoom__scaleXMin" name="Zoom__scaleXMin" href="#Zoom__scaleXMin">#</a> <em>Zoom</em>.<strong>scaleXMin</strong>&lt;number&gt;  <table><tr><td><strong>Default</strong></td><td>0</td></td></table></p>
 <p><a id="#Zoom__scaleYMax" name="Zoom__scaleYMax" href="#Zoom__scaleYMax">#</a> <em>Zoom</em>.<strong>scaleYMax</strong>&lt;number&gt;  <table><tr><td><strong>Default</strong></td><td>Infinity</td></td></table></p>
 <p><a id="#Zoom__scaleYMin" name="Zoom__scaleYMin" href="#Zoom__scaleYMin">#</a> <em>Zoom</em>.<strong>scaleYMin</strong>&lt;number&gt;  <table><tr><td><strong>Default</strong></td><td>0</td></td></table></p>
+<p><a id="#Zoom__style" name="Zoom__style" href="#Zoom__style">#</a> <em>Zoom</em>.<strong>style</strong>&lt;object&gt;  <table><tr><td><strong>Default</strong></td><td>undefined</td></td></table></p>
 <p><a id="#Zoom__transformMatrix" name="Zoom__transformMatrix" href="#Zoom__transformMatrix">#</a> <em>Zoom</em>.<strong>transformMatrix</strong>&lt;shape[object Object]&gt;  <table><tr><td><strong>Default</strong></td><td>{
   scaleX: 1,
   scaleY: 1,

--- a/packages/vx-zoom/Readme.md
+++ b/packages/vx-zoom/Readme.md
@@ -28,6 +28,8 @@ npm install --save @vx/zoom
 
 <a id="#Zoom__children" name="Zoom__children" href="#Zoom__children">#</a> *Zoom*.**children**&lt;func&gt; `required` 
 
+<a id="#Zoom__className" name="Zoom__className" href="#Zoom__className">#</a> *Zoom*.**className**&lt;string&gt;  <table><tr><td><strong>Default</strong></td><td>undefined</td></td></table>
+
 <a id="#Zoom__constrain" name="Zoom__constrain" href="#Zoom__constrain">#</a> *Zoom*.**constrain**&lt;func&gt; 
 
 By default constrain() will only constrain scale values. To change
@@ -55,6 +57,16 @@ function constrain(transformMatrix, prevTransformMatrix) {
 
 <a id="#Zoom__height" name="Zoom__height" href="#Zoom__height">#</a> *Zoom*.**height**&lt;number&gt; `required` 
 
+<a id="#Zoom__passive" name="Zoom__passive" href="#Zoom__passive">#</a> *Zoom*.**passive**&lt;bool&gt; 
+
+By default passive is `false`. This will wrap <Zoom> children in a <div> and add an active wheel
+event listener (handleWheel). `handleWheel()` will call `event.preventDefault()` before other
+execution. This prevents an outer parent from scrolling when the mouse wheel is used to zoom.
+
+When passive is `true` it is required to add `<MyComponent onWheel={zoom.handleWheel} />` to handle
+wheel events. **Note:** By default you do not need to add `<MyComponent onWheel={zoom.handleWheel} />`.
+This is only necessary when `<Zoom passive={true} />`. <table><tr><td><strong>Default</strong></td><td>false</td></td></table>
+
 <a id="#Zoom__scaleXMax" name="Zoom__scaleXMax" href="#Zoom__scaleXMax">#</a> *Zoom*.**scaleXMax**&lt;number&gt;  <table><tr><td><strong>Default</strong></td><td>Infinity</td></td></table>
 
 <a id="#Zoom__scaleXMin" name="Zoom__scaleXMin" href="#Zoom__scaleXMin">#</a> *Zoom*.**scaleXMin**&lt;number&gt;  <table><tr><td><strong>Default</strong></td><td>0</td></td></table>
@@ -62,6 +74,8 @@ function constrain(transformMatrix, prevTransformMatrix) {
 <a id="#Zoom__scaleYMax" name="Zoom__scaleYMax" href="#Zoom__scaleYMax">#</a> *Zoom*.**scaleYMax**&lt;number&gt;  <table><tr><td><strong>Default</strong></td><td>Infinity</td></td></table>
 
 <a id="#Zoom__scaleYMin" name="Zoom__scaleYMin" href="#Zoom__scaleYMin">#</a> *Zoom*.**scaleYMin**&lt;number&gt;  <table><tr><td><strong>Default</strong></td><td>0</td></td></table>
+
+<a id="#Zoom__style" name="Zoom__style" href="#Zoom__style">#</a> *Zoom*.**style**&lt;object&gt;  <table><tr><td><strong>Default</strong></td><td>undefined</td></td></table>
 
 <a id="#Zoom__transformMatrix" name="Zoom__transformMatrix" href="#Zoom__transformMatrix">#</a> *Zoom*.**transformMatrix**&lt;shape[object Object]&gt;  <table><tr><td><strong>Default</strong></td><td>{
   scaleX: 1,

--- a/packages/vx-zoom/docs/api.md
+++ b/packages/vx-zoom/docs/api.md
@@ -4,6 +4,8 @@
 
 <a id="#Zoom__children" name="Zoom__children" href="#Zoom__children">#</a> *Zoom*.**children**&lt;func&gt; `required` 
 
+<a id="#Zoom__className" name="Zoom__className" href="#Zoom__className">#</a> *Zoom*.**className**&lt;string&gt;  <table><tr><td><strong>Default</strong></td><td>undefined</td></td></table>
+
 <a id="#Zoom__constrain" name="Zoom__constrain" href="#Zoom__constrain">#</a> *Zoom*.**constrain**&lt;func&gt; 
 
 By default constrain() will only constrain scale values. To change
@@ -31,6 +33,16 @@ function constrain(transformMatrix, prevTransformMatrix) {
 
 <a id="#Zoom__height" name="Zoom__height" href="#Zoom__height">#</a> *Zoom*.**height**&lt;number&gt; `required` 
 
+<a id="#Zoom__passive" name="Zoom__passive" href="#Zoom__passive">#</a> *Zoom*.**passive**&lt;bool&gt; 
+
+By default passive is `false`. This will wrap <Zoom> children in a <div> and add an active wheel
+event listener (handleWheel). `handleWheel()` will call `event.preventDefault()` before other
+execution. This prevents an outer parent from scrolling when the mouse wheel is used to zoom.
+
+When passive is `true` it is required to add `<MyComponent onWheel={zoom.handleWheel} />` to handle
+wheel events. **Note:** By default you do not need to add `<MyComponent onWheel={zoom.handleWheel} />`.
+This is only necessary when `<Zoom passive={true} />`. <table><tr><td><strong>Default</strong></td><td>false</td></td></table>
+
 <a id="#Zoom__scaleXMax" name="Zoom__scaleXMax" href="#Zoom__scaleXMax">#</a> *Zoom*.**scaleXMax**&lt;number&gt;  <table><tr><td><strong>Default</strong></td><td>Infinity</td></td></table>
 
 <a id="#Zoom__scaleXMin" name="Zoom__scaleXMin" href="#Zoom__scaleXMin">#</a> *Zoom*.**scaleXMin**&lt;number&gt;  <table><tr><td><strong>Default</strong></td><td>0</td></td></table>
@@ -38,6 +50,8 @@ function constrain(transformMatrix, prevTransformMatrix) {
 <a id="#Zoom__scaleYMax" name="Zoom__scaleYMax" href="#Zoom__scaleYMax">#</a> *Zoom*.**scaleYMax**&lt;number&gt;  <table><tr><td><strong>Default</strong></td><td>Infinity</td></td></table>
 
 <a id="#Zoom__scaleYMin" name="Zoom__scaleYMin" href="#Zoom__scaleYMin">#</a> *Zoom*.**scaleYMin**&lt;number&gt;  <table><tr><td><strong>Default</strong></td><td>0</td></td></table>
+
+<a id="#Zoom__style" name="Zoom__style" href="#Zoom__style">#</a> *Zoom*.**style**&lt;object&gt;  <table><tr><td><strong>Default</strong></td><td>undefined</td></td></table>
 
 <a id="#Zoom__transformMatrix" name="Zoom__transformMatrix" href="#Zoom__transformMatrix">#</a> *Zoom*.**transformMatrix**&lt;shape[object Object]&gt;  <table><tr><td><strong>Default</strong></td><td>{
   scaleX: 1,

--- a/packages/vx-zoom/docs/docs.md
+++ b/packages/vx-zoom/docs/docs.md
@@ -28,6 +28,8 @@ npm install --save @vx/zoom
 
 <a id="#Zoom__children" name="Zoom__children" href="#Zoom__children">#</a> *Zoom*.**children**&lt;func&gt; `required` 
 
+<a id="#Zoom__className" name="Zoom__className" href="#Zoom__className">#</a> *Zoom*.**className**&lt;string&gt;  <table><tr><td><strong>Default</strong></td><td>undefined</td></td></table>
+
 <a id="#Zoom__constrain" name="Zoom__constrain" href="#Zoom__constrain">#</a> *Zoom*.**constrain**&lt;func&gt; 
 
 By default constrain() will only constrain scale values. To change
@@ -55,6 +57,16 @@ function constrain(transformMatrix, prevTransformMatrix) {
 
 <a id="#Zoom__height" name="Zoom__height" href="#Zoom__height">#</a> *Zoom*.**height**&lt;number&gt; `required` 
 
+<a id="#Zoom__passive" name="Zoom__passive" href="#Zoom__passive">#</a> *Zoom*.**passive**&lt;bool&gt; 
+
+By default passive is `false`. This will wrap <Zoom> children in a <div> and add an active wheel
+event listener (handleWheel). `handleWheel()` will call `event.preventDefault()` before other
+execution. This prevents an outer parent from scrolling when the mouse wheel is used to zoom.
+
+When passive is `true` it is required to add `<MyComponent onWheel={zoom.handleWheel} />` to handle
+wheel events. **Note:** By default you do not need to add `<MyComponent onWheel={zoom.handleWheel} />`.
+This is only necessary when `<Zoom passive={true} />`. <table><tr><td><strong>Default</strong></td><td>false</td></td></table>
+
 <a id="#Zoom__scaleXMax" name="Zoom__scaleXMax" href="#Zoom__scaleXMax">#</a> *Zoom*.**scaleXMax**&lt;number&gt;  <table><tr><td><strong>Default</strong></td><td>Infinity</td></td></table>
 
 <a id="#Zoom__scaleXMin" name="Zoom__scaleXMin" href="#Zoom__scaleXMin">#</a> *Zoom*.**scaleXMin**&lt;number&gt;  <table><tr><td><strong>Default</strong></td><td>0</td></td></table>
@@ -62,6 +74,8 @@ function constrain(transformMatrix, prevTransformMatrix) {
 <a id="#Zoom__scaleYMax" name="Zoom__scaleYMax" href="#Zoom__scaleYMax">#</a> *Zoom*.**scaleYMax**&lt;number&gt;  <table><tr><td><strong>Default</strong></td><td>Infinity</td></td></table>
 
 <a id="#Zoom__scaleYMin" name="Zoom__scaleYMin" href="#Zoom__scaleYMin">#</a> *Zoom*.**scaleYMin**&lt;number&gt;  <table><tr><td><strong>Default</strong></td><td>0</td></td></table>
+
+<a id="#Zoom__style" name="Zoom__style" href="#Zoom__style">#</a> *Zoom*.**style**&lt;object&gt;  <table><tr><td><strong>Default</strong></td><td>undefined</td></td></table>
 
 <a id="#Zoom__transformMatrix" name="Zoom__transformMatrix" href="#Zoom__transformMatrix">#</a> *Zoom*.**transformMatrix**&lt;shape[object Object]&gt;  <table><tr><td><strong>Default</strong></td><td>{
   scaleX: 1,


### PR DESCRIPTION
## The Problem

Chrome 73 made `wheel` event listeners passive by default.  A passive event listener is an event listener that does not call `preventDefault()` on the event. This is great because it makes scrolling faster. [https://developers.google.com/web/updates/2019/02/scrolling-intervention](https://developers.google.com/web/updates/2019/02/scrolling-intervention).

Google found 98% of `wheel` and `mousewheel` event listeners do not call `preventDefault()`. So the trade off here of faster scrolling on the web for the relatively small cost of 2% of listeners need to opt-in to making the wheel listener active. Unfortunately, `<Zoom />` falls in the 2% here.

### The recommended fix
Convert event listeners that rely on `preventDefault()` to active.

```diff
- node.addEventListener('wheel', this.handleWheel);
+ node.addEventListener('wheel', this.handleWheel, { passive: false });
```

### But what about React?

Folks in react-land probably aren't used to writing `addEventListener()` these days. The more usual pattern is to add `onWheel={this.handleWheel}` prop. So how do we make an event listener active in React? My observed behavior of React is that it registers event listeners without a default value for passive (I could be wrong about this, I was running in circles in the React codebase). Ideally React would support the ability to set the passive value. Until then, we'll have to fall back to rolling our own addEventListener + removeEventListener.

## The solution

### Keeping the default behavior

The default behavior for `<Zoom />` will be to add an active event listener in `componentDidMount` and remove it `componentWillUnmount()` and call `preventDefault()` on wheel events. This matches the previous default behavior, but requires the removal of a prop to get rid of the console warning from Chrome.

### The breaking change

If you update to this version of @vx/zoom, you'll just have to remove `onWheel={zoom.handleWheel}` and the warning will go away and everything should work as before. The diff is small:

  ```diff
  <MyComponent
  - onWheel={zoom.handleWheel}
  />
  ```

### Opt-in to passive on wheel event listener

The upside here is you now have a way to opt-in to passive on wheel event listener. This will not call `preventDefault()`

  ```diff
  <Zoom
  + passive={true}
  >
    {zoom => {
      return (
        <MyComponent
  +      onWheel={zoom.handleWheel}
        /> 
      );
    }}
  </Zoom>
  ```


### Further reading

- https://developers.google.com/web/updates/2019/02/scrolling-intervention
- https://github.com/facebook/react/issues/8968
- https://github.com/facebook/react/issues/14856
- https://github.com/facebook/react/issues/6436

## Changelog
#### :boom: Breaking Changes

- [zoom] make wheel event active by default. fixes Chrome 73 scroll intervention warning.
  + To keep the default behavior before Chrome 73 and remove console warnings in Chrome 73, **remove**: 
    ```diff
    <MyComponent
    - onWheel={zoom.handleWheel}
    />
    ```
  + To make the onWheel events passive, **add**:
    ```diff
    <Zoom
    + passive={true}
    >
      {zoom => {
        return (
          <MyComponent
    +      onWheel={zoom.handleWheel}
          /> 
        );
      }}
    </Zoom>
    ```

#### :memo: Documentation

- [zoom] update docs

Thanks to @j1mie for bringing this to my attention. 
