### PR TITLE
fix(vx-legend): Fix label generation in `Threshold` legend

### DIFF
--- a/packages/vx-demo/src/components/tiles/Legends.tsx
+++ b/packages/vx-demo/src/components/tiles/Legends.tsx
@@ -37,7 +37,7 @@ const linearScale = scaleLinear<string>({
 });
 
 const thresholdScale = scaleThreshold<number, string>({
-  domain: [0.01, 0.02, 0.04, 0.06, 0.08, 0.1],
+  domain: [0.01, 0.02, 0.04, 0.06, 0.08],
   range: ['#f2f0f7', '#dadaeb', '#bcbddc', '#9e9ac8', '#756bb1', '#54278f'],
 });
 

--- a/packages/vx-demo/src/pages/Legends.tsx
+++ b/packages/vx-demo/src/pages/Legends.tsx
@@ -54,7 +54,7 @@ const linearScale = scaleLinear<string>({
 });
 
 const thresholdScale = scaleThreshold<number, string>({
-  domain: [0.01, 0.02, 0.04, 0.06, 0.08, 0.1],
+  domain: [0.01, 0.02, 0.04, 0.06, 0.08],
   range: ['#f2f0f7', '#dadaeb', '#bcbddc', '#9e9ac8', '#756bb1', '#54278f'],
 });
 

--- a/packages/vx-legend/src/legends/Linear.tsx
+++ b/packages/vx-legend/src/legends/Linear.tsx
@@ -6,7 +6,7 @@ export type LegendLinearProps<Output> = {
   steps?: number;
 } & LegendProps<number, Output, ScaleLinear<number, Output>>;
 
-function defaultDomain<Output>({
+export function defaultDomain<Output>({
   steps = 5,
   scale,
 }: Pick<LegendLinearProps<Output>, 'steps' | 'scale'>) {


### PR DESCRIPTION
#### :bug: Bug Fix

This PR closes #605 where `@vx/legend`'s `LegendThreshold` does not generate the correct number of labels after the `TS` re-write.

**More context**
Without a major refactor, the base `Legend` generates its labels from the `domain` of the input `scale`. However for `threshold` (and `quantile`) scales,[ if the `domain` contains `n` threshold values, the `range` should include `n+1` values](https://github.com/d3/d3-scale#threshold_domain) to capture both the `less than domain[0]` and `greater than domain[1]` intervals of the thresholds.

**The fix**
- Previously this wasn't accounted for and thus `LegendThreshold` did not include the last value in range as seen in the linked issue. This updates `LegendThreshold` to instead behave like `LegendQuantile` to effectively allow label generation from the range values. 

- This PR also updates the `Legends` demo to use a valid threshold scale with `n` domain and `n+1` range values. 

**Before**
![image](https://user-images.githubusercontent.com/4496521/73128422-ff9d8380-3f83-11ea-9dfc-2b19966cc2db.png)

**After**
![image](https://user-images.githubusercontent.com/4496521/73128417-f6acb200-3f83-11ea-985a-0dadc66c3bd9.png)


@hshoff @camille-s @kristw 