### PR TITLE
Fix debounced calls after unmount in responsive components

### DIFF
--- a/packages/vx-responsive/src/components/ParentSize.tsx
+++ b/packages/vx-responsive/src/components/ParentSize.tsx
@@ -62,6 +62,7 @@ export default class ParentSize extends React.Component<
   componentWillUnmount() {
     if (this.animationFrameID) window.cancelAnimationFrame(this.animationFrameID);
     if (this.resizeObserver) this.resizeObserver.disconnect();
+    if (this.resize) this.resize.cancel();
   }
 
   resize = ({ width, height, top, left }: ParentSizeState) => {

--- a/packages/vx-responsive/src/components/ParentSize.tsx
+++ b/packages/vx-responsive/src/components/ParentSize.tsx
@@ -62,7 +62,7 @@ export default class ParentSize extends React.Component<
   componentWillUnmount() {
     if (this.animationFrameID) window.cancelAnimationFrame(this.animationFrameID);
     if (this.resizeObserver) this.resizeObserver.disconnect();
-    if (this.resize) this.resize.cancel();
+    this.resize.cancel();
   }
 
   resize = ({ width, height, top, left }: ParentSizeState) => {

--- a/packages/vx-responsive/src/enhancers/withParentSize.tsx
+++ b/packages/vx-responsive/src/enhancers/withParentSize.tsx
@@ -53,7 +53,7 @@ export default function withParentSize<Props extends WithParentSizeProps = {}>(
     componentWillUnmount() {
       if (this.animationFrameID) window.cancelAnimationFrame(this.animationFrameID);
       if (this.resizeObserver) this.resizeObserver.disconnect();
-      if (this.resize) this.resize.cancel();
+      this.debouncedResize.cancel();
     }
 
     resize = ({ width, height }: { width: number; height: number }) => {

--- a/packages/vx-responsive/src/enhancers/withParentSize.tsx
+++ b/packages/vx-responsive/src/enhancers/withParentSize.tsx
@@ -53,6 +53,7 @@ export default function withParentSize<Props extends WithParentSizeProps = {}>(
     componentWillUnmount() {
       if (this.animationFrameID) window.cancelAnimationFrame(this.animationFrameID);
       if (this.resizeObserver) this.resizeObserver.disconnect();
+      if (this.resize) this.resize.cancel();
     }
 
     resize = ({ width, height }: { width: number; height: number }) => {

--- a/packages/vx-responsive/src/enhancers/withScreenSize.tsx
+++ b/packages/vx-responsive/src/enhancers/withScreenSize.tsx
@@ -37,6 +37,7 @@ export default function withScreenSize<Props extends WithScreenSizeProps = {}>(
 
     componentWillUnmount() {
       window.removeEventListener('resize', this.handleResize, false);
+      this.resize.cancel();
     }
 
     resize = (/** event */) => {

--- a/packages/vx-responsive/src/enhancers/withScreenSize.tsx
+++ b/packages/vx-responsive/src/enhancers/withScreenSize.tsx
@@ -37,7 +37,7 @@ export default function withScreenSize<Props extends WithScreenSizeProps = {}>(
 
     componentWillUnmount() {
       window.removeEventListener('resize', this.handleResize, false);
-      this.resize.cancel();
+      this.handleResize.cancel();
     }
 
     resize = (/** event */) => {


### PR DESCRIPTION

#### :bug: Bug Fix

Debounce calls can still fire after unmount, so we need to cancel them.
