### PR TITLE
Move Babel deps to dev only

### DIFF
--- a/packages/vx-text/package.json
+++ b/packages/vx-text/package.json
@@ -28,8 +28,6 @@
   },
   "homepage": "https://github.com/hshoff/vx#readme",
   "dependencies": {
-    "@babel/core": "^7.0.0",
-    "babel-plugin-lodash": "^3.3.2",
     "classnames": "^2.2.5",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.2",
@@ -59,6 +57,7 @@
     "@babel/preset-react": "^7.0.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.4.2",
+    "babel-plugin-lodash": "^3.3.2",
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "^1.0.2",
     "jest": "^21.2.1",


### PR DESCRIPTION
Noticed these were being pulled in when installing the package, so moving to dev dependencies since they aren't referenced in the source.

#### :bug: Bug Fix

- Move Babel dependencies to dev only.