### PR TITLE
Add useTooltip hook

### DIFF
--- a/packages/vx-demo/src/pages/BarStack.tsx
+++ b/packages/vx-demo/src/pages/BarStack.tsx
@@ -19,8 +19,7 @@ import { AxisBottom } from '@vx/axis';
 import cityTemperature, { CityTemperature } from '@vx/mock-data/lib/mocks/cityTemperature';
 import { scaleBand, scaleLinear, scaleOrdinal } from '@vx/scale';
 import { timeParse, timeFormat } from 'd3-time-format';
-import { withTooltip, Tooltip } from '@vx/tooltip';
-import { WithTooltipProvidedProps } from '@vx/tooltip/lib/enhancers/withTooltip';
+import { useTooltip, Tooltip } from '@vx/tooltip';
 import { LegendOrdinal } from '@vx/legend';
 import { ShowProvidedProps } from '../../types';
 
@@ -76,7 +75,7 @@ const colorScale = scaleOrdinal<CityName, string>({
 
 let tooltipTimeout: number;
 
-export default withTooltip<ShowProvidedProps, TooltipData>(
+export default 
   ({
     width,
     height,
@@ -87,13 +86,16 @@ export default withTooltip<ShowProvidedProps, TooltipData>(
       bottom: 0,
       left: 0,
     },
-    tooltipOpen,
-    tooltipLeft,
-    tooltipTop,
-    tooltipData,
-    hideTooltip,
-    showTooltip,
-  }: ShowProvidedProps & WithTooltipProvidedProps<TooltipData>) => {
+  }: ShowProvidedProps) => {
+    const {
+      tooltipOpen,
+      tooltipLeft,
+      tooltipTop,
+      tooltipData,
+      hideTooltip,
+      showTooltip
+    } = useTooltip<TooltipData>();
+
     if (width < 10) return null;
     // bounds
     const xMax = width;
@@ -208,8 +210,7 @@ export default withTooltip<ShowProvidedProps, TooltipData>(
         )}
       </div>
     );
-  },
-);
+  }
 `}
     </Show>
   );

--- a/packages/vx-tooltip/Readme.md
+++ b/packages/vx-tooltip/Readme.md
@@ -4,10 +4,127 @@
 npm install --save @vx/tooltip
 ```
 
-The `@vx/tooltip` package provides utilities for making it easy to add `Tooltip`s to a visualization and includes higher-order component (HOC) enhancers and Tooltip components.
+The `@vx/tooltip` package provides utilities for making it easy to add `Tooltip`s to a visualization and includes hooks, higher-order component (HOC) enhancers and Tooltip components.
 
-### Example:
-``` js
+### Hooks and Enhancers
+
+This package provides two ways to add tooltip state logic to your chart components:
+
+- a hook: `useTooltip()` 
+- a higher order component (HOC): `withTooltip()`
+
+The `useTooltip` hook is the recommended way to add tooltip state logic to your components, but can only be used in functional components. The `withTooltip` HOC can be used with both functional and class components, and is the recommended way to add tooltip state logic to class components.
+
+Both `useTooltip` and `withTooltip` expose the same values and functions for use in your component:
+
+| Name          | Type   | Description                                                                                                                                           |
+| :------------ | :----- | :---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| showTooltip   | func   | Call this function with the signature `func({ tooltipData, tooltipLeft, tooltipTop })` to set the tooltip state to the specified values.              |
+| hideTooltip   | func   | Call this function to close a tooltip, i.e., set the `showTooltip` state to `false`.                                                                  |
+| tooltipOpen   | bool   | Whether the tooltip state is open or closed                                                                                                           |
+| tooltipLeft   | number | The `tooltipLeft` position passed to the `showTooltip` func, intended to be used for tooltip positioning                                              |
+| tooltipTop    | number | The `tooltipTop` position passed to the `showTooltip` func, intended to be used for tooltip positioning                                               |
+| tooltipData   | any    | The `tooltipData` value passed to the `showTooltip` func, intended to be used for any data that your tooltip might need to render                     |
+| updateTooltip | func   | Call this function with the signature `func({ tooltipOpen, tooltipLeft, tooltipTop, tooltipData })` to set the tooltip state to the specified values. |
+
+In the case of `useTooltip`, these will be returned from the `useTooltip()` call in your component. In the case of `withTooltip`, they will be passed as props to your wrapped component. Refer to the [Examples](#examples) section for a basic demo of each approach.
+
+#### useTooltip()
+
+If you would like to add tooltip state logic to a functional component, you may use the `useTooltip()` hook which will return an object with several properties that you can use to manage the tooltip state of your component.
+
+#### withTooltip(BaseComponent [, containerProps [, renderContainer]])
+
+If you would like to add tooltip state logic to a class component, you may wrap it in `withTooltip(BaseComponent [, containerProps [, renderContainer])`.
+
+The HOC will wrap your component in a `div` with `relative` positioning by default and handle state for tooltip positioning, visibility, and content by injecting the following props into your `BaseComponent`:
+
+You may override the container by specifying `containerProps` as the second argument to `withTooltip`, or by specifying `renderContainer` as the third argument to `withTooltip`.
+
+### Components
+#### Tooltip
+
+This is a simple Tooltip container component meant to be used to actually render a Tooltip. It accepts the following props, and will spread any additional props on the tooltip container div (i.e., ...restProps):
+
+| Name      | Type             | Default | Description                                                                   |
+| :-------- | :--------------- | :------ | :---------------------------------------------------------------------------- |
+| left      | number or string | --      | Sets style.left of the tooltip container                                      |
+| top       | number or string | --      | Sets style.top of the tooltip container                                       |
+| className | string           | --      | Adds a class (in addition to `vx-tooltip-portal`) to the tooltip container    |
+| style     | object           | --      | Sets / overrides any styles on the tooltip container (including top and left) |
+| children  | node             | --      | Sets the children of the tooltip, i.e., the actual content                    |
+
+#### TooltipWithBounds
+
+This tooltip component is exactly the same as `Tooltip` above, but it is aware of its boundaries meaning that it will flip left/right and bottom/top based on whether it would overflow its parent's boundaries. It accepts the following props, and will spread any additional props on the Tooltip component (i.e., ...restProps):
+
+| Name        | Type   | Default | Description                                                                                                                                                                      |
+| :---------- | :----- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| left        | number | --      | The horizontal position of the cursor, tooltip will be place to the left or right of this coordinate depending on the width of the tooltip and the size of the parent container. |
+| top         | number | --      | The vertical position of the cursor, tooltip will be place to the bottom or top of this coordinate depending on the height of the tooltip and the size of the parent container.  |
+| offsetLeft  | number | 10      | Horizontal offset of the tooltip from the passed `left` value, functions as a horizontal padding.                                                                                |
+| offsetRight | number | 10      | Vertical offset of the tooltip from the passed `top` value, functions as a vertical padding.                                                                                     |
+| style       | object | --      | Sets / overrides any styles on the tooltip container (including top and left)                                                                                                    |
+| children    | node   | --      | Sets the children of the tooltip, i.e., the actual content                                                                                                                       |
+
+Note that this component is positioned using a `transform`, so overriding `left` and `top` via styles may have no effect.
+
+### Examples
+#### useTooltip For Functional Components
+
+```js
+import { useTooltip, TooltipWithBounds } from '@vx/tooltip';
+import { localPoint } from '@vx/event';
+
+const ChartWithTooltip = () => {
+  const {
+    tooltipData,
+    tooltipLeft,
+    tooltipTop,
+    tooltipOpen,
+    showTooltip,
+    hideTooltip,
+  } = useTooltip();
+
+  const handleMouseOver = (event, datum) => {
+    const coords = localPoint(event.target.ownerSVGElement, event);
+    showTooltip({
+      tooltipLeft: coords.x,
+      tooltipTop: coords.y,
+      tooltipData: datum
+    });
+  };
+
+  return (
+    <>
+      <svg width={...} height={...}>
+        // Chart here...
+        <SomeChartElement
+          onMouseOver={this.handleMouseOver}
+          onMouseOut={hideTooltip}
+        />
+      </svg>
+
+      {tooltipOpen && (
+        <TooltipWithBounds
+          // set this to random so it correctly updates with parent bounds
+          key={Math.random()}
+          top={tooltipTop}
+          left={tooltipLeft}
+        >
+          Data value <strong>{tooltipData}</strong>
+        </TooltipWithBounds>
+      )}
+    </>
+  )
+};
+
+render(<ChartWithTooltip />, document.getElementById("root"));
+```
+
+#### withTooltip For Class Components
+
+```js
 import { withTooltip, TooltipWithBounds } from '@vx/tooltip';
 import { localPoint } from '@vx/event';
 
@@ -59,50 +176,3 @@ render(<ChartWithTooltip />, document.getElementById("root"));
 ```
 
 Example codesandbox [here](https://codesandbox.io/s/kw02m019mr).
-
-### Enhancers
-#### withTooltip(BaseComponent [, containerProps [, renderContainer]])
-If you would like to add tooltip state logic to your component, you may wrap it in `withTooltip(BaseComponent [, containerProps [, renderContainer])`.
-
-The HOC will wrap your component in a `div` with `relative` positioning by default and handle state for tooltip positioning, visibility, and content by injecting the following props into your `BaseComponent`:
-
-
-You may override the container by specifying `containerProps` as the second argument to `withTooltip`, or by specifying `renderContainer` as the third argument to `withTooltip`.
-
-| Name | Type | Description |
-|:---- |:---- |:----------- |
-| showTooltip | func | Call this function with the signature `func({ tooltipData, tooltipLeft, tooltipTop })` to set the tooltip state to the specified values.
-| hideTooltip | func | Call this function to close a tooltip, i.e., set the `showTooltip` state to `false`.
-| tooltipOpen | bool | Whether the tooltip state is open or closed |
-| tooltipLeft | number | The `tooltipLeft` position passed to the `showTooltip` func, intended to be used for tooltip positioning |
-| tooltipTop | number | The `tooltipTop` position passed to the `showTooltip` func, intended to be used for tooltip positioning |
-| tooltipData | any | The `tooltipData` value passed to the `showTooltip` func, intended to be used for any data that your tooltip might need to render |
-| updateTooltip | func | Call this function with the signature `func({ tooltipOpen, tooltipLeft, tooltipTop, tooltipData })` to set the tooltip state to the specified values. |
-
-
-### Components
-#### Tooltip
-This is a simple Tooltip container component meant to be used to actually render a Tooltip. It accepts the following props, and will spread any additional props on the tooltip container div (i.e., ...restProps):
-
-| Name | Type | Default | Description |
-|:---- |:---- |:------- |:----------- |
-| left | number or string | -- | Sets style.left of the tooltip container
-| top | number or string | -- | Sets style.top of the tooltip container
-| className | string | -- | Adds a class (in addition to `vx-tooltip-portal`) to the tooltip container
-| style | object | -- | Sets / overrides any styles on the tooltip container (including top and left)
-| children | node | -- | Sets the children of the tooltip, i.e., the actual content
-
-
-#### TooltipWithBounds
-This tooltip component is exactly the same as `Tooltip` above, but it is aware of its boundaries meaning that it will flip left/right and bottom/top based on whether it would overflow its parent's boundaries. It accepts the following props, and will spread any additional props on the Tooltip component (i.e., ...restProps):
-
-| Name | Type | Default | Description |
-|:---- |:---- |:------- |:----------- |
-| left | number | -- | The horizontal position of the cursor, tooltip will be place to the left or right of this coordinate depending on the width of the tooltip and the size of the parent container.
-| top | number | -- | The vertical position of the cursor, tooltip will be place to the bottom or top of this coordinate depending on the height of the tooltip and the size of the parent container.
-| offsetLeft | number | 10 | Horizontal offset of the tooltip from the passed `left` value, functions as a horizontal padding.
-| offsetRight | number | 10 | Vertical offset of the tooltip from the passed `top` value, functions as a vertical padding.
-| style | object | -- | Sets / overrides any styles on the tooltip container (including top and left)
-| children | node | -- | Sets the children of the tooltip, i.e., the actual content
-
-Note that this component is positioned using a `transform`, so overriding `left` and `top` via styles may have no effect.

--- a/packages/vx-tooltip/package.json
+++ b/packages/vx-tooltip/package.json
@@ -35,7 +35,7 @@
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {
-    "react": "^15.0.0-0 || ^16.0.0-0"
+    "react": "^16.8.0-0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vx-tooltip/src/enhancers/withTooltip.tsx
+++ b/packages/vx-tooltip/src/enhancers/withTooltip.tsx
@@ -1,26 +1,13 @@
-import React, { ReactElement, ReactNode } from 'react';
+import React, { ReactElement, FunctionComponent } from 'react';
 
-export type WithTooltipProvidedProps<TooltipData = {}> = {
-  tooltipOpen: boolean;
-  tooltipLeft?: number;
-  tooltipTop?: number;
-  tooltipData?: TooltipData;
-  updateTooltip: (args: UpdateTooltipArgs<TooltipData>) => void;
-  showTooltip: (args: ShowTooltipArgs<TooltipData>) => void;
-  hideTooltip: () => void;
-};
+import useTooltip, { UseTooltipParams } from '../hooks/useTooltip';
 
-type WithTooltipState<TooltipData> = Pick<
-  WithTooltipProvidedProps<TooltipData>,
-  'tooltipOpen' | 'tooltipLeft' | 'tooltipTop' | 'tooltipData'
->;
-type ShowTooltipArgs<TooltipData> = Omit<WithTooltipState<TooltipData>, 'tooltipOpen'>;
-type UpdateTooltipArgs<TooltipData> = WithTooltipState<TooltipData>;
+export type WithTooltipProvidedProps<TooltipData> = UseTooltipParams<TooltipData>;
 type WithTooltipContainerProps = React.HTMLProps<HTMLDivElement>;
 type RenderTooltipContainer = (
   children: ReactElement,
   containerProps?: WithTooltipContainerProps,
-) => ReactNode;
+) => ReactElement;
 
 export default function withTooltip<BaseComponentProps = {}, TooltipData = {}>(
   BaseComponent: React.ComponentType<BaseComponentProps & WithTooltipProvidedProps<TooltipData>>,
@@ -33,61 +20,11 @@ export default function withTooltip<BaseComponentProps = {}, TooltipData = {}>(
   },
   renderContainer: RenderTooltipContainer = (children, props) => <div {...props}>{children}</div>,
 ) {
-  return class WrappedComponent extends React.PureComponent<
-    BaseComponentProps,
-    WithTooltipState<TooltipData>
-  > {
-    state = {
-      tooltipOpen: false,
-      tooltipLeft: undefined,
-      tooltipTop: undefined,
-      tooltipData: undefined,
-    };
+  const WrappedComponent: FunctionComponent<BaseComponentProps> = props => {
+    const tooltipProps = useTooltip<TooltipData>();
 
-    updateTooltip = ({
-      tooltipOpen,
-      tooltipLeft,
-      tooltipTop,
-      tooltipData,
-    }: UpdateTooltipArgs<TooltipData>) => {
-      this.setState(prevState => ({
-        ...prevState,
-        tooltipOpen,
-        tooltipLeft,
-        tooltipTop,
-        tooltipData,
-      }));
-    };
-
-    showTooltip = ({ tooltipLeft, tooltipTop, tooltipData }: ShowTooltipArgs<TooltipData>) => {
-      this.updateTooltip({
-        tooltipOpen: true,
-        tooltipLeft,
-        tooltipTop,
-        tooltipData,
-      });
-    };
-
-    hideTooltip = () => {
-      this.updateTooltip({
-        tooltipOpen: false,
-        tooltipLeft: undefined,
-        tooltipTop: undefined,
-        tooltipData: undefined,
-      });
-    };
-
-    render() {
-      return renderContainer(
-        <BaseComponent
-          updateTooltip={this.updateTooltip}
-          showTooltip={this.showTooltip}
-          hideTooltip={this.hideTooltip}
-          {...this.state}
-          {...this.props}
-        />,
-        containerProps,
-      );
-    }
+    return renderContainer(<BaseComponent {...props} {...tooltipProps} />, containerProps);
   };
+
+  return WrappedComponent;
 }

--- a/packages/vx-tooltip/src/enhancers/withTooltip.tsx
+++ b/packages/vx-tooltip/src/enhancers/withTooltip.tsx
@@ -23,7 +23,7 @@ export default function withTooltip<BaseComponentProps = {}, TooltipData = {}>(
   const WrappedComponent: FunctionComponent<BaseComponentProps> = props => {
     const tooltipProps = useTooltip<TooltipData>();
 
-    return renderContainer(<BaseComponent {...props} {...tooltipProps} />, containerProps);
+    return renderContainer(<BaseComponent {...tooltipProps} {...props} />, containerProps);
   };
 
   return WrappedComponent;

--- a/packages/vx-tooltip/src/hooks/useTooltip.ts
+++ b/packages/vx-tooltip/src/hooks/useTooltip.ts
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+
+export type UseTooltipParams<TooltipData> = {
+  tooltipOpen: boolean;
+  tooltipLeft?: number;
+  tooltipTop?: number;
+  tooltipData?: TooltipData;
+  updateTooltip: (args: UpdateTooltipArgs<TooltipData>) => void;
+  showTooltip: (args: ShowTooltipArgs<TooltipData>) => void;
+  hideTooltip: () => void;
+};
+type UseTooltipState<TooltipData> = Pick<
+  UseTooltipParams<TooltipData>,
+  'tooltipOpen' | 'tooltipLeft' | 'tooltipTop' | 'tooltipData'
+>;
+type ShowTooltipArgs<TooltipData> = Omit<UseTooltipState<TooltipData>, 'tooltipOpen'>;
+type UpdateTooltipArgs<TooltipData> = UseTooltipState<TooltipData>;
+
+export default function useTooltip<TooltipData = {}>(): UseTooltipParams<TooltipData> {
+  const [{ tooltipOpen, tooltipLeft, tooltipTop, tooltipData }, setTooltipState] = useState<
+    UseTooltipState<TooltipData>
+  >({
+    tooltipOpen: false,
+    tooltipLeft: undefined,
+    tooltipTop: undefined,
+    tooltipData: undefined,
+  });
+
+  const updateTooltip = ({
+    tooltipOpen,
+    tooltipLeft,
+    tooltipTop,
+    tooltipData,
+  }: UpdateTooltipArgs<TooltipData>) =>
+    setTooltipState(prevState => ({
+      ...prevState,
+      tooltipOpen,
+      tooltipLeft,
+      tooltipTop,
+      tooltipData,
+    }));
+
+  const showTooltip = ({ tooltipLeft, tooltipTop, tooltipData }: ShowTooltipArgs<TooltipData>) =>
+    updateTooltip({
+      tooltipOpen: true,
+      tooltipLeft,
+      tooltipTop,
+      tooltipData,
+    });
+
+  const hideTooltip = () =>
+    updateTooltip({
+      tooltipOpen: false,
+      tooltipLeft: undefined,
+      tooltipTop: undefined,
+      tooltipData: undefined,
+    });
+
+  return {
+    tooltipOpen,
+    tooltipLeft,
+    tooltipTop,
+    tooltipData,
+    updateTooltip,
+    showTooltip,
+    hideTooltip,
+  };
+}

--- a/packages/vx-tooltip/src/index.ts
+++ b/packages/vx-tooltip/src/index.ts
@@ -1,3 +1,4 @@
 export { default as withTooltip } from './enhancers/withTooltip';
+export { default as useTooltip } from './hooks/useTooltip';
 export { default as Tooltip } from './tooltips/Tooltip';
 export { default as TooltipWithBounds } from './tooltips/TooltipWithBounds';

--- a/packages/vx-tooltip/test/useTooltip.test.tsx
+++ b/packages/vx-tooltip/test/useTooltip.test.tsx
@@ -1,0 +1,7 @@
+import useTooltip from '../src/hooks/useTooltip';
+
+describe('useTooltip()', () => {
+  test('it should be defined', () => {
+    expect(useTooltip).toBeDefined();
+  });
+});


### PR DESCRIPTION
#### :rocket: Enhancements

- Add a `useTooltip` hook to manage tooltip state for functional components, as discussed in https://github.com/hshoff/vx/issues/609

#### :boom: Breaking Changes

- This PR introduces `useState`, which requires bumping the `peerDep` for react to `^16.8.0-0`

#### :memo: Documentation

- Update `vx-tooltip` readme to include the new `useTooltip` hook, and recommend a state management approach depending on use case (specifically: recommending `useTooltip` for functional components, or `withTooltip` for class components)
- Rewrite the `BarStack` demo to use `useTooltip` instead of `withTooltip`, so there is an example of each approach to managing tooltip state in the gallery (`BarStack` for `useTooltip`, `BarStackHorizontal` for `withTooltip`)

#### :house: Internal

- Rewrote `withTooltip` in terms of `useTooltip`, to avoid maintaining multiple different implementations
