### PR TITLE
Fix rectangle displaying incorrectly for horizontal layouts

### DIFF
--- a/packages/vx-boxplot/src/boxplots/BoxPlot.js
+++ b/packages/vx-boxplot/src/boxplots/BoxPlot.js
@@ -126,7 +126,6 @@ export default function BoxPlot({
     boxplot.max = verticalToHorizontal(boxplot.max);
     boxplot.maxToThird = verticalToHorizontal(boxplot.maxToThird);
     boxplot.box = verticalToHorizontal(boxplot.box);
-    boxplot.box.y1 = valueScale(firstQuartile);
     boxplot.median = verticalToHorizontal(boxplot.median);
     boxplot.minToFirst = verticalToHorizontal(boxplot.minToFirst);
     boxplot.min = verticalToHorizontal(boxplot.min);

--- a/packages/vx-boxplot/src/boxplots/BoxPlot.js
+++ b/packages/vx-boxplot/src/boxplots/BoxPlot.js
@@ -125,6 +125,7 @@ export default function BoxPlot({
   if (horizontal) {
     boxplot.max = verticalToHorizontal(boxplot.max);
     boxplot.maxToThird = verticalToHorizontal(boxplot.maxToThird);
+    boxplot.box.y1 = valueScale(firstQuartile)
     boxplot.box = verticalToHorizontal(boxplot.box);
     boxplot.median = verticalToHorizontal(boxplot.median);
     boxplot.minToFirst = verticalToHorizontal(boxplot.minToFirst);


### PR DESCRIPTION
#### :boom: Breaking Changes

- 

#### :rocket: Enhancements

-

#### :memo: Documentation

-

:bug: Bug Fix

-  Described in issue #471 displaying boxplots horizontally causes the rectangle to be displayed in the wrong location.
 
#### :house: Internal

-
