### PR TITLE
Update Chord Diagram example to make more sense

### DIFF
--- a/packages/vx-demo/src/components/tiles/chord.js
+++ b/packages/vx-demo/src/components/tiles/chord.js
@@ -3,8 +3,16 @@ import { Arc } from '@vx/shape';
 import { Group } from '@vx/group';
 import { Chord, Ribbon } from '@vx/chord';
 import { scaleOrdinal } from '@vx/scale';
-import { schemeDark2 } from 'd3-scale-chromatic';
+import { LinearGradient } from '@vx/gradient';
 
+const pink = '#ff2fab';
+const orange = '#ffc62e';
+const purple = '#dc04ff';
+const purple2 = '#7324ff';
+const red = '#d04376';
+const green = '#52f091';
+const blue = '#04a6ff';
+const lime = '#00ddc6';
 const bg = '#e4e3d8';
 
 const matrix = [
@@ -19,8 +27,8 @@ function descending(a, b) {
 }
 
 const color = scaleOrdinal({
-  domain: [1, 2, 3, 4],
-  range: schemeDark2,
+  domain: [0, 1, 2, 3],
+  range: ['url(#gpinkorange)', 'url(#gpurplered)', 'url(#gpurplegreen)', 'url(#gbluelime)'],
 });
 
 export default ({ width, height, centerSize = 20, events = false }) => {
@@ -32,6 +40,10 @@ export default ({ width, height, centerSize = 20, events = false }) => {
   return (
     <div className="Chords">
       <svg width={width} height={height}>
+        <LinearGradient id="gpinkorange" from={pink} to={orange} vertical={false} />
+        <LinearGradient id="gpurplered" from={purple} to={red} vertical={false} />
+        <LinearGradient id="gpurplegreen" from={purple2} to={green} vertical={false} />
+        <LinearGradient id="gbluelime" from={blue} to={lime} vertical={false} />
         <rect width={width} height={height} fill={bg} rx={14} />
         <Group top={height / 2} left={width / 2}>
           <Chord matrix={matrix} padAngle={0.05} sortSubgroups={descending}>

--- a/packages/vx-demo/src/components/tiles/chord.js
+++ b/packages/vx-demo/src/components/tiles/chord.js
@@ -3,6 +3,7 @@ import { Arc } from '@vx/shape';
 import { Group } from '@vx/group';
 import { Chord, Ribbon } from '@vx/chord';
 import { scaleOrdinal } from '@vx/scale';
+import { schemeDark2 } from 'd3-scale-chromatic';
 
 const bg = '#e4e3d8';
 
@@ -19,7 +20,7 @@ function descending(a, b) {
 
 const color = scaleOrdinal({
   domain: [1, 2, 3, 4],
-  range: ['#1b9e77', '#d95f02', '#7570b3', '#e7298a', '#66a61e', '#e6ab02', '#a6761d', '#666666'],
+  range: schemeDark2,
 });
 
 export default ({ width, height, centerSize = 20, events = false }) => {

--- a/packages/vx-demo/src/components/tiles/chord.js
+++ b/packages/vx-demo/src/components/tiles/chord.js
@@ -3,16 +3,7 @@ import { Arc } from '@vx/shape';
 import { Group } from '@vx/group';
 import { Chord, Ribbon } from '@vx/chord';
 import { scaleOrdinal } from '@vx/scale';
-import { LinearGradient } from '@vx/gradient';
 
-const pink = '#ff2fab';
-const orange = '#ffc62e';
-const purple = '#dc04ff';
-const purple2 = '#7324ff';
-const red = '#d04376';
-const green = '#52f091';
-const blue = '#04a6ff';
-const lime = '#00ddc6';
 const bg = '#e4e3d8';
 
 const matrix = [
@@ -28,7 +19,7 @@ function descending(a, b) {
 
 const color = scaleOrdinal({
   domain: [1, 2, 3, 4],
-  range: ['url(#gpinkorange)', 'url(#gpurplered)', 'url(#gpurplegreen)', 'url(#gbluelime)'],
+  range: ['#1b9e77', '#d95f02', '#7570b3', '#e7298a', '#66a61e', '#e6ab02', '#a6761d', '#666666'],
 });
 
 export default ({ width, height, centerSize = 20, events = false }) => {
@@ -40,10 +31,6 @@ export default ({ width, height, centerSize = 20, events = false }) => {
   return (
     <div className="Chords">
       <svg width={width} height={height}>
-        <LinearGradient id="gpinkorange" from={pink} to={orange} vertical={false} />
-        <LinearGradient id="gpurplered" from={purple} to={red} vertical={false} />
-        <LinearGradient id="gpurplegreen" from={purple2} to={green} vertical={false} />
-        <LinearGradient id="gbluelime" from={blue} to={lime} vertical={false} />
         <rect width={width} height={height} fill={bg} rx={14} />
         <Group top={height / 2} left={width / 2}>
           <Chord matrix={matrix} padAngle={0.05} sortSubgroups={descending}>
@@ -71,7 +58,7 @@ export default ({ width, height, centerSize = 20, events = false }) => {
                         key={`ribbon-${i}`}
                         chord={chord}
                         radius={innerRadius}
-                        fill={color(i)}
+                        fill={color(chord.target.index)}
                         fillOpacity={0.75}
                         onClick={() => {
                           alert(`${JSON.stringify(chord)}`);

--- a/packages/vx-demo/src/pages/chord.js
+++ b/packages/vx-demo/src/pages/chord.js
@@ -77,7 +77,7 @@ export default ({ width, height, centerSize = 20, events = false }) => {
                         fill={color(chord.target.index)}
                         fillOpacity={0.75}
                         onClick={() => {
-                          alert(\'\${JSON.stringify(chord)}\`);
+                          alert(\`\${JSON.stringify(chord)}\`);
                         }}
                       />
                     );

--- a/packages/vx-demo/src/pages/chord.js
+++ b/packages/vx-demo/src/pages/chord.js
@@ -19,8 +19,16 @@ import { Arc } from '@vx/shape';
 import { Group } from '@vx/group';
 import { Chord, Ribbon } from '@vx/chord';
 import { scaleOrdinal } from '@vx/scale';
-import { schemeDark2 } from 'd3-scale-chromatic';
+import { LinearGradient } from '@vx/gradient';
 
+const pink = '#ff2fab';
+const orange = '#ffc62e';
+const purple = '#dc04ff';
+const purple2 = '#7324ff';
+const red = '#d04376';
+const green = '#52f091';
+const blue = '#04a6ff';
+const lime = '#00ddc6';
 const bg = '#e4e3d8';
 
 const matrix = [
@@ -35,8 +43,8 @@ function descending(a, b) {
 }
 
 const color = scaleOrdinal({
-  domain: [1, 2, 3, 4],
-  range: schemeDark2,
+  domain: [0, 1, 2, 3],
+  range: ['url(#gpinkorange)', 'url(#gpurplered)', 'url(#gpurplegreen)', 'url(#gbluelime)'],
 });
 
 export default ({ width, height, centerSize = 20, events = false }) => {
@@ -48,6 +56,10 @@ export default ({ width, height, centerSize = 20, events = false }) => {
   return (
     <div className="Chords">
       <svg width={width} height={height}>
+        <LinearGradient id="gpinkorange" from={pink} to={orange} vertical={false} />
+        <LinearGradient id="gpurplered" from={purple} to={red} vertical={false} />
+        <LinearGradient id="gpurplegreen" from={purple2} to={green} vertical={false} />
+        <LinearGradient id="gbluelime" from={blue} to={lime} vertical={false} />
         <rect width={width} height={height} fill={bg} rx={14} />
         <Group top={height / 2} left={width / 2}>
           <Chord matrix={matrix} padAngle={0.05} sortSubgroups={descending}>

--- a/packages/vx-demo/src/pages/chord.js
+++ b/packages/vx-demo/src/pages/chord.js
@@ -19,23 +19,14 @@ import { Arc } from '@vx/shape';
 import { Group } from '@vx/group';
 import { Chord, Ribbon } from '@vx/chord';
 import { scaleOrdinal } from '@vx/scale';
-import { LinearGradient } from '@vx/gradient';
 
-const pink = '#ff2fab';
-const orange = '#ffc62e';
-const purple = '#dc04ff';
-const purple2 = '#7324ff';
-const red = '#d04376';
-const green = '#52f091';
-const blue = '#04a6ff';
-const lime = '#00ddc6';
 const bg = '#e4e3d8';
 
 const matrix = [
   [11975, 5871, 8916, 2868],
   [1951, 10048, 2060, 6171],
   [8010, 16145, 8090, 8045],
-  [1013, 990, 940, 6907]
+  [1013, 990, 940, 6907],
 ];
 
 function descending(a, b) {
@@ -44,20 +35,18 @@ function descending(a, b) {
 
 const color = scaleOrdinal({
   domain: [1, 2, 3, 4],
-  range: ['url(#gpinkorange)', 'url(#gpurplered)', 'url(#gpurplegreen)', 'url(#gbluelime)']
+  range: ['#1b9e77', '#d95f02', '#7570b3', '#e7298a', '#66a61e', '#e6ab02', '#a6761d', '#666666'],
 });
 
-export default ({ width, height, centerSize = 20 }) => {
+export default ({ width, height, centerSize = 20, events = false }) => {
+  if (width < 10) return null;
+
   const outerRadius = Math.min(width, height) * 0.5 - (centerSize + 10);
   const innerRadius = outerRadius - centerSize;
 
   return (
     <div className="Chords">
       <svg width={width} height={height}>
-        <LinearGradient id="gpinkorange" from={pink} to={orange} vertical={false} />
-        <LinearGradient id="gpurplered" from={purple} to={red} vertical={false} />
-        <LinearGradient id="gpurplegreen" from={purple2} to={green} vertical={false} />
-        <LinearGradient id="gbluelime" from={blue} to={lime} vertical={false} />
         <rect width={width} height={height} fill={bg} rx={14} />
         <Group top={height / 2} left={width / 2}>
           <Chord matrix={matrix} padAngle={0.05} sortSubgroups={descending}>
@@ -72,7 +61,8 @@ export default ({ width, height, centerSize = 20 }) => {
                         innerRadius={innerRadius}
                         outerRadius={outerRadius}
                         fill={color(i)}
-                        onClick={event => {
+                        onClick={() => {
+                          if (!events) return;
                           alert(\`\${JSON.stringify(group)}\`);
                         }}
                       />
@@ -84,10 +74,10 @@ export default ({ width, height, centerSize = 20 }) => {
                         key={\`ribbon-\${i}\`}
                         chord={chord}
                         radius={innerRadius}
-                        fill={color(i)}
+                        fill={color(chord.target.index)}
                         fillOpacity={0.75}
-                        onClick={event => {
-                          alert(\`\${JSON.stringify(chord)}\`);
+                        onClick={() => {
+                          alert(\'\${JSON.stringify(chord)}\`);
                         }}
                       />
                     );
@@ -99,8 +89,6 @@ export default ({ width, height, centerSize = 20 }) => {
         </Group>
       </svg>
     </div>
-  );
-};
 `}
     </Show>
   );

--- a/packages/vx-demo/src/pages/chord.js
+++ b/packages/vx-demo/src/pages/chord.js
@@ -19,6 +19,7 @@ import { Arc } from '@vx/shape';
 import { Group } from '@vx/group';
 import { Chord, Ribbon } from '@vx/chord';
 import { scaleOrdinal } from '@vx/scale';
+import { schemeDark2 } from 'd3-scale-chromatic';
 
 const bg = '#e4e3d8';
 
@@ -35,7 +36,7 @@ function descending(a, b) {
 
 const color = scaleOrdinal({
   domain: [1, 2, 3, 4],
-  range: ['#1b9e77', '#d95f02', '#7570b3', '#e7298a', '#66a61e', '#e6ab02', '#a6761d', '#666666'],
+  range: schemeDark2,
 });
 
 export default ({ width, height, centerSize = 20, events = false }) => {


### PR DESCRIPTION
This PR updates the chord diagram.

1. The linear gradients are replaced by static colors to better show what is going on.
2. The coloring of the ribbons is fixed. Previously, the coloring function was used identically for the arcs and ribbons (using the index), but that doesn't work for ribbons, as the index of a ribbon is not related to the index of the arcs (resulting in a ribbon coloring that doesn't make sense). Now, the index of the target group is used to color the ribbons.
3. The code example of the chord graph is updated accordingly.

**Old**:
Notice how the coloring of the ribbons with identical source and target group is different than the coloring of that group. I suppose that this wasn't noticed because of the gradients :smile:
![Selection_003](https://user-images.githubusercontent.com/5368029/71678453-7c727e80-2d85-11ea-8aaa-54242cb64477.png)

**New**:
![Selection_004](https://user-images.githubusercontent.com/5368029/71678451-7bd9e800-2d85-11ea-98b3-35200011c0b0.png)
