### PR TITLE
typescript(vx-demo): rewrite StatsPlot example in TypeScript

### DIFF
--- a/packages/vx-demo/src/components/gallery.js
+++ b/packages/vx-demo/src/components/gallery.js
@@ -26,7 +26,7 @@ import Trees from './tiles/tree';
 import Cluster from './tiles/dendrogram';
 import Voronoi from './tiles/voronoi';
 import Legends from './tiles/legends';
-import StatsPlot from './tiles/statsplot';
+import StatsPlot from './tiles/Statsplot.tsx';
 import GeoMercator from './tiles/geo-mercator';
 import GeoCustom from './tiles/geo-custom';
 import Network from './tiles/Network.tsx';

--- a/packages/vx-demo/src/components/tiles/Statsplot.tsx
+++ b/packages/vx-demo/src/components/tiles/Statsplot.tsx
@@ -29,7 +29,7 @@ interface TooltipData {
   thirdQuartile?: number;
 }
 
-export default withTooltip<ShowProvidedProps & WithTooltipProvidedProps<TooltipData>, TooltipData>(
+export default withTooltip<ShowProvidedProps, TooltipData>(
   ({
     width,
     height,
@@ -53,7 +53,10 @@ export default withTooltip<ShowProvidedProps & WithTooltipProvidedProps<TooltipD
       padding: 0.4,
     });
 
-    const values = data.reduce((r, { boxPlot: e }) => r.push(e.min, e.max) && r, []);
+    const values = data.reduce((allValues, { boxPlot }) => {
+      allValues.push(boxPlot.min, boxPlot.max);
+      return allValues;
+    }, [] as number[]);
     const minYValue = Math.min(...values);
     const maxYValue = Math.max(...values);
 
@@ -76,7 +79,7 @@ export default withTooltip<ShowProvidedProps & WithTooltipProvidedProps<TooltipD
             width={3}
             stroke="#ced4da"
             strokeWidth={1}
-            fill="rgba(0,0,0,0.3)"
+            // fill="rgba(0,0,0,0.3)"
             orientation={['horizontal']}
           />
           <Group top={40}>
@@ -85,7 +88,7 @@ export default withTooltip<ShowProvidedProps & WithTooltipProvidedProps<TooltipD
                 <ViolinPlot
                   data={d.binData}
                   stroke="#dee2e6"
-                  left={xScale(x(d))}
+                  left={xScale(x(d))!}
                   width={constrainedWidth}
                   valueScale={yScale}
                   fill="url(#hViolinLines)"
@@ -93,7 +96,7 @@ export default withTooltip<ShowProvidedProps & WithTooltipProvidedProps<TooltipD
                 <BoxPlot
                   min={min(d)}
                   max={max(d)}
-                  left={xScale(x(d)) + 0.3 * constrainedWidth}
+                  left={xScale(x(d))! + 0.3 * constrainedWidth}
                   firstQuartile={firstQuartile(d)}
                   thirdQuartile={thirdQuartile(d)}
                   median={median(d)}
@@ -108,7 +111,7 @@ export default withTooltip<ShowProvidedProps & WithTooltipProvidedProps<TooltipD
                     onMouseOver: () => {
                       showTooltip({
                         tooltipTop: yScale(min(d)) + 40,
-                        tooltipLeft: xScale(x(d)) + constrainedWidth + 5,
+                        tooltipLeft: xScale(x(d))! + constrainedWidth + 5,
                         tooltipData: {
                           min: min(d),
                           name: x(d),
@@ -123,7 +126,7 @@ export default withTooltip<ShowProvidedProps & WithTooltipProvidedProps<TooltipD
                     onMouseOver: () => {
                       showTooltip({
                         tooltipTop: yScale(max(d)) + 40,
-                        tooltipLeft: xScale(x(d)) + constrainedWidth + 5,
+                        tooltipLeft: xScale(x(d))! + constrainedWidth + 5,
                         tooltipData: {
                           max: max(d),
                           name: x(d),
@@ -138,7 +141,7 @@ export default withTooltip<ShowProvidedProps & WithTooltipProvidedProps<TooltipD
                     onMouseOver: () => {
                       showTooltip({
                         tooltipTop: yScale(median(d)) + 40,
-                        tooltipLeft: xScale(x(d)) + constrainedWidth + 5,
+                        tooltipLeft: xScale(x(d))! + constrainedWidth + 5,
                         tooltipData: {
                           ...d.boxPlot,
                           name: x(d),
@@ -156,7 +159,7 @@ export default withTooltip<ShowProvidedProps & WithTooltipProvidedProps<TooltipD
                     onMouseOver: () => {
                       showTooltip({
                         tooltipTop: yScale(median(d)) + 40,
-                        tooltipLeft: xScale(x(d)) + constrainedWidth + 5,
+                        tooltipLeft: xScale(x(d))! + constrainedWidth + 5,
                         tooltipData: {
                           median: median(d),
                           name: x(d),
@@ -172,6 +175,7 @@ export default withTooltip<ShowProvidedProps & WithTooltipProvidedProps<TooltipD
             ))}
           </Group>
         </svg>
+
         {tooltipOpen && tooltipData && (
           <Tooltip
             top={tooltipTop}

--- a/packages/vx-demo/src/components/tiles/Statsplot.tsx
+++ b/packages/vx-demo/src/components/tiles/Statsplot.tsx
@@ -1,30 +1,35 @@
 import React from 'react';
-import Show from '../components/Show.tsx';
-import StatsPlot from '../components/tiles/statsplot';
-
-export default () => (
-  <Show events margin={{ top: 80 }} component={StatsPlot} title="BoxPlot With ViolinPlot">
-    {`import React from 'react';
 import { Group } from '@vx/group';
 import { ViolinPlot, BoxPlot } from '@vx/stats';
 import { LinearGradient } from '@vx/gradient';
 import { scaleBand, scaleLinear } from '@vx/scale';
-import { genStats } from '@vx/mock-data';
+import genStats, { Stats } from '@vx/mock-data/lib/generators/genStats';
 import { withTooltip, Tooltip } from '@vx/tooltip';
+import { WithTooltipProvidedProps } from '@vx/tooltip/lib/enhancers/withTooltip';
 import { PatternLines } from '@vx/pattern';
+import { ShowProvidedProps } from '../../types';
 
-const data = genStats(5);
+const data: Stats[] = genStats(5);
 
 // accessors
-const x = d => d.boxPlot.x;
-const min = d => d.boxPlot.min;
-const max = d => d.boxPlot.max;
-const median = d => d.boxPlot.median;
-const firstQuartile = d => d.boxPlot.firstQuartile;
-const thirdQuartile = d => d.boxPlot.thirdQuartile;
-const outliers = d => d.boxPlot.outliers;
+const x = (d: Stats) => d.boxPlot.x;
+const min = (d: Stats) => d.boxPlot.min;
+const max = (d: Stats) => d.boxPlot.max;
+const median = (d: Stats) => d.boxPlot.median;
+const firstQuartile = (d: Stats) => d.boxPlot.firstQuartile;
+const thirdQuartile = (d: Stats) => d.boxPlot.thirdQuartile;
+const outliers = (d: Stats) => d.boxPlot.outliers;
 
-export default withTooltip(
+interface TooltipData {
+  name?: string;
+  min?: number;
+  median?: number;
+  max?: number;
+  firstQuartile?: number;
+  thirdQuartile?: number;
+}
+
+export default withTooltip<ShowProvidedProps & WithTooltipProvidedProps<TooltipData>, TooltipData>(
   ({
     width,
     height,
@@ -33,30 +38,28 @@ export default withTooltip(
     tooltipTop,
     tooltipData,
     showTooltip,
-    hideTooltip
-  }) => {
+    hideTooltip,
+  }: ShowProvidedProps & WithTooltipProvidedProps<TooltipData>) => {
+    if (width < 10) return null;
+
     // bounds
     const xMax = width;
     const yMax = height - 120;
 
     // scales
-    const xScale = scaleBand({
+    const xScale = scaleBand<string>({
       rangeRound: [0, xMax],
       domain: data.map(x),
-      padding: 0.4
+      padding: 0.4,
     });
 
     const values = data.reduce((r, { boxPlot: e }) => r.push(e.min, e.max) && r, []);
     const minYValue = Math.min(...values);
     const maxYValue = Math.max(...values);
-    const yDomain = [
-      minYValue - 0.1 * Math.abs(minYValue),
-      maxYValue + 0.1 * Math.abs(minYValue)
-    ];
 
-    const yScale = scaleLinear({
+    const yScale = scaleLinear<number>({
       rangeRound: [yMax, 0],
-      domain: [minYValue, maxYValue]
+      domain: [minYValue, maxYValue],
     });
 
     const boxWidth = xScale.bandwidth();
@@ -66,7 +69,7 @@ export default withTooltip(
       <div style={{ position: 'relative' }}>
         <svg width={width} height={height}>
           <LinearGradient id="statsplot" to="#8b6ce7" from="#87f2d4" />
-          <rect x={0} y={0} width={width} height={height} fill={\`url(#statsplot)\`} rx={14} />
+          <rect x={0} y={0} width={width} height={height} fill="url(#statsplot)" rx={14} />
           <PatternLines
             id="hViolinLines"
             height={3}
@@ -77,7 +80,7 @@ export default withTooltip(
             orientation={['horizontal']}
           />
           <Group top={40}>
-            {data.map((d, i) => (
+            {data.map((d: Stats, i) => (
               <g key={i}>
                 <ViolinPlot
                   data={d.binData}
@@ -88,7 +91,6 @@ export default withTooltip(
                   fill="url(#hViolinLines)"
                 />
                 <BoxPlot
-                  data={d.binData}
                   min={min(d)}
                   max={max(d)}
                   left={xScale(x(d)) + 0.3 * constrainedWidth}
@@ -103,74 +105,74 @@ export default withTooltip(
                   valueScale={yScale}
                   outliers={outliers(d)}
                   minProps={{
-                    onMouseOver: event => {
+                    onMouseOver: () => {
                       showTooltip({
                         tooltipTop: yScale(min(d)) + 40,
                         tooltipLeft: xScale(x(d)) + constrainedWidth + 5,
                         tooltipData: {
                           min: min(d),
-                          name: x(d)
-                        }
+                          name: x(d),
+                        },
                       });
                     },
-                    onMouseLeave: event => {
+                    onMouseLeave: () => {
                       hideTooltip();
-                    }
+                    },
                   }}
                   maxProps={{
-                    onMouseOver: event => {
+                    onMouseOver: () => {
                       showTooltip({
                         tooltipTop: yScale(max(d)) + 40,
                         tooltipLeft: xScale(x(d)) + constrainedWidth + 5,
                         tooltipData: {
                           max: max(d),
-                          name: x(d)
-                        }
+                          name: x(d),
+                        },
                       });
                     },
-                    onMouseLeave: event => {
+                    onMouseLeave: () => {
                       hideTooltip();
-                    }
+                    },
                   }}
                   boxProps={{
-                    onMouseOver: event => {
+                    onMouseOver: () => {
                       showTooltip({
                         tooltipTop: yScale(median(d)) + 40,
                         tooltipLeft: xScale(x(d)) + constrainedWidth + 5,
                         tooltipData: {
                           ...d.boxPlot,
-                          name: x(d)
-                        }
+                          name: x(d),
+                        },
                       });
                     },
-                    onMouseLeave: event => {
+                    onMouseLeave: () => {
                       hideTooltip();
-                    }
+                    },
                   }}
                   medianProps={{
                     style: {
-                      stroke: 'white'
+                      stroke: 'white',
                     },
-                    onMouseOver: event => {
+                    onMouseOver: () => {
                       showTooltip({
                         tooltipTop: yScale(median(d)) + 40,
                         tooltipLeft: xScale(x(d)) + constrainedWidth + 5,
                         tooltipData: {
                           median: median(d),
-                          name: x(d)
-                        }
+                          name: x(d),
+                        },
                       });
                     },
-                    onMouseLeave: event => {
+                    onMouseLeave: () => {
                       hideTooltip();
-                    }
+                    },
                   }}
                 />
               </g>
             ))}
           </Group>
         </svg>
-        {tooltipOpen && (
+        {tooltipOpen && tooltipData && (
           <Tooltip
             top={tooltipTop}
             left={tooltipLeft}
@@ -190,8 +192,5 @@ export default withTooltip(
         )}
       </div>
     );
-  }
-);
-`}
-  </Show>
+  },
 );

--- a/packages/vx-demo/src/pages/Statsplot.tsx
+++ b/packages/vx-demo/src/pages/Statsplot.tsx
@@ -14,22 +14,33 @@ import { Group } from '@vx/group';
 import { ViolinPlot, BoxPlot } from '@vx/stats';
 import { LinearGradient } from '@vx/gradient';
 import { scaleBand, scaleLinear } from '@vx/scale';
-import { genStats } from '@vx/mock-data';
+import genStats, { Stats } from '@vx/mock-data/lib/generators/genStats';
 import { withTooltip, Tooltip } from '@vx/tooltip';
+import { WithTooltipProvidedProps } from '@vx/tooltip/lib/enhancers/withTooltip';
 import { PatternLines } from '@vx/pattern';
+import { ShowProvidedProps } from '../../types';
 
-const data = genStats(5);
+const data: Stats[] = genStats(5);
 
 // accessors
-const x = d => d.boxPlot.x;
-const min = d => d.boxPlot.min;
-const max = d => d.boxPlot.max;
-const median = d => d.boxPlot.median;
-const firstQuartile = d => d.boxPlot.firstQuartile;
-const thirdQuartile = d => d.boxPlot.thirdQuartile;
-const outliers = d => d.boxPlot.outliers;
+const x = (d: Stats) => d.boxPlot.x;
+const min = (d: Stats) => d.boxPlot.min;
+const max = (d: Stats) => d.boxPlot.max;
+const median = (d: Stats) => d.boxPlot.median;
+const firstQuartile = (d: Stats) => d.boxPlot.firstQuartile;
+const thirdQuartile = (d: Stats) => d.boxPlot.thirdQuartile;
+const outliers = (d: Stats) => d.boxPlot.outliers;
 
-export default withTooltip(
+interface TooltipData {
+  name?: string;
+  min?: number;
+  median?: number;
+  max?: number;
+  firstQuartile?: number;
+  thirdQuartile?: number;
+}
+
+export default withTooltip<ShowProvidedProps, TooltipData>(
   ({
     width,
     height,
@@ -38,30 +49,31 @@ export default withTooltip(
     tooltipTop,
     tooltipData,
     showTooltip,
-    hideTooltip
-  }) => {
+    hideTooltip,
+  }: ShowProvidedProps & WithTooltipProvidedProps<TooltipData>) => {
+    if (width < 10) return null;
+
     // bounds
     const xMax = width;
     const yMax = height - 120;
 
     // scales
-    const xScale = scaleBand({
+    const xScale = scaleBand<string>({
       rangeRound: [0, xMax],
       domain: data.map(x),
-      padding: 0.4
+      padding: 0.4,
     });
 
-    const values = data.reduce((r, { boxPlot: e }) => r.push(e.min, e.max) && r, []);
+    const values = data.reduce((allValues, { boxPlot }) => {
+      allValues.push(boxPlot.min, boxPlot.max);
+      return allValues;
+    }, [] as number[]);
     const minYValue = Math.min(...values);
     const maxYValue = Math.max(...values);
-    const yDomain = [
-      minYValue - 0.1 * Math.abs(minYValue),
-      maxYValue + 0.1 * Math.abs(minYValue)
-    ];
 
-    const yScale = scaleLinear({
+    const yScale = scaleLinear<number>({
       rangeRound: [yMax, 0],
-      domain: [minYValue, maxYValue]
+      domain: [minYValue, maxYValue],
     });
 
     const boxWidth = xScale.bandwidth();
@@ -71,32 +83,31 @@ export default withTooltip(
       <div style={{ position: 'relative' }}>
         <svg width={width} height={height}>
           <LinearGradient id="statsplot" to="#8b6ce7" from="#87f2d4" />
-          <rect x={0} y={0} width={width} height={height} fill={\`url(#statsplot)\`} rx={14} />
+          <rect x={0} y={0} width={width} height={height} fill="url(#statsplot)" rx={14} />
           <PatternLines
             id="hViolinLines"
             height={3}
             width={3}
             stroke="#ced4da"
             strokeWidth={1}
-            fill="rgba(0,0,0,0.3)"
+            // fill="rgba(0,0,0,0.3)"
             orientation={['horizontal']}
           />
           <Group top={40}>
-            {data.map((d, i) => (
+            {data.map((d: Stats, i) => (
               <g key={i}>
                 <ViolinPlot
                   data={d.binData}
                   stroke="#dee2e6"
-                  left={xScale(x(d))}
+                  left={xScale(x(d))!}
                   width={constrainedWidth}
                   valueScale={yScale}
                   fill="url(#hViolinLines)"
                 />
                 <BoxPlot
-                  data={d.binData}
                   min={min(d)}
                   max={max(d)}
-                  left={xScale(x(d)) + 0.3 * constrainedWidth}
+                  left={xScale(x(d))! + 0.3 * constrainedWidth}
                   firstQuartile={firstQuartile(d)}
                   thirdQuartile={thirdQuartile(d)}
                   median={median(d)}
@@ -108,74 +119,75 @@ export default withTooltip(
                   valueScale={yScale}
                   outliers={outliers(d)}
                   minProps={{
-                    onMouseOver: event => {
+                    onMouseOver: () => {
                       showTooltip({
                         tooltipTop: yScale(min(d)) + 40,
-                        tooltipLeft: xScale(x(d)) + constrainedWidth + 5,
+                        tooltipLeft: xScale(x(d))! + constrainedWidth + 5,
                         tooltipData: {
                           min: min(d),
-                          name: x(d)
-                        }
+                          name: x(d),
+                        },
                       });
                     },
-                    onMouseLeave: event => {
+                    onMouseLeave: () => {
                       hideTooltip();
-                    }
+                    },
                   }}
                   maxProps={{
-                    onMouseOver: event => {
+                    onMouseOver: () => {
                       showTooltip({
                         tooltipTop: yScale(max(d)) + 40,
-                        tooltipLeft: xScale(x(d)) + constrainedWidth + 5,
+                        tooltipLeft: xScale(x(d))! + constrainedWidth + 5,
                         tooltipData: {
                           max: max(d),
-                          name: x(d)
-                        }
+                          name: x(d),
+                        },
                       });
                     },
-                    onMouseLeave: event => {
+                    onMouseLeave: () => {
                       hideTooltip();
-                    }
+                    },
                   }}
                   boxProps={{
-                    onMouseOver: event => {
+                    onMouseOver: () => {
                       showTooltip({
                         tooltipTop: yScale(median(d)) + 40,
-                        tooltipLeft: xScale(x(d)) + constrainedWidth + 5,
+                        tooltipLeft: xScale(x(d))! + constrainedWidth + 5,
                         tooltipData: {
                           ...d.boxPlot,
-                          name: x(d)
-                        }
+                          name: x(d),
+                        },
                       });
                     },
-                    onMouseLeave: event => {
+                    onMouseLeave: () => {
                       hideTooltip();
-                    }
+                    },
                   }}
                   medianProps={{
                     style: {
-                      stroke: 'white'
+                      stroke: 'white',
                     },
-                    onMouseOver: event => {
+                    onMouseOver: () => {
                       showTooltip({
                         tooltipTop: yScale(median(d)) + 40,
-                        tooltipLeft: xScale(x(d)) + constrainedWidth + 5,
+                        tooltipLeft: xScale(x(d))! + constrainedWidth + 5,
                         tooltipData: {
                           median: median(d),
-                          name: x(d)
-                        }
+                          name: x(d),
+                        },
                       });
                     },
-                    onMouseLeave: event => {
+                    onMouseLeave: () => {
                       hideTooltip();
-                    }
+                    },
                   }}
                 />
               </g>
             ))}
           </Group>
         </svg>
-        {tooltipOpen && (
+
+        {tooltipOpen && tooltipData && (
           <Tooltip
             top={tooltipTop}
             left={tooltipLeft}
@@ -195,7 +207,7 @@ export default withTooltip(
         )}
       </div>
     );
-  }
+  },
 );
 `}
   </Show>

--- a/packages/vx-demo/src/pages/Statsplot.tsx
+++ b/packages/vx-demo/src/pages/Statsplot.tsx
@@ -1,4 +1,15 @@
 import React from 'react';
+import Show from '../components/Show';
+import StatsPlot from '../components/tiles/Statsplot';
+
+export default () => (
+  <Show
+    events
+    margin={{ top: 80, right: 0, bottom: 0, left: 0 }}
+    component={StatsPlot}
+    title="BoxPlot With ViolinPlot"
+  >
+    {`import React from 'react';
 import { Group } from '@vx/group';
 import { ViolinPlot, BoxPlot } from '@vx/stats';
 import { LinearGradient } from '@vx/gradient';
@@ -27,10 +38,8 @@ export default withTooltip(
     tooltipTop,
     tooltipData,
     showTooltip,
-    hideTooltip,
+    hideTooltip
   }) => {
-    if (width < 10) return null;
-
     // bounds
     const xMax = width;
     const yMax = height - 120;
@@ -39,16 +48,20 @@ export default withTooltip(
     const xScale = scaleBand({
       rangeRound: [0, xMax],
       domain: data.map(x),
-      padding: 0.4,
+      padding: 0.4
     });
 
     const values = data.reduce((r, { boxPlot: e }) => r.push(e.min, e.max) && r, []);
     const minYValue = Math.min(...values);
     const maxYValue = Math.max(...values);
+    const yDomain = [
+      minYValue - 0.1 * Math.abs(minYValue),
+      maxYValue + 0.1 * Math.abs(minYValue)
+    ];
 
     const yScale = scaleLinear({
       rangeRound: [yMax, 0],
-      domain: [minYValue, maxYValue],
+      domain: [minYValue, maxYValue]
     });
 
     const boxWidth = xScale.bandwidth();
@@ -58,7 +71,7 @@ export default withTooltip(
       <div style={{ position: 'relative' }}>
         <svg width={width} height={height}>
           <LinearGradient id="statsplot" to="#8b6ce7" from="#87f2d4" />
-          <rect x={0} y={0} width={width} height={height} fill="url(#statsplot)" rx={14} />
+          <rect x={0} y={0} width={width} height={height} fill={\`url(#statsplot)\`} rx={14} />
           <PatternLines
             id="hViolinLines"
             height={3}
@@ -95,67 +108,67 @@ export default withTooltip(
                   valueScale={yScale}
                   outliers={outliers(d)}
                   minProps={{
-                    onMouseOver: () => {
+                    onMouseOver: event => {
                       showTooltip({
                         tooltipTop: yScale(min(d)) + 40,
                         tooltipLeft: xScale(x(d)) + constrainedWidth + 5,
                         tooltipData: {
                           min: min(d),
-                          name: x(d),
-                        },
+                          name: x(d)
+                        }
                       });
                     },
-                    onMouseLeave: () => {
+                    onMouseLeave: event => {
                       hideTooltip();
-                    },
+                    }
                   }}
                   maxProps={{
-                    onMouseOver: () => {
+                    onMouseOver: event => {
                       showTooltip({
                         tooltipTop: yScale(max(d)) + 40,
                         tooltipLeft: xScale(x(d)) + constrainedWidth + 5,
                         tooltipData: {
                           max: max(d),
-                          name: x(d),
-                        },
+                          name: x(d)
+                        }
                       });
                     },
-                    onMouseLeave: () => {
+                    onMouseLeave: event => {
                       hideTooltip();
-                    },
+                    }
                   }}
                   boxProps={{
-                    onMouseOver: () => {
+                    onMouseOver: event => {
                       showTooltip({
                         tooltipTop: yScale(median(d)) + 40,
                         tooltipLeft: xScale(x(d)) + constrainedWidth + 5,
                         tooltipData: {
                           ...d.boxPlot,
-                          name: x(d),
-                        },
+                          name: x(d)
+                        }
                       });
                     },
-                    onMouseLeave: () => {
+                    onMouseLeave: event => {
                       hideTooltip();
-                    },
+                    }
                   }}
                   medianProps={{
                     style: {
-                      stroke: 'white',
+                      stroke: 'white'
                     },
-                    onMouseOver: () => {
+                    onMouseOver: event => {
                       showTooltip({
                         tooltipTop: yScale(median(d)) + 40,
                         tooltipLeft: xScale(x(d)) + constrainedWidth + 5,
                         tooltipData: {
                           median: median(d),
-                          name: x(d),
-                        },
+                          name: x(d)
+                        }
                       });
                     },
-                    onMouseLeave: () => {
+                    onMouseLeave: event => {
                       hideTooltip();
-                    },
+                    }
                   }}
                 />
               </g>
@@ -182,5 +195,8 @@ export default withTooltip(
         )}
       </div>
     );
-  },
+  }
+);
+`}
+  </Show>
 );

--- a/packages/vx-responsive/src/enhancers/withParentSize.tsx
+++ b/packages/vx-responsive/src/enhancers/withParentSize.tsx
@@ -13,10 +13,13 @@ type WithParentSizeState = {
 
 export type WithParentSizeProvidedProps = WithParentSizeState;
 
-export default function withParentSize<
-  Props extends WithParentSizeProps & WithParentSizeState = {}
->(BaseComponent: React.ComponentType<Props>) {
-  return class WrappedComponent extends React.Component<Props, WithParentSizeState> {
+export default function withParentSize<BaseComponentProps extends WithParentSizeProps = {}>(
+  BaseComponent: React.ComponentType<BaseComponentProps & WithParentSizeProvidedProps>,
+) {
+  return class WrappedComponent extends React.Component<
+    BaseComponentProps & WithParentSizeProvidedProps,
+    WithParentSizeState
+  > {
     static defaultProps = {
       debounceTime: 300,
     };
@@ -25,7 +28,7 @@ export default function withParentSize<
     container: HTMLDivElement | null = null;
     debouncedResize: ({ width, height }: { width: number; height: number }) => void;
 
-    constructor(props: Props) {
+    constructor(props: BaseComponentProps & WithParentSizeProvidedProps) {
       super(props);
       this.state = {
         parentWidth: undefined,

--- a/packages/vx-responsive/src/enhancers/withScreenSize.tsx
+++ b/packages/vx-responsive/src/enhancers/withScreenSize.tsx
@@ -12,17 +12,20 @@ type WithScreenSizeState = {
 
 export type WithScreenSizeProvidedProps = WithScreenSizeState;
 
-export default function withScreenSize<
-  Props extends WithScreenSizeProps & WithScreenSizeProvidedProps = {}
->(BaseComponent: React.ComponentType<Props>) {
-  return class WrappedComponent extends React.Component<Props, WithScreenSizeState> {
+export default function withScreenSize<BaseComponentProps extends WithScreenSizeProps = {}>(
+  BaseComponent: React.ComponentType<BaseComponentProps>,
+) {
+  return class WrappedComponent extends React.Component<
+    BaseComponentProps & WithScreenSizeProvidedProps,
+    WithScreenSizeState
+  > {
     static defaultProps = {
       windowResizeDebounceTime: 300,
     };
 
     handleResize: () => void;
 
-    constructor(props: Props) {
+    constructor(props: BaseComponentProps & WithScreenSizeProvidedProps) {
       super(props);
       this.state = {
         screenWidth: undefined,

--- a/packages/vx-scale/src/scales/band.ts
+++ b/packages/vx-scale/src/scales/band.ts
@@ -1,6 +1,6 @@
 import { scaleBand } from 'd3-scale';
 
-type StringLike = string | { valueOf(): string };
+type StringLike = string | { toString(): string };
 type Numeric = number | { valueOf(): number };
 
 export type BandConfig<Datum extends StringLike> = {

--- a/packages/vx-stats/src/types.ts
+++ b/packages/vx-stats/src/types.ts
@@ -47,7 +47,6 @@ export type ChildRenderProps = {
 export interface GenericScale<ScaleInput> {
   (input: ScaleInput): number;
   range(): number[] | [number, number];
-  range(range?: number[] | [number, number]): this;
 }
 
 export type SharedProps = {

--- a/packages/vx-tooltip/src/enhancers/withTooltip.tsx
+++ b/packages/vx-tooltip/src/enhancers/withTooltip.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export type WithTooltipProvidedProps<TooltipData> = {
+export type WithTooltipProvidedProps<TooltipData = {}> = {
   tooltipOpen: boolean;
   tooltipLeft?: number;
   tooltipTop?: number;
@@ -18,11 +18,8 @@ type ShowTooltipArgs<TooltipData> = Omit<WithTooltipState<TooltipData>, 'tooltip
 type UpdateTooltipArgs<TooltipData> = WithTooltipState<TooltipData>;
 type WithTooltipContainerProps = { style: React.CSSProperties };
 
-export default function withTooltip<
-  Props extends WithTooltipProvidedProps<TooltipData>,
-  TooltipData
->(
-  BaseComponent: React.ComponentType<Props>,
+export default function withTooltip<BaseComponentProps = {}, TooltipData = {}>(
+  BaseComponent: React.ComponentType<BaseComponentProps & WithTooltipProvidedProps<TooltipData>>,
   containerProps: WithTooltipContainerProps = {
     style: {
       position: 'relative',
@@ -31,25 +28,23 @@ export default function withTooltip<
     } as const,
   },
 ) {
-  return class WrappedComponent extends React.PureComponent<Props, WithTooltipState<TooltipData>> {
-    constructor(props: Props) {
-      super(props);
-      this.state = {
-        tooltipOpen: false,
-        tooltipLeft: undefined,
-        tooltipTop: undefined,
-        tooltipData: undefined,
-      };
-      this.updateTooltip = this.updateTooltip.bind(this);
-      this.showTooltip = this.showTooltip.bind(this);
-      this.hideTooltip = this.hideTooltip.bind(this);
-    }
-    updateTooltip({
+  return class WrappedComponent extends React.PureComponent<
+    BaseComponentProps,
+    WithTooltipState<TooltipData>
+  > {
+    state = {
+      tooltipOpen: false,
+      tooltipLeft: undefined,
+      tooltipTop: undefined,
+      tooltipData: undefined,
+    };
+
+    updateTooltip = ({
       tooltipOpen,
       tooltipLeft,
       tooltipTop,
       tooltipData,
-    }: UpdateTooltipArgs<TooltipData>) {
+    }: UpdateTooltipArgs<TooltipData>) => {
       this.setState(prevState => ({
         ...prevState,
         tooltipOpen,
@@ -57,23 +52,26 @@ export default function withTooltip<
         tooltipTop,
         tooltipData,
       }));
-    }
-    showTooltip({ tooltipLeft, tooltipTop, tooltipData }: ShowTooltipArgs<TooltipData>) {
+    };
+
+    showTooltip = ({ tooltipLeft, tooltipTop, tooltipData }: ShowTooltipArgs<TooltipData>) => {
       this.updateTooltip({
         tooltipOpen: true,
         tooltipLeft,
         tooltipTop,
         tooltipData,
       });
-    }
-    hideTooltip() {
+    };
+
+    hideTooltip = () => {
       this.updateTooltip({
         tooltipOpen: false,
         tooltipLeft: undefined,
         tooltipTop: undefined,
         tooltipData: undefined,
       });
-    }
+    };
+
     render() {
       return (
         <div {...containerProps}>

--- a/packages/vx-tooltip/src/enhancers/withTooltip.tsx
+++ b/packages/vx-tooltip/src/enhancers/withTooltip.tsx
@@ -1,23 +1,27 @@
 import React from 'react';
 
-export type WithTooltipProvidedProps = {
-  tooltipOpen?: boolean;
+export type WithTooltipProvidedProps<TooltipData> = {
+  tooltipOpen: boolean;
   tooltipLeft?: number;
   tooltipTop?: number;
-  tooltipData?: object;
-  updateTooltip?: (args: UpdateTooltipArgs) => void;
-  showTooltip?: (args: ShowTooltipArgs) => void;
-  hideTooltip?: () => void;
+  tooltipData?: TooltipData;
+  updateTooltip: (args: UpdateTooltipArgs<TooltipData>) => void;
+  showTooltip: (args: ShowTooltipArgs<TooltipData>) => void;
+  hideTooltip: () => void;
 };
-type WithTooltipState = Pick<
-  WithTooltipProvidedProps,
+
+type WithTooltipState<TooltipData> = Pick<
+  WithTooltipProvidedProps<TooltipData>,
   'tooltipOpen' | 'tooltipLeft' | 'tooltipTop' | 'tooltipData'
 >;
-type ShowTooltipArgs = Omit<WithTooltipState, 'tooltipOpen'>;
-type UpdateTooltipArgs = WithTooltipState;
+type ShowTooltipArgs<TooltipData> = Omit<WithTooltipState<TooltipData>, 'tooltipOpen'>;
+type UpdateTooltipArgs<TooltipData> = WithTooltipState<TooltipData>;
 type WithTooltipContainerProps = { style: React.CSSProperties };
 
-export default function withTooltip<Props extends object = {}>(
+export default function withTooltip<
+  Props extends WithTooltipProvidedProps<TooltipData>,
+  TooltipData
+>(
   BaseComponent: React.ComponentType<Props>,
   containerProps: WithTooltipContainerProps = {
     style: {
@@ -27,7 +31,7 @@ export default function withTooltip<Props extends object = {}>(
     } as const,
   },
 ) {
-  return class WrappedComponent extends React.PureComponent<Props, WithTooltipState> {
+  return class WrappedComponent extends React.PureComponent<Props, WithTooltipState<TooltipData>> {
     constructor(props: Props) {
       super(props);
       this.state = {
@@ -40,7 +44,12 @@ export default function withTooltip<Props extends object = {}>(
       this.showTooltip = this.showTooltip.bind(this);
       this.hideTooltip = this.hideTooltip.bind(this);
     }
-    updateTooltip({ tooltipOpen, tooltipLeft, tooltipTop, tooltipData }: UpdateTooltipArgs) {
+    updateTooltip({
+      tooltipOpen,
+      tooltipLeft,
+      tooltipTop,
+      tooltipData,
+    }: UpdateTooltipArgs<TooltipData>) {
       this.setState(prevState => ({
         ...prevState,
         tooltipOpen,
@@ -49,7 +58,7 @@ export default function withTooltip<Props extends object = {}>(
         tooltipData,
       }));
     }
-    showTooltip({ tooltipLeft, tooltipTop, tooltipData }: ShowTooltipArgs) {
+    showTooltip({ tooltipLeft, tooltipTop, tooltipData }: ShowTooltipArgs<TooltipData>) {
       this.updateTooltip({
         tooltipOpen: true,
         tooltipLeft,


### PR DESCRIPTION
#### :memo: Documentation

This PR is part of #579 to re-write the `vx-demo` site in TypeScript. It re-writes the `Statsplot` example in TypeScript.

 **Before/After**
<img src="https://user-images.githubusercontent.com/4496521/71946012-4a925b00-317d-11ea-8818-75ce6d8063d9.png" width="800" />

#### :bug: Bug Fix

- Fixes the types for `ProvidedProps` vs `BaseComponentProps` for `withTooltip`, `withScreenSize`, and `withParentSize` in `@vx/responsive` and `@vx/tooltip`
- Makes `TooltipData` a generic in `withTooltip` for better consumer experience
- Fixes a `.range()` type issue with `GenericScale in the `@vx/stats` package

#### Testing
- [x] functional
- [x] CI

cc @hshoff @kristw @schillerk 