### PR TITLE
Fix typo within readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ yarn
 yarn build
 ```
 
-#### Rebuild on package
+#### Rebuild one package
 
 Upon modification of a single `package` you can run
 
@@ -312,10 +312,10 @@ Upon modification of a single `package` you can run
 # build the package as cjs version
 yarn build-one --workspaces=@vx/package
 
-# build the esm version
+# build the esm version (the @vx/demo next server sources these files)
 yarn build-one --workspaces=@vx/package --esm
 
-# generate d.ts(definition files) for lib
+# generate d.ts(definition files) for a lib
 yarn type-one --workspaces=@vx/package --esm
 ```
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ yarn build
 
 #### Rebuild on package
 
-Upon modification of a signle `package` you can run
+Upon modification of a single `package` you can run
 
 ```sh
 # build the package as cjs version


### PR DESCRIPTION
Additionally, should the section header above this fix be `Rebuild one package` (one instead of on)?

#### :memo: Documentation

- Fix typo in root readme
