### PR TITLE
ci(travis): Move fast_finish to jobs key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,8 @@ install:
   - yarn install --ignore-engines
 before_script:
   - yarn run build
-matrix:
-  fast_finish: true
 jobs:
+  fast_finish: true
   include:
     - name: Test
       script: yarn run jest -w 4


### PR DESCRIPTION
#### :house: Internal

- Consolidated the `matrix` and `jobs` configuration in `.travis.yml`, since those two keys override each other.  This was causing Travis to run the default test script (`yarn test`) instead of running both the test and lint steps as desired (closes https://github.com/hshoff/vx/issues/638).

~~Note: the CI build for this this will (correctly) fail, since the linter will throw errors until https://github.com/hshoff/vx/pull/639 is merged.~~ I've rebased over the latest master and force pushed, so I'd expect CI to pass now 🤞 