### PR TITLE
Allow withTooltip to be used to enhance components rendered within an SVG element

### DIFF
--- a/packages/vx-tooltip/Readme.md
+++ b/packages/vx-tooltip/Readme.md
@@ -61,12 +61,13 @@ render(<ChartWithTooltip />, document.getElementById("root"));
 Example codesandbox [here](https://codesandbox.io/s/kw02m019mr).
 
 ### Enhancers
-#### withTooltip(BaseComponent [, containerProps])
-If you would like to add tooltip state logic to your component, you may wrap it in `withTooltip(BaseComponent [, containerProps])`.
+#### withTooltip(BaseComponent [, containerProps [, renderContainer]])
+If you would like to add tooltip state logic to your component, you may wrap it in `withTooltip(BaseComponent [, containerProps [, renderContainer])`.
+
 The HOC will wrap your component in a `div` with `relative` positioning by default and handle state for tooltip positioning, visibility, and content by injecting the following props into your `BaseComponent`:
 
 
-You may override the container by specifying `containerProps` as the second argument to `withTooltip`.
+You may override the container by specifying `containerProps` as the second argument to `withTooltip`, or by specifying `renderContainer` as the third argument to `withTooltip`.
 
 | Name | Type | Description |
 |:---- |:---- |:----------- |

--- a/packages/vx-tooltip/src/enhancers/withTooltip.tsx
+++ b/packages/vx-tooltip/src/enhancers/withTooltip.tsx
@@ -16,17 +16,9 @@ type WithTooltipState<TooltipData> = Pick<
 >;
 type ShowTooltipArgs<TooltipData> = Omit<WithTooltipState<TooltipData>, 'tooltipOpen'>;
 type UpdateTooltipArgs<TooltipData> = WithTooltipState<TooltipData>;
-type WithTooltipContainerProps = { style: React.CSSProperties };
 
 export default function withTooltip<BaseComponentProps = {}, TooltipData = {}>(
   BaseComponent: React.ComponentType<BaseComponentProps & WithTooltipProvidedProps<TooltipData>>,
-  containerProps: WithTooltipContainerProps = {
-    style: {
-      position: 'relative',
-      width: 'inherit',
-      height: 'inherit',
-    } as const,
-  },
 ) {
   return class WrappedComponent extends React.PureComponent<
     BaseComponentProps,
@@ -74,15 +66,13 @@ export default function withTooltip<BaseComponentProps = {}, TooltipData = {}>(
 
     render() {
       return (
-        <div {...containerProps}>
-          <BaseComponent
-            updateTooltip={this.updateTooltip}
-            showTooltip={this.showTooltip}
-            hideTooltip={this.hideTooltip}
-            {...this.state}
-            {...this.props}
-          />
-        </div>
+        <BaseComponent
+          updateTooltip={this.updateTooltip}
+          showTooltip={this.showTooltip}
+          hideTooltip={this.hideTooltip}
+          {...this.state}
+          {...this.props}
+        />
       );
     }
   };

--- a/packages/vx-tooltip/src/enhancers/withTooltip.tsx
+++ b/packages/vx-tooltip/src/enhancers/withTooltip.tsx
@@ -16,9 +16,17 @@ type WithTooltipState<TooltipData> = Pick<
 >;
 type ShowTooltipArgs<TooltipData> = Omit<WithTooltipState<TooltipData>, 'tooltipOpen'>;
 type UpdateTooltipArgs<TooltipData> = WithTooltipState<TooltipData>;
+type WithTooltipContainerProps = { style: React.CSSProperties };
 
 export default function withTooltip<BaseComponentProps = {}, TooltipData = {}>(
   BaseComponent: React.ComponentType<BaseComponentProps & WithTooltipProvidedProps<TooltipData>>,
+  containerProps: WithTooltipContainerProps = {
+    style: {
+      position: 'relative',
+      width: 'inherit',
+      height: 'inherit',
+    } as const,
+  },
 ) {
   return class WrappedComponent extends React.PureComponent<
     BaseComponentProps,
@@ -66,13 +74,15 @@ export default function withTooltip<BaseComponentProps = {}, TooltipData = {}>(
 
     render() {
       return (
-        <BaseComponent
-          updateTooltip={this.updateTooltip}
-          showTooltip={this.showTooltip}
-          hideTooltip={this.hideTooltip}
-          {...this.state}
-          {...this.props}
-        />
+        <div {...containerProps}>
+          <BaseComponent
+            updateTooltip={this.updateTooltip}
+            showTooltip={this.showTooltip}
+            hideTooltip={this.hideTooltip}
+            {...this.state}
+            {...this.props}
+          />
+        </div>
       );
     }
   };

--- a/packages/vx-tooltip/src/enhancers/withTooltip.tsx
+++ b/packages/vx-tooltip/src/enhancers/withTooltip.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 export type WithTooltipProvidedProps<TooltipData = {}> = {
   tooltipOpen: boolean;
@@ -20,7 +20,7 @@ type WithTooltipContainerProps = React.HTMLProps<HTMLDivElement>;
 type RenderTooltipContainer = (
   children: ReactElement,
   containerProps?: WithTooltipContainerProps,
-) => ReactElement;
+) => ReactNode;
 
 export default function withTooltip<BaseComponentProps = {}, TooltipData = {}>(
   BaseComponent: React.ComponentType<BaseComponentProps & WithTooltipProvidedProps<TooltipData>>,

--- a/packages/vx-tooltip/src/enhancers/withTooltip.tsx
+++ b/packages/vx-tooltip/src/enhancers/withTooltip.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 export type WithTooltipProvidedProps<TooltipData = {}> = {
   tooltipOpen: boolean;
@@ -17,6 +17,10 @@ type WithTooltipState<TooltipData> = Pick<
 type ShowTooltipArgs<TooltipData> = Omit<WithTooltipState<TooltipData>, 'tooltipOpen'>;
 type UpdateTooltipArgs<TooltipData> = WithTooltipState<TooltipData>;
 type WithTooltipContainerProps = { style: React.CSSProperties };
+type RenderTooltipContainer = (
+  children: ReactElement,
+  containerProps?: WithTooltipContainerProps,
+) => ReactElement;
 
 export default function withTooltip<BaseComponentProps = {}, TooltipData = {}>(
   BaseComponent: React.ComponentType<BaseComponentProps & WithTooltipProvidedProps<TooltipData>>,
@@ -27,6 +31,7 @@ export default function withTooltip<BaseComponentProps = {}, TooltipData = {}>(
       height: 'inherit',
     } as const,
   },
+  renderContainer: RenderTooltipContainer = (children, props) => <div {...props}>{children}</div>,
 ) {
   return class WrappedComponent extends React.PureComponent<
     BaseComponentProps,
@@ -73,16 +78,15 @@ export default function withTooltip<BaseComponentProps = {}, TooltipData = {}>(
     };
 
     render() {
-      return (
-        <div {...containerProps}>
-          <BaseComponent
-            updateTooltip={this.updateTooltip}
-            showTooltip={this.showTooltip}
-            hideTooltip={this.hideTooltip}
-            {...this.state}
-            {...this.props}
-          />
-        </div>
+      return renderContainer(
+        <BaseComponent
+          updateTooltip={this.updateTooltip}
+          showTooltip={this.showTooltip}
+          hideTooltip={this.hideTooltip}
+          {...this.state}
+          {...this.props}
+        />,
+        containerProps,
       );
     }
   };

--- a/packages/vx-tooltip/src/enhancers/withTooltip.tsx
+++ b/packages/vx-tooltip/src/enhancers/withTooltip.tsx
@@ -16,7 +16,7 @@ type WithTooltipState<TooltipData> = Pick<
 >;
 type ShowTooltipArgs<TooltipData> = Omit<WithTooltipState<TooltipData>, 'tooltipOpen'>;
 type UpdateTooltipArgs<TooltipData> = WithTooltipState<TooltipData>;
-type WithTooltipContainerProps = { style: React.CSSProperties };
+type WithTooltipContainerProps = React.HTMLProps<HTMLDivElement>;
 type RenderTooltipContainer = (
   children: ReactElement,
   containerProps?: WithTooltipContainerProps,

--- a/packages/vx-tooltip/test/withTooltip.test.ts
+++ b/packages/vx-tooltip/test/withTooltip.test.ts
@@ -1,7 +1,0 @@
-import { withTooltip } from '../src';
-
-describe('withTooltip()', () => {
-  test('it should be defined', () => {
-    expect(withTooltip).toBeDefined();
-  });
-});

--- a/packages/vx-tooltip/test/withTooltip.test.tsx
+++ b/packages/vx-tooltip/test/withTooltip.test.tsx
@@ -9,6 +9,11 @@ const DummyComponentWithDefaultTooltip = withTooltip(DummyComponent);
 const DummyComponentWithCustomContainerPropsTooltip = withTooltip(DummyComponent, {
   style: { position: 'static' },
 });
+const DummyComponentWithNoContainerTooltip = withTooltip(
+  DummyComponent,
+  undefined,
+  children => children,
+);
 
 describe('withTooltip()', () => {
   test('it should be defined', () => {
@@ -44,6 +49,13 @@ describe('withTooltip()', () => {
     ).toEqual({
       position: 'static',
     });
+    expect(wrapper.find(DummyComponent)).toHaveLength(1);
+  });
+
+  test('it should render with a custom container', () => {
+    const wrapper = shallow(<DummyComponentWithNoContainerTooltip />);
+
+    expect(wrapper.find('div')).toHaveLength(0);
     expect(wrapper.find(DummyComponent)).toHaveLength(1);
   });
 });

--- a/packages/vx-tooltip/test/withTooltip.test.tsx
+++ b/packages/vx-tooltip/test/withTooltip.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { withTooltip } from '../src';
+
+const DummyComponent = () => null;
+
+const DummyComponentWithDefaultTooltip = withTooltip(DummyComponent);
+const DummyComponentWithCustomContainerPropsTooltip = withTooltip(DummyComponent, {
+  style: { position: 'static' },
+});
+
+describe('withTooltip()', () => {
+  test('it should be defined', () => {
+    expect(withTooltip).toBeDefined();
+  });
+
+  test('it should render a default container', () => {
+    const wrapper = shallow(<DummyComponentWithDefaultTooltip />);
+
+    expect(wrapper.find('div')).toHaveLength(1);
+    expect(
+      wrapper
+        .find('div')
+        .first()
+        .prop('style'),
+    ).toEqual({
+      position: 'relative',
+      width: 'inherit',
+      height: 'inherit',
+    });
+    expect(wrapper.find(DummyComponent)).toHaveLength(1);
+  });
+
+  test('it should pass custom props to the container', () => {
+    const wrapper = shallow(<DummyComponentWithCustomContainerPropsTooltip />);
+
+    expect(wrapper.find('div')).toHaveLength(1);
+    expect(
+      wrapper
+        .find('div')
+        .first()
+        .prop('style'),
+    ).toEqual({
+      position: 'static',
+    });
+    expect(wrapper.find(DummyComponent)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
#### :rocket: Enhancements

- Addresses #609, enabling the `withTooltip` enhancer to be used on components that render within an SVG, such as `Axis`

#### :boom: Breaking Changes

- Since this removes the container `div` added by `withTooltip`, any implementations relying on the container would have to instead add such a container around their wrapped component themselves.  To me it looks like a more flexible approach since it allows any component to be enhanced using `withTooltip`, but there may be use cases or context I'm not aware of here!