### PR TITLE
[stats] fix horizontal boxplot in @vx/stats

### DIFF
--- a/packages/vx-boxplot/src/boxplots/BoxPlot.js
+++ b/packages/vx-boxplot/src/boxplots/BoxPlot.js
@@ -125,7 +125,7 @@ export default function BoxPlot({
   if (horizontal) {
     boxplot.max = verticalToHorizontal(boxplot.max);
     boxplot.maxToThird = verticalToHorizontal(boxplot.maxToThird);
-    boxplot.box.y1 = valueScale(firstQuartile)
+    boxplot.box.y1 = valueScale(firstQuartile);
     boxplot.box = verticalToHorizontal(boxplot.box);
     boxplot.median = verticalToHorizontal(boxplot.median);
     boxplot.minToFirst = verticalToHorizontal(boxplot.minToFirst);

--- a/packages/vx-stats/src/boxplot/BoxPlot.js
+++ b/packages/vx-stats/src/boxplot/BoxPlot.js
@@ -125,8 +125,8 @@ export default function BoxPlot({
   if (horizontal) {
     boxplot.max = verticalToHorizontal(boxplot.max);
     boxplot.maxToThird = verticalToHorizontal(boxplot.maxToThird);
-    boxplot.box = verticalToHorizontal(boxplot.box);
     boxplot.box.y1 = valueScale(firstQuartile);
+    boxplot.box = verticalToHorizontal(boxplot.box);
     boxplot.median = verticalToHorizontal(boxplot.median);
     boxplot.minToFirst = verticalToHorizontal(boxplot.minToFirst);
     boxplot.min = verticalToHorizontal(boxplot.min);


### PR DESCRIPTION
Counterpart to https://github.com/hshoff/vx/pull/472 which fixes the bug in `@vx/boxplot`. Eventually the plan is deprecate `@vx/boxplot` in favor of `@vx/stats`. Until then, we'll need to update both. 

#### :bug: Bug Fix

- [stats] fix horizontal boxplot in @vx/stats
