### PR TITLE
[scale] bump d3-scale dep for scaleSymlog

### DIFF
--- a/packages/vx-scale/package.json
+++ b/packages/vx-scale/package.json
@@ -8,25 +8,17 @@
   "scripts": {
     "build": "npm run build:babel && npm run build:dist",
     "build:dist": "rm -rf dist && mkdir dist && rollup -c",
-    "build:babel": "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets @babel/preset-react,@babel/preset-env",
+    "build:babel":
+      "rm -rf build && mkdir build && babel src --out-dir build --ignore node_modules/ --presets @babel/preset-react,@babel/preset-env",
     "prepublish": "npm run build",
     "test": "jest"
   },
-  "files": [
-    "dist",
-    "build"
-  ],
+  "files": ["dist", "build"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hshoff/vx.git"
   },
-  "keywords": [
-    "vx",
-    "react",
-    "d3",
-    "visualizations",
-    "charts"
-  ],
+  "keywords": ["vx", "react", "d3", "visualizations", "charts"],
   "author": "@hshoff",
   "license": "MIT",
   "bugs": {
@@ -73,7 +65,7 @@
     "rollup-plugin-uglify": "^4.0.0"
   },
   "dependencies": {
-    "d3-scale": "^2.0.0"
+    "d3-scale": "^2.2.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Counterpart to https://github.com/hshoff/vx/pull/470 which makes sure the correct `d3-scale` version is installed to support the addition of `scaleSymlog`.

#### 💥 Breaking changes

- [scale] [d3-scale 2.2.2 changed](https://github.com/d3/d3-scale/issues/117) the behavior of a collapsed domain. See [this comment](https://github.com/hshoff/vx/issues/473#issuecomment-508203310) for how to handle the updated behavior.

#### :rocket: Enhancements

- [scale] bump d3-scale dep to `^2.2.2` for scaleSymlog

_Sidenote_: Since `d3-scale` [added convenience constructors](https://github.com/d3/d3-scale/issues/157) (`scale(domain, range)`) we may deprecate `@vx/scale` in favor of `d3-scale` in the future. Currently, `@vx/scale` only adds two additional behaviors around d3-scale: Convenience constructors (as named args: `scale({ domain, range })`) and a `.type` property on scale instances. These benefits may not be worth the cost of maintaining the wrapping functions. I always thought i would add a way to make scales immutable, but it may not be worth it anymore. 