### PR TITLE
new(vx-brush): handle mouseup outside of Brush extent

### DIFF
--- a/packages/vx-brush/src/BaseBrush.tsx
+++ b/packages/vx-brush/src/BaseBrush.tsx
@@ -6,7 +6,7 @@ import Drag, { HandlerArgs as DragArgs } from '@vx/drag/lib/Drag';
 import BrushHandle from './BrushHandle';
 import BrushCorner from './BrushCorner';
 import BrushSelection from './BrushSelection';
-import { MarginShape, Point, BrushShape, ResizeTriggerAreas } from './types';
+import { MarginShape, Point, BrushShape, ResizeTriggerAreas, ScrubberShape } from './types';
 
 const BRUSH_OVERLAY_STYLES = { cursor: 'crosshair' };
 
@@ -16,6 +16,7 @@ type MouseHandlerEvent =
 
 export type BaseBrushProps = {
   brushDirection?: 'horizontal' | 'vertical' | 'both';
+  scrubberInitialState?: ScrubberShape;
   width: number;
   height: number;
   left: number;
@@ -46,27 +47,45 @@ export type UpdateBrush =
   | ((prevState: Readonly<BaseBrushState>, props: Readonly<BaseBrushProps>) => BaseBrushState);
 
 export default class BaseBrush extends React.Component<BaseBrushProps, BaseBrushState> {
+  private constructor(props: BaseBrushProps) {
+    super(props);
+    let scrubberState;
+    if (this.props.scrubberInitialState) {
+      scrubberState = {
+        start: this.props.scrubberInitialState.start,
+        end: this.props.scrubberInitialState.end,
+        extent: this.getExtent(
+          this.props.scrubberInitialState.start,
+          this.props.scrubberInitialState.end,
+        ),
+      };
+    } else {
+      scrubberState = {
+        start: { x: 0, y: 0 },
+        end: { x: 0, y: 0 },
+        extent: {
+          x0: -1,
+          x1: -1,
+          y0: -1,
+          y1: -1,
+        },
+      };
+    }
+    this.state = {
+      ...scrubberState,
+      bounds: {
+        x0: 0,
+        x1: this.props.width,
+        y0: 0,
+        y1: this.props.height,
+      },
+      isBrushing: false,
+      activeHandle: null,
+    };
+  }
+
   private mouseUpTime: number = 0;
   private mouseDownTime: number = 0;
-
-  state = {
-    start: { x: 0, y: 0 },
-    end: { x: 0, y: 0 },
-    extent: {
-      x0: -1,
-      x1: -1,
-      y0: -1,
-      y1: -1,
-    },
-    bounds: {
-      x0: 0,
-      x1: this.props.width,
-      y0: 0,
-      y1: this.props.height,
-    },
-    isBrushing: false,
-    activeHandle: null,
-  };
 
   static defaultProps = {
     brushDirection: 'both',
@@ -88,15 +107,16 @@ export default class BaseBrush extends React.Component<BaseBrushProps, BaseBrush
     disableDraggingSelection: false,
     clickSensitivity: 200,
     resetOnEnd: false,
+    scrubberInitialState: null,
   };
-      
+
   componentDidMount = () => {
-    window.addEventListener("mouseup", this.handleDragEnd);
-  }
-  
+    window.addEventListener('mouseup', this.handleDragEnd);
+  };
+
   componentWillUnmount = () => {
-    window.removeEventListener("mouseup", this.handleDragEnd);
-  }
+    window.removeEventListener('mouseup', this.handleDragEnd);
+  };
 
   componentDidUpdate(prevProps: BaseBrushProps) {
     if (this.props.width !== prevProps.width || this.props.height !== prevProps.height) {
@@ -177,32 +197,36 @@ export default class BaseBrush extends React.Component<BaseBrushProps, BaseBrush
   };
 
   handleDragEnd = () => {
-    const { onBrushEnd, resetOnEnd } = this.props;
-    this.updateBrush((prevBrush: BaseBrushState) => {
-      const { extent } = prevBrush;
-      const newState = {
-        ...prevBrush,
-        start: {
-          x: extent.x0,
-          y: extent.y0,
-        },
-        end: {
-          x: extent.x1,
-          y: extent.y1,
-        },
-        isBrushing: false,
-        activeHandle: null,
-      };
-      if (onBrushEnd) {
-        onBrushEnd(newState);
-      }
+    const { isBrushing } = this.state;
+    if (isBrushing) {
+      const { onBrushEnd, resetOnEnd } = this.props;
+      this.updateBrush((prevBrush: BaseBrushState) => {
+        const { extent } = prevBrush;
+        const newState = {
+          ...prevBrush,
+          start: {
+            x: extent.x0,
+            y: extent.y0,
+          },
+          end: {
+            x: extent.x1,
+            y: extent.y1,
+          },
+          isBrushing: false,
+          activeHandle: null,
+        };
 
-      if (resetOnEnd) {
-        this.reset();
-      }
+        if (onBrushEnd) {
+          onBrushEnd(newState);
+        }
 
-      return newState;
-    });
+        if (resetOnEnd) {
+          this.reset();
+        }
+
+        return newState;
+      });
+    }
   };
 
   getBrushWidth = () => {
@@ -265,7 +289,14 @@ export default class BaseBrush extends React.Component<BaseBrushProps, BaseBrush
   };
 
   corners = (): Partial<
-    { [key in ResizeTriggerAreas]: { x: number; y: number; width: number; height: number } }
+    {
+      [key in ResizeTriggerAreas]: {
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+      };
+    }
   > => {
     const { handleSize } = this.props;
     const { extent } = this.state;

--- a/packages/vx-brush/src/BaseBrush.tsx
+++ b/packages/vx-brush/src/BaseBrush.tsx
@@ -49,30 +49,18 @@ export type UpdateBrush =
 export default class BaseBrush extends React.Component<BaseBrushProps, BaseBrushState> {
   private constructor(props: BaseBrushProps) {
     super(props);
-    let scrubberState;
-    if (this.props.initialBrushPosition) {
-      scrubberState = {
-        start: this.props.initialBrushPosition.start,
-        end: this.props.initialBrushPosition.end,
-        extent: this.getExtent(
-          this.props.initialBrushPosition.start,
-          this.props.initialBrushPosition.end,
-        ),
-      };
-    } else {
-      scrubberState = {
-        start: { x: 0, y: 0 },
-        end: { x: 0, y: 0 },
-        extent: {
-          x0: -1,
-          x1: -1,
-          y0: -1,
-          y1: -1,
-        },
-      };
-    }
     this.state = {
-      ...scrubberState,
+      start: { x: 0, y: 0 },
+      end: { x: 0, y: 0 },
+      ...this.props.initialBrushPosition,
+      extent: this.props.initialBrushPosition
+        ? this.getExtent(this.props.initialBrushPosition.start, this.props.initialBrushPosition.end)
+        : {
+            x0: -1,
+            x1: -1,
+            y0: -1,
+            y1: -1,
+          },
       bounds: {
         x0: 0,
         x1: this.props.width,

--- a/packages/vx-brush/src/BaseBrush.tsx
+++ b/packages/vx-brush/src/BaseBrush.tsx
@@ -6,7 +6,7 @@ import Drag, { HandlerArgs as DragArgs } from '@vx/drag/lib/Drag';
 import BrushHandle from './BrushHandle';
 import BrushCorner from './BrushCorner';
 import BrushSelection from './BrushSelection';
-import { MarginShape, Point, BrushShape, ResizeTriggerAreas, ScrubberShape } from './types';
+import { MarginShape, Point, BrushShape, BrushStartEnd, ResizeTriggerAreas } from './types';
 
 const BRUSH_OVERLAY_STYLES = { cursor: 'crosshair' };
 
@@ -16,7 +16,7 @@ type MouseHandlerEvent =
 
 export type BaseBrushProps = {
   brushDirection?: 'horizontal' | 'vertical' | 'both';
-  scrubberInitialState?: ScrubberShape;
+  initialBrushPosition?: BrushStartEnd;
   width: number;
   height: number;
   left: number;
@@ -50,13 +50,13 @@ export default class BaseBrush extends React.Component<BaseBrushProps, BaseBrush
   private constructor(props: BaseBrushProps) {
     super(props);
     let scrubberState;
-    if (this.props.scrubberInitialState) {
+    if (this.props.initialBrushPosition) {
       scrubberState = {
-        start: this.props.scrubberInitialState.start,
-        end: this.props.scrubberInitialState.end,
+        start: this.props.initialBrushPosition.start,
+        end: this.props.initialBrushPosition.end,
         extent: this.getExtent(
-          this.props.scrubberInitialState.start,
-          this.props.scrubberInitialState.end,
+          this.props.initialBrushPosition.start,
+          this.props.initialBrushPosition.end,
         ),
       };
     } else {
@@ -107,16 +107,16 @@ export default class BaseBrush extends React.Component<BaseBrushProps, BaseBrush
     disableDraggingSelection: false,
     clickSensitivity: 200,
     resetOnEnd: false,
-    scrubberInitialState: null,
+    initialBrushPosition: null,
   };
 
-  componentDidMount = () => {
+  componentDidMount() {
     window.addEventListener('mouseup', this.handleDragEnd);
-  };
+  }
 
-  componentWillUnmount = () => {
+  componentWillUnmount() {
     window.removeEventListener('mouseup', this.handleDragEnd);
-  };
+  }
 
   componentDidUpdate(prevProps: BaseBrushProps) {
     if (this.props.width !== prevProps.width || this.props.height !== prevProps.height) {

--- a/packages/vx-brush/src/BaseBrush.tsx
+++ b/packages/vx-brush/src/BaseBrush.tsx
@@ -91,11 +91,11 @@ export default class BaseBrush extends React.Component<BaseBrushProps, BaseBrush
   };
       
   componentDidMount = () => {
-    window.addEventListener("mouseup", handleDragEnd);
+    window.addEventListener("mouseup", this.handleDragEnd);
   }
   
   componentWillUnmount = () => {
-    window.removeEventListener("mouseup", handleDragEnd);
+    window.removeEventListener("mouseup", this.handleDragEnd);
   }
 
   componentDidUpdate(prevProps: BaseBrushProps) {

--- a/packages/vx-brush/src/BaseBrush.tsx
+++ b/packages/vx-brush/src/BaseBrush.tsx
@@ -89,6 +89,14 @@ export default class BaseBrush extends React.Component<BaseBrushProps, BaseBrush
     clickSensitivity: 200,
     resetOnEnd: false,
   };
+      
+  componentDidMount = () => {
+    window.addEventListener("mouseup", handleDragEnd);
+  }
+  
+  componentWillUnmount = () => {
+    window.removeEventListener("mouseup", handleDragEnd);
+  }
 
   componentDidUpdate(prevProps: BaseBrushProps) {
     if (this.props.width !== prevProps.width || this.props.height !== prevProps.height) {

--- a/packages/vx-brush/src/Brush.tsx
+++ b/packages/vx-brush/src/Brush.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import BaseBrush, { BaseBrushProps, BaseBrushState } from './BaseBrush';
-import { Bounds, MarginShape, Point, ResizeTriggerAreas, Scale } from './types';
+import { Bounds, MarginShape, Point, ResizeTriggerAreas, Scale, ScrubberShape } from './types';
 import { scaleInvert, getDomainFromExtent } from './utils';
 
 const SAFE_PIXEL = 2;
@@ -20,6 +20,7 @@ export type BrushProps = {
   onClick: BaseBrushProps['onClick'];
   margin: MarginShape;
   brushDirection: 'vertical' | 'horizontal' | 'both';
+  scrubberInitialState?: ScrubberShape;
   resizeTriggerAreas: ResizeTriggerAreas[];
   brushRegion: 'xAxis' | 'yAxis' | 'chart';
   yAxisOrientation: 'left' | 'right';
@@ -51,6 +52,7 @@ class Brush extends React.Component<BrushProps> {
     },
     handleSize: 4,
     brushDirection: 'horizontal',
+    scrubberInitialState: null,
     resizeTriggerAreas: ['left', 'right'],
     brushRegion: 'chart',
     yAxisOrientation: 'right',
@@ -129,6 +131,7 @@ class Brush extends React.Component<BrushProps> {
       width,
       margin,
       brushDirection,
+      scrubberInitialState,
       resizeTriggerAreas,
       brushRegion,
       yAxisOrientation,
@@ -186,6 +189,7 @@ class Brush extends React.Component<BrushProps> {
         left={left}
         top={top}
         inheritedMargin={margin}
+        scrubberInitialState={scrubberInitialState}
         onChange={this.handleChange}
         onBrushEnd={this.handleBrushEnd}
         onBrushStart={this.handleBrushStart}

--- a/packages/vx-brush/src/Brush.tsx
+++ b/packages/vx-brush/src/Brush.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import BaseBrush, { BaseBrushProps, BaseBrushState } from './BaseBrush';
-import { Bounds, MarginShape, Point, ResizeTriggerAreas, Scale, ScrubberShape } from './types';
+import { Bounds, BrushStartEnd, MarginShape, Point, ResizeTriggerAreas, Scale } from './types';
 import { scaleInvert, getDomainFromExtent } from './utils';
 
 const SAFE_PIXEL = 2;
@@ -20,7 +20,7 @@ export type BrushProps = {
   onClick: BaseBrushProps['onClick'];
   margin: MarginShape;
   brushDirection: 'vertical' | 'horizontal' | 'both';
-  scrubberInitialState?: ScrubberShape;
+  initialBrushPosition?: BrushStartEnd;
   resizeTriggerAreas: ResizeTriggerAreas[];
   brushRegion: 'xAxis' | 'yAxis' | 'chart';
   yAxisOrientation: 'left' | 'right';
@@ -52,7 +52,7 @@ class Brush extends React.Component<BrushProps> {
     },
     handleSize: 4,
     brushDirection: 'horizontal',
-    scrubberInitialState: null,
+    initialBrushPosition: null,
     resizeTriggerAreas: ['left', 'right'],
     brushRegion: 'chart',
     yAxisOrientation: 'right',
@@ -131,7 +131,7 @@ class Brush extends React.Component<BrushProps> {
       width,
       margin,
       brushDirection,
-      scrubberInitialState,
+      initialBrushPosition,
       resizeTriggerAreas,
       brushRegion,
       yAxisOrientation,
@@ -189,7 +189,7 @@ class Brush extends React.Component<BrushProps> {
         left={left}
         top={top}
         inheritedMargin={margin}
-        scrubberInitialState={scrubberInitialState}
+        initialBrushPosition={initialBrushPosition}
         onChange={this.handleChange}
         onBrushEnd={this.handleBrushEnd}
         onBrushStart={this.handleBrushStart}

--- a/packages/vx-brush/src/types.ts
+++ b/packages/vx-brush/src/types.ts
@@ -19,12 +19,12 @@ export interface MarginShape {
   bottom?: number;
 }
 
-export interface BrushShape extends ScrubberShape {
+export interface BrushShape extends BrushStartEnd {
   extent: Bounds;
   bounds: Bounds;
 }
 
-export interface ScrubberShape {
+export interface BrushStartEnd {
   start: Point;
   end: Point;
 }

--- a/packages/vx-brush/src/types.ts
+++ b/packages/vx-brush/src/types.ts
@@ -19,11 +19,14 @@ export interface MarginShape {
   bottom?: number;
 }
 
-export interface BrushShape {
-  start: Point;
-  end: Point;
+export interface BrushShape extends ScrubberShape {
   extent: Bounds;
   bounds: Bounds;
+}
+
+export interface ScrubberShape {
+  start: Point;
+  end: Point;
 }
 
 export type ResizeTriggerAreas =


### PR DESCRIPTION
#### :boom: Breaking Changes

- None

#### :rocket: Enhancements

- Brush now listens to when a mouseup event happens on the window to disable brush drag
- Brush accepts an optional prop to default the scrubber state to an initial value

#### :memo: Documentation

-

#### :bug: Bug Fix

-

#### :house: Internal

-
