### PR TITLE
[demo] lock nextjs version, fix breaking dep problem

### DIFF
--- a/packages/vx-demo/package.json
+++ b/packages/vx-demo/package.json
@@ -64,7 +64,7 @@
     "d3-scale-chromatic": "^1.3.3",
     "d3-shape": "^1.0.6",
     "d3-time-format": "^2.0.5",
-    "next": "^9.0.5",
+    "next": "9.3.0",
     "nprogress": "^0.2.0",
     "prismjs": "^1.19.0",
     "raw-loader": "^4.0.0",


### PR DESCRIPTION
#### :house: Internal

- [demo] bump nextjs + lock version. fixes: https://github.com/zeit/next.js/issues/11230
