### PR TITLE
[root] disable no-useless-rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
         {
           "files": "*.{js,jsx,ts,tsx}",
           "rules": {
+            "no-useless-rename": "off",
             "linebreak-style": "off",
             "operator-linebreak": "off",
             "no-use-before-define": "off",


### PR DESCRIPTION
Should fix the broken build on master https://travis-ci.org/hshoff/vx/builds/591675984

#### :house: Internal

- [eslint] disable `no-useless-name`
