### PR TITLE
style(vx-tooltip): resolve linter errors (no-shadow)

### DIFF
--- a/packages/vx-tooltip/src/hooks/useTooltip.ts
+++ b/packages/vx-tooltip/src/hooks/useTooltip.ts
@@ -17,9 +17,7 @@ type ShowTooltipArgs<TooltipData> = Omit<UseTooltipState<TooltipData>, 'tooltipO
 type UpdateTooltipArgs<TooltipData> = UseTooltipState<TooltipData>;
 
 export default function useTooltip<TooltipData = {}>(): UseTooltipParams<TooltipData> {
-  const [{ tooltipOpen, tooltipLeft, tooltipTop, tooltipData }, setTooltipState] = useState<
-    UseTooltipState<TooltipData>
-  >({
+  const [tooltipState, setTooltipState] = useState<UseTooltipState<TooltipData>>({
     tooltipOpen: false,
     tooltipLeft: undefined,
     tooltipTop: undefined,
@@ -57,10 +55,10 @@ export default function useTooltip<TooltipData = {}>(): UseTooltipParams<Tooltip
     });
 
   return {
-    tooltipOpen,
-    tooltipLeft,
-    tooltipTop,
-    tooltipData,
+    tooltipOpen: tooltipState.tooltipOpen,
+    tooltipLeft: tooltipState.tooltipLeft,
+    tooltipTop: tooltipState.tooltipTop,
+    tooltipData: tooltipState.tooltipData,
     updateTooltip,
     showTooltip,
     hideTooltip,


### PR DESCRIPTION
#### :house: Internal

- Fixing a few linter errors regarding shadowed variables that I didn't catch when I submitted https://github.com/hshoff/vx/pull/631, and which don't seem to be flagged as part of the Travis build (see: https://github.com/hshoff/vx/issues/638).
