### PR TITLE
[shape] add arc prop undefined checks. fixes #462

### DIFF
--- a/packages/vx-shape/src/shapes/Arc.js
+++ b/packages/vx-shape/src/shapes/Arc.js
@@ -35,13 +35,13 @@ export default function Arc({
 }) {
   const arc = d3Arc();
   if (centroid) arc.centroid(centroid);
-  if (innerRadius) arc.innerRadius(innerRadius);
-  if (outerRadius) arc.outerRadius(outerRadius);
-  if (cornerRadius) arc.cornerRadius(cornerRadius);
-  if (startAngle) arc.startAngle(startAngle);
-  if (endAngle) arc.endAngle(endAngle);
-  if (padAngle) arc.padAngle(padAngle);
-  if (padRadius) arc.padRadius(padRadius);
+  if (innerRadius !== undefined) arc.innerRadius(innerRadius);
+  if (outerRadius !== undefined) arc.outerRadius(outerRadius);
+  if (cornerRadius !== undefined) arc.cornerRadius(cornerRadius);
+  if (startAngle !== undefined) arc.startAngle(startAngle);
+  if (endAngle !== undefined) arc.endAngle(endAngle);
+  if (padAngle !== undefined) arc.padAngle(padAngle);
+  if (padRadius !== undefined) arc.padRadius(padRadius);
   if (children) return children({ path: arc });
   return <path ref={innerRef} className={cx('vx-arc', className)} d={arc(data)} {...restProps} />;
 }

--- a/packages/vx-shape/src/shapes/Pie.js
+++ b/packages/vx-shape/src/shapes/Pie.js
@@ -51,7 +51,7 @@ export default function Pie({
   const pie = d3Pie();
   if (pieSort !== undefined) pie.sort(pieSort);
   if (pieSortValues !== undefined) pie.sortValues(pieSortValues);
-  if (pieValue) pie.value(pieValue);
+  if (pieValue !== undefined) pie.value(pieValue);
   if (padAngle != null) pie.padAngle(padAngle);
   if (startAngle != null) pie.startAngle(startAngle);
   if (endAngle != null) pie.endAngle(endAngle);

--- a/packages/vx-shape/test/Arc.test.js
+++ b/packages/vx-shape/test/Arc.test.js
@@ -87,18 +87,102 @@ describe('<Arc />', () => {
     expect(args.path.outerRadius()()).toBe(42);
   });
 
-  test('it should take an cornerRadius number prop', () => {
+  test('it should take a cornerRadius number prop', () => {
     const fn = jest.fn();
     const wrapper = ArcChildren({ children: fn, cornerRadius: 42 });
     const args = fn.mock.calls[0][0];
     expect(args.path.cornerRadius()()).toBe(42);
   });
 
-  test('it should take an cornerRadius fn prop', () => {
+  test('it should take a cornerRadius fn prop', () => {
     const fn = jest.fn();
     const wrapper = ArcChildren({ children: fn, cornerRadius: () => 42 });
     const args = fn.mock.calls[0][0];
     expect(args.path.cornerRadius()()).toBe(42);
+  });
+
+  test('it should take a startAngle number prop', () => {
+    const fn = jest.fn();
+    const wrapper = ArcChildren({ children: fn, startAngle: 42 });
+    const args = fn.mock.calls[0][0];
+    expect(args.path.startAngle()()).toBe(42);
+  });
+
+  test('it should take a startAngle 0 prop', () => {
+    const fn = jest.fn();
+    const wrapper = ArcChildren({ children: fn, startAngle: 0 });
+    const args = fn.mock.calls[0][0];
+    expect(args.path.startAngle()()).toBe(0);
+  });
+
+  test('it should take a startAngle fn prop', () => {
+    const fn = jest.fn();
+    const wrapper = ArcChildren({ children: fn, startAngle: () => 42 });
+    const args = fn.mock.calls[0][0];
+    expect(args.path.startAngle()()).toBe(42);
+  });
+
+  test('it should take a endAngle number prop', () => {
+    const fn = jest.fn();
+    const wrapper = ArcChildren({ children: fn, endAngle: 42 });
+    const args = fn.mock.calls[0][0];
+    expect(args.path.endAngle()()).toBe(42);
+  });
+
+  test('it should take a endAngle 0 prop', () => {
+    const fn = jest.fn();
+    const wrapper = ArcChildren({ children: fn, endAngle: 0 });
+    const args = fn.mock.calls[0][0];
+    expect(args.path.endAngle()()).toBe(0);
+  });
+
+  test('it should take a endAngle fn prop', () => {
+    const fn = jest.fn();
+    const wrapper = ArcChildren({ children: fn, endAngle: () => 42 });
+    const args = fn.mock.calls[0][0];
+    expect(args.path.endAngle()()).toBe(42);
+  });
+
+  test('it should take a padAngle number prop', () => {
+    const fn = jest.fn();
+    const wrapper = ArcChildren({ children: fn, padAngle: 42 });
+    const args = fn.mock.calls[0][0];
+    expect(args.path.padAngle()()).toBe(42);
+  });
+
+  test('it should take a padAngle 0 prop', () => {
+    const fn = jest.fn();
+    const wrapper = ArcChildren({ children: fn, padAngle: 0 });
+    const args = fn.mock.calls[0][0];
+    expect(args.path.padAngle()()).toBe(0);
+  });
+
+  test('it should take a padAngle fn prop', () => {
+    const fn = jest.fn();
+    const wrapper = ArcChildren({ children: fn, padAngle: () => 42 });
+    const args = fn.mock.calls[0][0];
+    expect(args.path.padAngle()()).toBe(42);
+  });
+
+  test('it should take a padRadius number prop', () => {
+    const fn = jest.fn();
+    const wrapper = ArcChildren({ children: fn, padRadius: 42 });
+    const args = fn.mock.calls[0][0];
+    expect(args.path.padRadius()()).toBe(42);
+  });
+
+  test('it should take a padRadius 0 prop', () => {
+    const fn = jest.fn();
+    const wrapper = ArcChildren({ children: fn, padRadius: 0 });
+    const args = fn.mock.calls[0][0];
+    expect(args.path.padRadius()()).toBe(0);
+  });
+
+  test('it should take a padRadius fn prop', () => {
+    const fn = jest.fn();
+    const wrapper = ArcChildren({ children: fn, padRadius: () => 42 });
+    const args = fn.mock.calls[0][0];
+    expect(args.path.padRadius()()).toBe(42);
   });
 
   test('calling path with data returns a string', () => {


### PR DESCRIPTION
#### :boom: Breaking Changes

- [shape] `<Arc />` and `<Pie pieValue={} />` props now check for `!== undefined`. Before `0` wouldn't set the prop to `0` because `if (0)` is `false`. This is only a breaking change if you were passing `0` before and happy with `<Arc />` treating that as `undefined` and using d3.arc() defaults.

#### :bug: Bug Fix

- [shape] `<Arc />` now respects `0` as an allowed prop value
- [shape] `<Pie />`  `pieValue` now respects `0` as an allowed prop value

#### :house: Internal

- [shape] add more `<Arc />` tests
- [shape] convert `Arc.test` from `CRLF` => `LF`
