### PR TITLE
Change Text's use of deprecated lifecycle

### DIFF
--- a/packages/vx-text/src/Text.tsx
+++ b/packages/vx-text/src/Text.tsx
@@ -85,16 +85,19 @@ class Text extends React.Component<TextProps, TextState> {
 
   private spaceWidth: number = 0;
 
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
     this.updateWordsByLines(this.props, true);
   }
 
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillReceiveProps(nextProps: TextProps) {
+  componentDidUpdate(prevProps: TextProps, prevState: TextState) {
+    // We calculated a new state, break out of the loop.
+    if (prevState.wordsByLines !== this.state.wordsByLines) {
+      return;
+    }
+
     const needCalculate =
-      this.props.children !== nextProps.children || this.props.style !== nextProps.style;
-    this.updateWordsByLines(nextProps, needCalculate);
+      prevProps.children !== this.props.children || prevProps.style !== this.props.style;
+    this.updateWordsByLines(this.props, needCalculate);
   }
 
   updateWordsByLines(props: TextProps, needCalculate: boolean = false) {


### PR DESCRIPTION
#### :house: Internal

- [text] Remove deprecated lifecycles used in Text

Fixes #396. Closes #431. I thought I might as well take a crack at converting the deprecated lifecycles to something better. I was gonna use hooks but I have no idea if I can use it yet.

