### PR TITLE
[eslint] turn off react/jsx-curly-brace-presence

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
             "import/prefer-default-export": "off",
             "promise/param-names": "off",
             "react/sort-comp": "off",
+            "react/jsx-curly-brace-presence": "off",
             "react/jsx-filename-extension": "off",
             "react/jsx-no-literals": "off",
             "react/jsx-props-no-spreading": "off",


### PR DESCRIPTION
Some reason lint fails on travis-ci but passes locally. 

#### :house: Internal

- [eslint] turn off react/jsx-curly-brace-presence
