### PR TITLE
Remove tooltip default styles

### DIFF
--- a/packages/vx-tooltip/Readme.md
+++ b/packages/vx-tooltip/Readme.md
@@ -46,13 +46,14 @@ You may override the container by specifying `containerProps` as the second argu
 
 This is a simple Tooltip container component meant to be used to actually render a Tooltip. It accepts the following props, and will spread any additional props on the tooltip container div (i.e., ...restProps):
 
-| Name      | Type             | Default | Description                                                                   |
-| :-------- | :--------------- | :------ | :---------------------------------------------------------------------------- |
-| left      | number or string | --      | Sets style.left of the tooltip container                                      |
-| top       | number or string | --      | Sets style.top of the tooltip container                                       |
-| className | string           | --      | Adds a class (in addition to `vx-tooltip-portal`) to the tooltip container    |
-| style     | object           | --      | Sets / overrides any styles on the tooltip container (including top and left) |
-| children  | node             | --      | Sets the children of the tooltip, i.e., the actual content                    |
+| Name              | Type             | Default | Description                                                                   |
+| :-----------------| :--------------- | :------ | :---------------------------------------------------------------------------- |
+| left              | number or string | --      | Sets style.left of the tooltip container                                      |
+| top               | number or string | --      | Sets style.top of the tooltip container                                       |
+| className         | string           | --      | Adds a class (in addition to `vx-tooltip-portal`) to the tooltip container    |
+| style             | object           | --      | Sets / overrides any styles on the tooltip container (including top and left) |
+| children          | node             | --      | Sets the children of the tooltip, i.e., the actual content                    |
+| withDefaultStyles | bool             | true    | Whether the tooltip should have default styles or not                         |
 
 #### TooltipWithBounds
 

--- a/packages/vx-tooltip/Readme.md
+++ b/packages/vx-tooltip/Readme.md
@@ -47,13 +47,13 @@ You may override the container by specifying `containerProps` as the second argu
 This is a simple Tooltip container component meant to be used to actually render a Tooltip. It accepts the following props, and will spread any additional props on the tooltip container div (i.e., ...restProps):
 
 | Name      | Type             | Default | Description                                                                   |
-| :---------| :--------------- | :------ | :---------------------------------------------------------------------------- |
+| :-------- | :--------------- | :------ | :---------------------------------------------------------------------------- |
 | left      | number or string | --      | Sets style.left of the tooltip container                                      |
 | top       | number or string | --      | Sets style.top of the tooltip container                                       |
 | className | string           | --      | Adds a class (in addition to `vx-tooltip-portal`) to the tooltip container    |
 | style     | object           | --      | Sets / overrides any styles on the tooltip container (including top and left) |
 | children  | node             | --      | Sets the children of the tooltip, i.e., the actual content                    |
-| unstyled  | bool             | true    | Whether the tooltip should have default styles or not                         |
+| unstyled  | bool             | true    | Whether the tooltip use styles from the style prop or not                     |
 
 #### TooltipWithBounds
 

--- a/packages/vx-tooltip/Readme.md
+++ b/packages/vx-tooltip/Readme.md
@@ -46,14 +46,14 @@ You may override the container by specifying `containerProps` as the second argu
 
 This is a simple Tooltip container component meant to be used to actually render a Tooltip. It accepts the following props, and will spread any additional props on the tooltip container div (i.e., ...restProps):
 
-| Name              | Type             | Default | Description                                                                   |
-| :-----------------| :--------------- | :------ | :---------------------------------------------------------------------------- |
-| left              | number or string | --      | Sets style.left of the tooltip container                                      |
-| top               | number or string | --      | Sets style.top of the tooltip container                                       |
-| className         | string           | --      | Adds a class (in addition to `vx-tooltip-portal`) to the tooltip container    |
-| style             | object           | --      | Sets / overrides any styles on the tooltip container (including top and left) |
-| children          | node             | --      | Sets the children of the tooltip, i.e., the actual content                    |
-| withDefaultStyles | bool             | true    | Whether the tooltip should have default styles or not                         |
+| Name      | Type             | Default | Description                                                                   |
+| :---------| :--------------- | :------ | :---------------------------------------------------------------------------- |
+| left      | number or string | --      | Sets style.left of the tooltip container                                      |
+| top       | number or string | --      | Sets style.top of the tooltip container                                       |
+| className | string           | --      | Adds a class (in addition to `vx-tooltip-portal`) to the tooltip container    |
+| style     | object           | --      | Sets / overrides any styles on the tooltip container (including top and left) |
+| children  | node             | --      | Sets the children of the tooltip, i.e., the actual content                    |
+| unstyled  | bool             | true    | Whether the tooltip should have default styles or not                         |
 
 #### TooltipWithBounds
 

--- a/packages/vx-tooltip/package.json
+++ b/packages/vx-tooltip/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@types/classnames": "^2.2.9",
     "@types/react": "*",
-    "@vx/bounds": "^0.0.195",
+    "@vx/bounds": "0.0.195",
     "classnames": "^2.2.5",
     "prop-types": "^15.5.10"
   },

--- a/packages/vx-tooltip/package.json
+++ b/packages/vx-tooltip/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@types/classnames": "^2.2.9",
     "@types/react": "*",
-    "@vx/bounds": "0.0.195",
+    "@vx/bounds": "^0.0.195",
     "classnames": "^2.2.5",
     "prop-types": "^15.5.10"
   },

--- a/packages/vx-tooltip/src/index.ts
+++ b/packages/vx-tooltip/src/index.ts
@@ -1,4 +1,4 @@
 export { default as withTooltip } from './enhancers/withTooltip';
 export { default as useTooltip } from './hooks/useTooltip';
-export { default as Tooltip } from './tooltips/Tooltip';
+export { default as Tooltip, defaultStyles as tooltipDefaultStyles } from './tooltips/Tooltip';
 export { default as TooltipWithBounds } from './tooltips/TooltipWithBounds';

--- a/packages/vx-tooltip/src/index.ts
+++ b/packages/vx-tooltip/src/index.ts
@@ -1,4 +1,4 @@
 export { default as withTooltip } from './enhancers/withTooltip';
 export { default as useTooltip } from './hooks/useTooltip';
-export { default as Tooltip, defaultStyles as tooltipDefaultStyles } from './tooltips/Tooltip';
+export { default as Tooltip, defaultStyles } from './tooltips/Tooltip';
 export { default as TooltipWithBounds } from './tooltips/TooltipWithBounds';

--- a/packages/vx-tooltip/src/tooltips/Tooltip.tsx
+++ b/packages/vx-tooltip/src/tooltips/Tooltip.tsx
@@ -7,7 +7,7 @@ export type TooltipProps = {
   className?: string;
   style?: React.CSSProperties;
   children?: React.ReactNode;
-  withDefaultStyles?: boolean;
+  unstyled?: boolean;
 };
 
 export const defaultStyles: React.CSSProperties = {
@@ -26,20 +26,15 @@ export default function Tooltip({
   className,
   top,
   left,
-  style,
+  style = defaultStyles,
   children,
-  withDefaultStyles = true,
+  unstyled = false,
   ...restProps
 }: TooltipProps & JSX.IntrinsicElements['div']) {
   return (
     <div
       className={cx('vx-tooltip-portal', className)}
-      style={{
-        ...(withDefaultStyles && defaultStyles),
-        top,
-        left,
-        ...style,
-      }}
+      style={{ top, left, ...(!unstyled && style) }}
       {...restProps}
     >
       {children}

--- a/packages/vx-tooltip/src/tooltips/Tooltip.tsx
+++ b/packages/vx-tooltip/src/tooltips/Tooltip.tsx
@@ -7,6 +7,19 @@ export type TooltipProps = {
   className?: string;
   style?: React.CSSProperties;
   children?: React.ReactNode;
+  withDefaultStyles?: boolean;
+};
+
+export const defaultStyles: React.CSSProperties = {
+  position: 'absolute',
+  backgroundColor: 'white',
+  color: '#666666',
+  padding: '.3rem .5rem',
+  borderRadius: '3px',
+  fontSize: '14px',
+  boxShadow: '0 1px 2px rgba(33,33,33,0.2)',
+  lineHeight: '1em',
+  pointerEvents: 'none',
 };
 
 export default function Tooltip({
@@ -15,21 +28,14 @@ export default function Tooltip({
   left,
   style,
   children,
+  withDefaultStyles = true,
   ...restProps
 }: TooltipProps & JSX.IntrinsicElements['div']) {
   return (
     <div
       className={cx('vx-tooltip-portal', className)}
       style={{
-        position: 'absolute',
-        backgroundColor: 'white',
-        color: '#666666',
-        padding: '.3rem .5rem',
-        borderRadius: '3px',
-        fontSize: '14px',
-        boxShadow: '0 1px 2px rgba(33,33,33,0.2)',
-        lineHeight: '1em',
-        pointerEvents: 'none',
+        ...(withDefaultStyles && defaultStyles),
         top,
         left,
         ...style,

--- a/packages/vx-tooltip/src/tooltips/TooltipWithBounds.tsx
+++ b/packages/vx-tooltip/src/tooltips/TooltipWithBounds.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-// @ts-ignore This line could be removed after bounds migration to the TS
 import { withBoundingRects } from '@vx/bounds';
 
 import Tooltip from './Tooltip';

--- a/packages/vx-tooltip/test/Tooltip.test.tsx
+++ b/packages/vx-tooltip/test/Tooltip.test.tsx
@@ -7,7 +7,7 @@ describe('<Tooltip />', () => {
     expect(Tooltip).toBeDefined();
   });
 
-  it('should render with the correct default styles', () => {
+  it('should render with the default styles', () => {
     const wrapper = shallow(<Tooltip>Hello</Tooltip>);
     const styles = wrapper.props().style;
     Object.entries(defaultStyles).forEach(([key, value]) => {
@@ -16,10 +16,28 @@ describe('<Tooltip />', () => {
   });
 
   it('should render with no default styles', () => {
-    const wrapper = shallow(<Tooltip unstyled={true}>Hello</Tooltip>);
+    const wrapper = shallow(<Tooltip unstyled>Hello</Tooltip>);
     const styles = wrapper.props().style;
     Object.keys(defaultStyles).forEach(key => {
       expect(styles[key]).toBe(undefined);
+    });
+  });
+
+  it('should overwrite default styles when given the style prop', () => {
+    const newStyles: React.CSSProperties = {
+      position: 'relative',
+      backgroundColor: 'green',
+      color: 'red',
+      padding: '.8rem .8rem',
+      borderRadius: '13px',
+      fontSize: '17px',
+      boxShadow: '0 2px 3px rgba(133,133,133,0.5)',
+      lineHeight: '2em',
+    };
+    const wrapper = shallow(<Tooltip style={newStyles}></Tooltip>);
+    const styles = wrapper.props().style;
+    Object.entries(newStyles).forEach(([key, value]) => {
+      expect(styles[key]).toBe(value);
     });
   });
 });

--- a/packages/vx-tooltip/test/Tooltip.test.tsx
+++ b/packages/vx-tooltip/test/Tooltip.test.tsx
@@ -1,7 +1,25 @@
-import { Tooltip } from '../src';
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Tooltip, tooltipDefaultStyles } from '../src';
 
 describe('<Tooltip />', () => {
   test('it should be defined', () => {
     expect(Tooltip).toBeDefined();
+  });
+
+  it('should render with the correct default styles', () => {
+    const wrapper = shallow(<Tooltip>Hello</Tooltip>);
+    const styles = wrapper.props().style;
+    Object.entries(tooltipDefaultStyles).forEach(([key, value]) => {
+      expect(styles[key]).toBe(value);
+    });
+  });
+
+  it('should render with no default styles', () => {
+    const wrapper = shallow(<Tooltip withDefaultStyles={false}>Hello</Tooltip>);
+    const styles = wrapper.props().style;
+    Object.entries(tooltipDefaultStyles).forEach(([key]) => {
+      expect(styles[key]).toBe(undefined);
+    });
   });
 });

--- a/packages/vx-tooltip/test/Tooltip.test.tsx
+++ b/packages/vx-tooltip/test/Tooltip.test.tsx
@@ -18,7 +18,7 @@ describe('<Tooltip />', () => {
   it('should render with no default styles', () => {
     const wrapper = shallow(<Tooltip withDefaultStyles={false}>Hello</Tooltip>);
     const styles = wrapper.props().style;
-    Object.entries(tooltipDefaultStyles).forEach(([key]) => {
+    Object.keys(tooltipDefaultStyles).forEach(key => {
       expect(styles[key]).toBe(undefined);
     });
   });

--- a/packages/vx-tooltip/test/Tooltip.test.tsx
+++ b/packages/vx-tooltip/test/Tooltip.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Tooltip, tooltipDefaultStyles } from '../src';
+import { Tooltip, defaultStyles } from '../src';
 
 describe('<Tooltip />', () => {
   test('it should be defined', () => {
@@ -10,15 +10,15 @@ describe('<Tooltip />', () => {
   it('should render with the correct default styles', () => {
     const wrapper = shallow(<Tooltip>Hello</Tooltip>);
     const styles = wrapper.props().style;
-    Object.entries(tooltipDefaultStyles).forEach(([key, value]) => {
+    Object.entries(defaultStyles).forEach(([key, value]) => {
       expect(styles[key]).toBe(value);
     });
   });
 
   it('should render with no default styles', () => {
-    const wrapper = shallow(<Tooltip withDefaultStyles={false}>Hello</Tooltip>);
+    const wrapper = shallow(<Tooltip unstyled={true}>Hello</Tooltip>);
     const styles = wrapper.props().style;
-    Object.keys(tooltipDefaultStyles).forEach(key => {
+    Object.keys(defaultStyles).forEach(key => {
       expect(styles[key]).toBe(undefined);
     });
   });


### PR DESCRIPTION
#### :boom: Breaking Changes

-

#### :rocket: Enhancements

- Enable users to use or remove default tooltip styles

#### :memo: Documentation

- Update tooltip docs

#### :bug: Bug Fix

-

#### :house: Internal

-

Fixes https://github.com/hshoff/vx/issues/650
