### PR TITLE
Uninvert BarGroupHorizontal x scale

### DIFF
--- a/packages/vx-demo/src/components/tiles/bargrouphorizontal.js
+++ b/packages/vx-demo/src/components/tiles/bargrouphorizontal.js
@@ -53,7 +53,7 @@ export default ({
   // scales
   y0Scale.rangeRound([0, yMax]);
   y1Scale.rangeRound([0, y0Scale.bandwidth()]);
-  xScale.rangeRound([xMax, 0]);
+  xScale.rangeRound([0, xMax]);
 
   return (
     <svg width={width} height={height}>

--- a/packages/vx-demo/src/pages/bargrouphorizontal.js
+++ b/packages/vx-demo/src/pages/bargrouphorizontal.js
@@ -64,7 +64,7 @@ export default ({
   // scales
   y0Scale.rangeRound([0, yMax]);
   y1Scale.rangeRound([0, y0Scale.bandwidth()]);
-  xScale.rangeRound([xMax, 0]);
+  xScale.rangeRound([0, xMax]);
 
   return (
     <svg width={width} height={height}>

--- a/packages/vx-shape/src/shapes/BarGroupHorizontal.tsx
+++ b/packages/vx-shape/src/shapes/BarGroupHorizontal.tsx
@@ -63,7 +63,7 @@ export default function BarGroupHorizontalComponent<Datum extends { [key: string
           x: x(value),
           y: y1Scale(key),
           color: color(key, j),
-          width: width - xScale(value),
+          width: xScale(value),
         };
       }),
     };


### PR DESCRIPTION
Fixes #573.

#### :boom: Breaking Changes

- [shape] `BarGroupHorizontal` now takes an uninverted `xScale`.


