### PR TITLE
[heatmap] rm bin.x0. fixes #474

### DIFF
--- a/packages/vx-heatmap/src/heatmaps/HeatmapRect.js
+++ b/packages/vx-heatmap/src/heatmaps/HeatmapRect.js
@@ -72,7 +72,7 @@ export default function HeatmapRect({
               className={cx('vx-heatmap-rect', className)}
               width={bin.width}
               height={bin.height}
-              x={bin.x + bin.x0}
+              x={bin.x}
               y={bin.y}
               fill={bin.color}
               fillOpacity={bin.opacity}


### PR DESCRIPTION
#### :bug: Bug Fix

- [heatmap] remove `bin.x0`. The x0 offset is accounted for in `bin.x`. fixes #474