### PR TITLE
typescript(vx-demo): re-write Gradients + Polygons demos in TypeScript

### DIFF
--- a/packages/vx-demo/src/components/gallery.js
+++ b/packages/vx-demo/src/components/gallery.js
@@ -10,7 +10,7 @@ import Lines from './tiles/lines';
 import Bars from './tiles/bars';
 import Dots from './tiles/dots';
 import Patterns from './tiles/Patterns.tsx';
-import Gradients from './tiles/gradients';
+import Gradients from './tiles/Gradients.tsx';
 import Area from './tiles/area';
 import Stacked from './tiles/stacked';
 import MultiLine from './tiles/multiline';
@@ -40,7 +40,7 @@ import DragII from './tiles/drag-ii';
 import LinkTypes from './tiles/linkTypes';
 import Threshold from './tiles/threshold';
 import Chord from './tiles/chord';
-import Polygons from './tiles/polygons';
+import Polygons from './tiles/Polygons.tsx';
 import ZoomI from './tiles/zoom-i';
 import BrushChart from './tiles/brush';
 

--- a/packages/vx-demo/src/components/tiles/Gradients.tsx
+++ b/packages/vx-demo/src/components/tiles/Gradients.tsx
@@ -1,18 +1,4 @@
 import React from 'react';
-import Show from '../components/Show.tsx';
-import Gradients from '../components/tiles/gradients';
-
-export default () => {
-  return (
-    <Show
-      component={Gradients}
-      title="Gradients"
-      shadow
-      margin={{
-        bottom: 0,
-      }}
-    >
-      {`import React from 'react';
 import { Bar } from '@vx/shape';
 import {
   GradientDarkgreenGreen,
@@ -22,11 +8,11 @@ import {
   GradientPinkRed,
   GradientPurpleOrange,
   GradientPurpleRed,
-  GradientPurpleTeal,
   GradientSteelPurple,
   GradientTealBlue,
   RadialGradient,
 } from '@vx/gradient';
+import { ShowProvidedProps } from '../../types';
 
 export default ({
   width,
@@ -37,9 +23,10 @@ export default ({
     right: 0,
     bottom: 80,
   },
-}) => {
-  const w = width / 4;
-  const h = (height - margin.bottom) / 2;
+}: ShowProvidedProps) => {
+  const barWidth = Math.max(width / 4, 0);
+  const barHeight = Math.max((height - margin.bottom) / 2, 0);
+
   return (
     <svg width={width} height={height}>
       <GradientDarkgreenGreen id="DarkgreenGreen" />
@@ -49,93 +36,89 @@ export default ({
       <GradientPinkRed id="PinkRed" vertical={false} />
       <GradientPurpleOrange id="PurpleOrange" vertical={false} />
       <GradientPurpleRed id="PurpleRed" vertical={false} />
-      <RadialGradient from="#55bdd5" to="#4f3681" id="Radial" r={'80%'} />
+      <RadialGradient from="#55bdd5" to="#4f3681" id="Radial" r="80%" />
       <GradientSteelPurple id="SteelPurple" vertical={false} />
       <GradientTealBlue id="TealBlue" vertical={false} />
       <Bar
         x={0}
         y={0}
-        width={w}
-        height={h}
-        fill={\`url(#LightgreenGreen)\`}
+        width={barWidth}
+        height={barHeight}
+        fill="url(#LightgreenGreen)"
         stroke="#ffffff"
         strokeWidth={8}
         rx={14}
       />
       <Bar
-        x={w}
+        x={barWidth}
         y={0}
-        width={w}
-        height={h}
-        fill={\`url(#OrangeRed)\`}
+        width={barWidth}
+        height={barHeight}
+        fill="url(#OrangeRed)"
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
       />
       <Bar
-        x={w * 2}
+        x={barWidth * 2}
         y={0}
-        width={w}
-        height={h}
-        fill={\`url(#PinkBlue)\`}
+        width={barWidth}
+        height={barHeight}
+        fill="url(#PinkBlue)"
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
       />
       <Bar
-        x={w * 3}
+        x={barWidth * 3}
         y={0}
-        width={w}
-        height={h}
-        fill={\`url(#DarkgreenGreen)\`}
+        width={barWidth}
+        height={barHeight}
+        fill="url(#DarkgreenGreen)"
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
       />
       <Bar
         x={0}
-        y={h}
-        width={w}
-        height={h}
-        fill={\`url(#PinkRed)\`}
+        y={barHeight}
+        width={barWidth}
+        height={barHeight}
+        fill="url(#PinkRed)"
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
       />
       <Bar
-        x={w}
-        y={h}
-        width={w}
-        height={h}
-        fill={\`url(#TealBlue)\`}
+        x={barWidth}
+        y={barHeight}
+        width={barWidth}
+        height={barHeight}
+        fill="url(#TealBlue)"
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
       />
       <Bar
-        x={w * 2}
-        y={h}
-        width={w}
-        height={h}
-        fill={\`url(#PurpleOrange)\`}
+        x={barWidth * 2}
+        y={barHeight}
+        width={barWidth}
+        height={barHeight}
+        fill="url(#PurpleOrange)"
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
       />
       <Bar
-        x={w * 3}
-        y={h}
-        width={w}
-        height={h}
-        fill={\`url(#Radial)\`}
+        x={barWidth * 3}
+        y={barHeight}
+        width={barWidth}
+        height={barHeight}
+        fill="url(#Radial)"
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
       />
     </svg>
-  );
-};
-`}
-    </Show>
   );
 };

--- a/packages/vx-demo/src/components/tiles/Polygons.tsx
+++ b/packages/vx-demo/src/components/tiles/Polygons.tsx
@@ -1,57 +1,49 @@
 import React from 'react';
-import Show from '../components/Show.tsx';
-import Polygons from '../components/tiles/polygons';
-
-export default () => (
-  <Show component={Polygons} title="Polygons">
-    {`import React from 'react';
 import { Polygon } from '@vx/shape';
 import { Group } from '@vx/group';
 import { scaleBand } from '@vx/scale';
 import { GradientPinkRed } from '@vx/gradient';
+import { ShowProvidedProps } from '../../types';
 
 const polygons = [
   {
     sides: 3,
     fill: 'rgb(174, 238, 248)',
-    rotate: 90
+    rotate: 90,
   },
   {
     sides: 4,
     fill: 'rgb(229, 253, 61)',
-    rotate: 45
+    rotate: 45,
   },
   {
     sides: 6,
     fill: 'rgb(229, 130, 255)',
-    rotate: 0
+    rotate: 0,
   },
   {
     sides: 8,
     fill: 'url(#polygon-pink)',
-    rotate: 0
-  }
+    rotate: 0,
+  },
 ];
 
-const yScale = scaleBand({
+const yScale = scaleBand<number>({
   domain: polygons.map((p, i) => i),
-  padding: 0.5
+  padding: 0.5,
 });
 
-export default ({ width, height }) => {
+export default ({ width, height }: ShowProvidedProps) => {
   yScale.rangeRound([0, height]);
   return (
     <svg width={width} height={height}>
       <rect width={width} height={height} fill="#7f82e3" rx={14} />
       <GradientPinkRed id="polygon-pink" />
       {polygons.map((polygon, i) => (
-        <Group key={\`polygon-\${i}\`} top={yScale(i)} left={width / 2}>
+        <Group key={`polygon-${i}`} top={yScale(i)} left={width / 2}>
           <Polygon sides={polygon.sides} size={25} fill={polygon.fill} rotate={polygon.rotate} />
         </Group>
       ))}
     </svg>
   );
 };
-`}
-  </Show>
-);

--- a/packages/vx-demo/src/pages/Gradients.tsx
+++ b/packages/vx-demo/src/pages/Gradients.tsx
@@ -1,4 +1,21 @@
 import React from 'react';
+import Show from '../components/Show';
+import Gradients from '../components/tiles/Gradients';
+
+export default () => {
+  return (
+    <Show
+      component={Gradients}
+      title="Gradients"
+      shadow
+      margin={{
+        bottom: 0,
+        top: 0,
+        left: 0,
+        right: 0,
+      }}
+    >
+      {`import React from 'react';
 import { Bar } from '@vx/shape';
 import {
   GradientDarkgreenGreen,
@@ -8,6 +25,7 @@ import {
   GradientPinkRed,
   GradientPurpleOrange,
   GradientPurpleRed,
+  GradientPurpleTeal,
   GradientSteelPurple,
   GradientTealBlue,
   RadialGradient,
@@ -23,10 +41,8 @@ export default ({
     bottom: 80,
   },
 }) => {
-  let w = width / 4;
-  let h = (height - margin.bottom) / 2;
-  w = w < 0 ? 0 : w;
-  h = h < 0 ? 0 : h;
+  const w = width / 4;
+  const h = (height - margin.bottom) / 2;
   return (
     <svg width={width} height={height}>
       <GradientDarkgreenGreen id="DarkgreenGreen" />
@@ -36,7 +52,7 @@ export default ({
       <GradientPinkRed id="PinkRed" vertical={false} />
       <GradientPurpleOrange id="PurpleOrange" vertical={false} />
       <GradientPurpleRed id="PurpleRed" vertical={false} />
-      <RadialGradient from="#55bdd5" to="#4f3681" id="Radial" r="80%" />
+      <RadialGradient from="#55bdd5" to="#4f3681" id="Radial" r={'80%'} />
       <GradientSteelPurple id="SteelPurple" vertical={false} />
       <GradientTealBlue id="TealBlue" vertical={false} />
       <Bar
@@ -44,7 +60,7 @@ export default ({
         y={0}
         width={w}
         height={h}
-        fill="url(#LightgreenGreen)"
+        fill={\`url(#LightgreenGreen)\`}
         stroke="#ffffff"
         strokeWidth={8}
         rx={14}
@@ -54,7 +70,7 @@ export default ({
         y={0}
         width={w}
         height={h}
-        fill="url(#OrangeRed)"
+        fill={\`url(#OrangeRed)\`}
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
@@ -64,7 +80,7 @@ export default ({
         y={0}
         width={w}
         height={h}
-        fill="url(#PinkBlue)"
+        fill={\`url(#PinkBlue)\`}
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
@@ -74,7 +90,7 @@ export default ({
         y={0}
         width={w}
         height={h}
-        fill="url(#DarkgreenGreen)"
+        fill={\`url(#DarkgreenGreen)\`}
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
@@ -84,7 +100,7 @@ export default ({
         y={h}
         width={w}
         height={h}
-        fill="url(#PinkRed)"
+        fill={\`url(#PinkRed)\`}
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
@@ -94,7 +110,7 @@ export default ({
         y={h}
         width={w}
         height={h}
-        fill="url(#TealBlue)"
+        fill={\`url(#TealBlue)\`}
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
@@ -104,7 +120,7 @@ export default ({
         y={h}
         width={w}
         height={h}
-        fill="url(#PurpleOrange)"
+        fill={\`url(#PurpleOrange)\`}
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
@@ -114,11 +130,15 @@ export default ({
         y={h}
         width={w}
         height={h}
-        fill="url(#Radial)"
+        fill={\`url(#Radial)\`}
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
       />
     </svg>
+  );
+};
+`}
+    </Show>
   );
 };

--- a/packages/vx-demo/src/pages/Gradients.tsx
+++ b/packages/vx-demo/src/pages/Gradients.tsx
@@ -25,11 +25,11 @@ import {
   GradientPinkRed,
   GradientPurpleOrange,
   GradientPurpleRed,
-  GradientPurpleTeal,
   GradientSteelPurple,
   GradientTealBlue,
   RadialGradient,
 } from '@vx/gradient';
+import { ShowProvidedProps } from '../../types';
 
 export default ({
   width,
@@ -40,9 +40,10 @@ export default ({
     right: 0,
     bottom: 80,
   },
-}) => {
-  const w = width / 4;
-  const h = (height - margin.bottom) / 2;
+}: ShowProvidedProps) => {
+  const barWidth = Math.max(width / 4, 0);
+  const barHeight = Math.max((height - margin.bottom) / 2, 0);
+
   return (
     <svg width={width} height={height}>
       <GradientDarkgreenGreen id="DarkgreenGreen" />
@@ -52,85 +53,85 @@ export default ({
       <GradientPinkRed id="PinkRed" vertical={false} />
       <GradientPurpleOrange id="PurpleOrange" vertical={false} />
       <GradientPurpleRed id="PurpleRed" vertical={false} />
-      <RadialGradient from="#55bdd5" to="#4f3681" id="Radial" r={'80%'} />
+      <RadialGradient from="#55bdd5" to="#4f3681" id="Radial" r="80%" />
       <GradientSteelPurple id="SteelPurple" vertical={false} />
       <GradientTealBlue id="TealBlue" vertical={false} />
       <Bar
         x={0}
         y={0}
-        width={w}
-        height={h}
-        fill={\`url(#LightgreenGreen)\`}
+        width={barWidth}
+        height={barHeight}
+        fill="url(#LightgreenGreen)"
         stroke="#ffffff"
         strokeWidth={8}
         rx={14}
       />
       <Bar
-        x={w}
+        x={barWidth}
         y={0}
-        width={w}
-        height={h}
-        fill={\`url(#OrangeRed)\`}
+        width={barWidth}
+        height={barHeight}
+        fill="url(#OrangeRed)"
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
       />
       <Bar
-        x={w * 2}
+        x={barWidth * 2}
         y={0}
-        width={w}
-        height={h}
-        fill={\`url(#PinkBlue)\`}
+        width={barWidth}
+        height={barHeight}
+        fill="url(#PinkBlue)"
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
       />
       <Bar
-        x={w * 3}
+        x={barWidth * 3}
         y={0}
-        width={w}
-        height={h}
-        fill={\`url(#DarkgreenGreen)\`}
+        width={barWidth}
+        height={barHeight}
+        fill="url(#DarkgreenGreen)"
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
       />
       <Bar
         x={0}
-        y={h}
-        width={w}
-        height={h}
-        fill={\`url(#PinkRed)\`}
+        y={barHeight}
+        width={barWidth}
+        height={barHeight}
+        fill="url(#PinkRed)"
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
       />
       <Bar
-        x={w}
-        y={h}
-        width={w}
-        height={h}
-        fill={\`url(#TealBlue)\`}
+        x={barWidth}
+        y={barHeight}
+        width={barWidth}
+        height={barHeight}
+        fill="url(#TealBlue)"
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
       />
       <Bar
-        x={w * 2}
-        y={h}
-        width={w}
-        height={h}
-        fill={\`url(#PurpleOrange)\`}
+        x={barWidth * 2}
+        y={barHeight}
+        width={barWidth}
+        height={barHeight}
+        fill="url(#PurpleOrange)"
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}
       />
       <Bar
-        x={w * 3}
-        y={h}
-        width={w}
-        height={h}
-        fill={\`url(#Radial)\`}
+        x={barWidth * 3}
+        y={barHeight}
+        width={barWidth}
+        height={barHeight}
+        fill="url(#Radial)"
         rx={14}
         stroke="#ffffff"
         strokeWidth={8}

--- a/packages/vx-demo/src/pages/Polygons.tsx
+++ b/packages/vx-demo/src/pages/Polygons.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
+import Show from '../components/Show';
+import Polygons from '../components/tiles/Polygons';
+
+export default () => (
+  <Show component={Polygons} title="Polygons">
+    {`import React from 'react';
 import { Polygon } from '@vx/shape';
 import { Group } from '@vx/group';
 import { scaleBand } from '@vx/scale';
 import { GradientPinkRed } from '@vx/gradient';
+import { ShowProvidedProps } from '../../types';
 
 const polygons = [
   {
@@ -27,22 +34,25 @@ const polygons = [
   },
 ];
 
-const yScale = scaleBand({
+const yScale = scaleBand<number>({
   domain: polygons.map((p, i) => i),
   padding: 0.5,
 });
 
-export default ({ width, height }) => {
+export default ({ width, height }: ShowProvidedProps) => {
   yScale.rangeRound([0, height]);
   return (
     <svg width={width} height={height}>
       <rect width={width} height={height} fill="#7f82e3" rx={14} />
       <GradientPinkRed id="polygon-pink" />
       {polygons.map((polygon, i) => (
-        <Group key={`polygon-${i}`} top={yScale(i)} left={width / 2}>
+        <Group key={\`polygon-\${i}\`} top={yScale(i)} left={width / 2}>
           <Polygon sides={polygon.sides} size={25} fill={polygon.fill} rotate={polygon.rotate} />
         </Group>
       ))}
     </svg>
   );
 };
+`}
+  </Show>
+);

--- a/packages/vx-scale/src/scales/band.ts
+++ b/packages/vx-scale/src/scales/band.ts
@@ -1,6 +1,6 @@
 import { scaleBand } from 'd3-scale';
 
-type StringLike = string | { valueOf(): string };
+type StringLike = string | { toString(): string };
 type Numeric = number | { valueOf(): number };
 
 export type BandConfig<Datum extends StringLike> = {


### PR DESCRIPTION
#### :memo: Documentation

This PR is part of #579 to re-write the `vx-demo` site in TypeScript. It re-writes the `gradients` + `polygons` examples in TypeScript and makes a fix to `scaleBand`.

 **Before/After**
<img src="https://user-images.githubusercontent.com/4496521/71933466-1146f480-3157-11ea-97b2-073a989e3c05.png" width="800" />
<img src="https://user-images.githubusercontent.com/4496521/71933501-258af180-3157-11ea-95b9-c3cdf4817772.png" width="800" />

#### :bug: Bug Fix

Fixes `@vx/scale`s `scaleBand` `StringLike` generic to accept anything coercible to strings. The previous syntax was wrong/used coercible number syntax.

#### Testing
- [x] functional
- [x] CI

cc @hshoff @kristw @schillerk 