### PR TITLE
Fixed Zoom constrain prop to work with useCallback made functions

### DIFF
--- a/packages/vx-zoom/src/Zoom.tsx
+++ b/packages/vx-zoom/src/Zoom.tsx
@@ -198,19 +198,18 @@ class Zoom extends React.Component<ZoomProps, ZoomState> {
     return `matrix(${scaleX}, ${skewY}, ${skewX}, ${scaleY}, ${translateX}, ${translateY})`;
   };
 
-  constrain =
-    this.props.constrain ||
-    ((transformMatrix: TransformMatrix, prevTransformMatrix: TransformMatrix) => {
-      const { scaleXMin, scaleXMax, scaleYMin, scaleYMax } = this.props;
-      const { scaleX, scaleY } = transformMatrix;
-      const shouldConstrainScaleX = scaleX > scaleXMax! || scaleX < scaleXMin!;
-      const shouldConstrainScaleY = scaleY > scaleYMax! || scaleY < scaleYMin!;
+  constrain = (transformMatrix: TransformMatrix, prevTransformMatrix: TransformMatrix) => {
+    if (this.props.constrain) return this.props.constrain(transformMatrix, prevTransformMatrix);
+    const { scaleXMin, scaleXMax, scaleYMin, scaleYMax } = this.props;
+    const { scaleX, scaleY } = transformMatrix;
+    const shouldConstrainScaleX = scaleX > scaleXMax! || scaleX < scaleXMin!;
+    const shouldConstrainScaleY = scaleY > scaleYMax! || scaleY < scaleYMin!;
 
-      if (shouldConstrainScaleX || shouldConstrainScaleY) {
-        return prevTransformMatrix;
-      }
-      return transformMatrix;
-    });
+    if (shouldConstrainScaleX || shouldConstrainScaleY) {
+      return prevTransformMatrix;
+    }
+    return transformMatrix;
+  };
 
   dragStart = (event: React.MouseEvent) => {
     const { transformMatrix } = this.state;


### PR DESCRIPTION
In the Zoom package, the constrain function initially took a reference to the constrain prop once on mount. During subsequent renders the function never updated when the prop did.

This PR changes it so that this.props.constrain function will always be the most recent reference. This is important when working with hooks and useCallback made functions, which will create a new reference with updates.

#### :boom: Breaking Changes

- Im not sure if this was intentional, after all it very well could be

#### :bug: Bug Fix

- [#622](https://github.com/hshoff/vx/issues/622)
