### PR TITLE
fix(network, shape, chord, bounds): Fix type exports + misc component types

### DIFF
--- a/packages/vx-bounds/src/index.ts
+++ b/packages/vx-bounds/src/index.ts
@@ -1,4 +1,5 @@
 import { WithBoundingRectsProps as WithBoundingRectsPropsType } from './enhancers/withBoundingRects';
+
 export { default as withBoundingRects } from './enhancers/withBoundingRects';
 
 export type WithBoundingRectsProps = WithBoundingRectsPropsType;

--- a/packages/vx-bounds/src/index.ts
+++ b/packages/vx-bounds/src/index.ts
@@ -1,4 +1,4 @@
-export {
-  default as withBoundingRects,
-  WithBoundingRectsProps,
-} from './enhancers/withBoundingRects';
+import { WithBoundingRectsProps as WithBoundingRectsPropsType } from './enhancers/withBoundingRects';
+export { default as withBoundingRects } from './enhancers/withBoundingRects';
+
+export type WithBoundingRectsProps = WithBoundingRectsPropsType;

--- a/packages/vx-chord/src/Ribbon.tsx
+++ b/packages/vx-chord/src/Ribbon.tsx
@@ -2,16 +2,27 @@ import React from 'react';
 import cx from 'classnames';
 import { ribbon as d3ribbon, Chord, ChordSubgroup } from 'd3-chord';
 
+type NumAccessor = (d: ChordSubgroup) => number;
+
 export type RibbonProps = {
   chord: Chord;
   source?: (d: Chord) => ChordSubgroup;
   target?: (d: Chord) => ChordSubgroup;
-  radius?: (d: ChordSubgroup) => number;
-  startAngle?: (d: ChordSubgroup) => number;
-  endAngle?: (d: ChordSubgroup) => number;
+  radius?: number | NumAccessor;
+  startAngle?: number | NumAccessor;
+  endAngle?: number | NumAccessor;
   children?: ({ path }: { path: string | null }) => string | undefined;
   className?: string;
 };
+
+/** This is a workaround for TypeScript not inferring the correct method overload */
+function setNumberOrNumberAccessor(
+  func: (d: number | NumAccessor) => void,
+  value: number | NumAccessor,
+) {
+  if (typeof value === 'number') func(value);
+  else func(value);
+}
 
 export default function Ribbon({
   chord,
@@ -27,9 +38,9 @@ export default function Ribbon({
   const ribbon = d3ribbon<any, Chord, ChordSubgroup>();
   if (source) ribbon.source(source);
   if (target) ribbon.target(target);
-  if (radius) ribbon.radius(radius);
-  if (startAngle) ribbon.startAngle(startAngle);
-  if (endAngle) ribbon.endAngle(endAngle);
+  if (radius) setNumberOrNumberAccessor(ribbon.radius, radius);
+  if (startAngle) setNumberOrNumberAccessor(ribbon.startAngle, startAngle);
+  if (endAngle) setNumberOrNumberAccessor(ribbon.endAngle, endAngle);
   const path = ribbon(chord) as any;
   if (children) return <>{children({ path })}</>;
 

--- a/packages/vx-network/src/Graph.tsx
+++ b/packages/vx-network/src/Graph.tsx
@@ -16,12 +16,12 @@ type Props<Link, Node> = {
   /** Graph to render nodes and links for. */
   graph?: GraphType<Link, Node>;
   /** Component for rendering a single Link. */
-  linkComponent:
+  linkComponent?:
     | string
     | React.FunctionComponent<LinkProvidedProps<Link>>
     | React.ComponentClass<LinkProvidedProps<Link>>;
   /** Component for rendering a single Node. */
-  nodeComponent:
+  nodeComponent?:
     | string
     | React.FunctionComponent<NodeProvidedProps<Node>>
     | React.ComponentClass<NodeProvidedProps<Node>>;

--- a/packages/vx-shape/src/shapes/BarStack.tsx
+++ b/packages/vx-shape/src/shapes/BarStack.tsx
@@ -7,11 +7,11 @@ import { stack as d3stack, SeriesPoint } from 'd3-shape';
 import stackOrder from '../util/stackOrder';
 import stackOffset from '../util/stackOffset';
 import Bar from './Bar';
-import { StackProps, NumAccessor } from './Stack';
+import { StackProps, NumAccessor as StackNumAccessor } from './Stack';
 import { ScaleType, StackKey, BarStack, $TSFIXME } from '../types';
 import setNumOrAccessor from '../util/setNumberOrNumberAccessor';
 
-export { NumAccessor };
+export type NumAccessor<Datum> = StackNumAccessor<Datum>;
 
 export type BarStackProps<Datum> = Pick<
   StackProps<Datum>,

--- a/packages/vx-shape/src/shapes/LineRadial.tsx
+++ b/packages/vx-shape/src/shapes/LineRadial.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import cx from 'classnames';
 import { radialLine, RadialLine } from 'd3-shape';
 import { LinePathProps } from './LinePath';
+import setNumberOrNumberAccessor from '../util/setNumberOrNumberAccessor';
+
+export type NumAccessor<Datum> = (datum: Datum, index: number, data: Datum[]) => number;
 
 export type LineRadialProps<Datum> = Pick<
   LinePathProps<Datum>,
@@ -10,9 +13,9 @@ export type LineRadialProps<Datum> = Pick<
   /** Override render function which is passed the configured path generator as input. */
   children?: (args: { path: RadialLine<Datum> }) => React.ReactNode;
   /** Returns the angle value in radians for a given Datum, with 0 at -y (12 o’clock). */
-  angle?: (datum: Datum, index: number, data: Datum[]) => number;
+  angle?: number | NumAccessor<Datum>;
   /** Returns the radius value in radians for a given Datum, with 0 at the center. */
-  radius?: (datum: Datum, index: number, data: Datum[]) => number;
+  radius?: number | NumAccessor<Datum>;
 };
 
 export default function LineRadial<Datum>({
@@ -28,8 +31,8 @@ export default function LineRadial<Datum>({
   ...restProps
 }: LineRadialProps<Datum> & Omit<React.SVGProps<SVGPathElement>, keyof LineRadialProps<Datum>>) {
   const path = radialLine<Datum>();
-  if (angle) path.angle(angle);
-  if (radius) path.radius(radius);
+  if (angle) setNumberOrNumberAccessor(path.angle, angle);
+  if (radius) setNumberOrNumberAccessor(path.radius, radius);
   if (defined) path.defined(defined);
   if (curve) path.curve(curve);
   if (children) return <>{children({ path })}</>;


### PR DESCRIPTION
#### :bug: Bug Fix

This PR fixes a few things

- Closes #542, where `type` exports in `@vx/bounds` and `@vx/shape` were not handled correctly in the `esm/` build. 
  - It seems that the `export { TypeName, VariableName } from '...'` and `export { TypeName }` syntax doesn't correctly distinguish TS `type`s / `interface`s from JS variables, and since `types` are not generated for `esm/` this gives unresolved errors in the `demo` packages which imports from `esm/`
  - This seems to be resolved with more explicit `type` exports: the demo builds without error, and the `type`s don't show up in the `esm/` files any more

- Loosens requirements for some `type`s that I noticed were giving errors in the demo: 
  - `@vx/network` `Graph` 
  - `@vx/shape` `LineRadial`
  - `@vx/chord` `Ribbon`

@hshoff 