### PR TITLE
fix(vx-brush): Fix initialBrushPosition

### DIFF
--- a/packages/vx-brush/src/Brush.tsx
+++ b/packages/vx-brush/src/Brush.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import BaseBrush, { BaseBrushProps, BaseBrushState } from './BaseBrush';
-import { Bounds, BrushStartEnd, MarginShape, Point, ResizeTriggerAreas, Scale } from './types';
+import {
+  Bounds,
+  PartialBrushStartEnd,
+  MarginShape,
+  Point,
+  ResizeTriggerAreas,
+  Scale,
+} from './types';
 import { scaleInvert, getDomainFromExtent } from './utils';
 
 const SAFE_PIXEL = 2;
@@ -20,7 +27,7 @@ export type BrushProps = {
   onClick: BaseBrushProps['onClick'];
   margin: MarginShape;
   brushDirection: 'vertical' | 'horizontal' | 'both';
-  initialBrushPosition?: BrushStartEnd;
+  initialBrushPosition?: PartialBrushStartEnd;
   resizeTriggerAreas: ResizeTriggerAreas[];
   brushRegion: 'xAxis' | 'yAxis' | 'chart';
   yAxisOrientation: 'left' | 'right';

--- a/packages/vx-brush/src/types.ts
+++ b/packages/vx-brush/src/types.ts
@@ -29,6 +29,11 @@ export interface BrushStartEnd {
   end: Point;
 }
 
+export interface PartialBrushStartEnd {
+  start: Partial<Point>;
+  end: Partial<Point>;
+}
+
 export type ResizeTriggerAreas =
   | 'left'
   | 'right'

--- a/packages/vx-demo/src/components/Gallery.tsx
+++ b/packages/vx-demo/src/components/Gallery.tsx
@@ -67,7 +67,7 @@ const items = [
 const tiltOptions = { max: 8, scale: 1 };
 const detailsHeight = 76;
 
-export default function() {
+export default function Gallery() {
   return (
     <div>
       <div className="gallery">

--- a/packages/vx-demo/src/components/tiles/Brush.tsx
+++ b/packages/vx-demo/src/components/tiles/Brush.tsx
@@ -157,7 +157,7 @@ function BrushChart({
 
   const initialBrushPosition = {
     start: { x: brushDateScale(getDate(stock[50])) },
-    end: { x: brushDateScale(getDate(stock[150])) },
+    end: { x: brushDateScale(getDate(stock[100])) },
   };
 
   return (

--- a/packages/vx-demo/src/components/tiles/Brush.tsx
+++ b/packages/vx-demo/src/components/tiles/Brush.tsx
@@ -16,7 +16,7 @@ import { ShowProvidedProps, MarginShape } from '../../types';
 /**
  * Initialize some variables
  */
-const stock = appleStock.slice(1200);
+const stock = appleStock.slice(1000);
 const axisColor = '#fff';
 const axisBottomTickLabelProps = {
   textAnchor: 'middle' as const,
@@ -155,6 +155,11 @@ function BrushChart({
     nice: true,
   });
 
+  const initialBrushPosition = {
+    start: { x: brushDateScale(getDate(stock[50])) },
+    end: { x: brushDateScale(getDate(stock[150])) },
+  };
+
   return (
     <div>
       <svg width={width} height={height}>
@@ -203,6 +208,7 @@ function BrushChart({
             handleSize={8}
             resizeTriggerAreas={['left', 'right', 'bottomRight']}
             brushDirection="horizontal"
+            initialBrushPosition={initialBrushPosition}
             onChange={onBrushChange}
             onClick={() => setFilteredStock(stock)}
             selectedBoxStyle={{

--- a/packages/vx-tooltip/test/Tooltip.test.tsx
+++ b/packages/vx-tooltip/test/Tooltip.test.tsx
@@ -19,7 +19,7 @@ describe('<Tooltip />', () => {
     const wrapper = shallow(<Tooltip unstyled>Hello</Tooltip>);
     const styles = wrapper.props().style;
     Object.keys(defaultStyles).forEach(key => {
-      expect(styles[key]).toBe(undefined);
+      expect(styles[key]).toBeUndefined();
     });
   });
 
@@ -34,7 +34,7 @@ describe('<Tooltip />', () => {
       boxShadow: '0 2px 3px rgba(133,133,133,0.5)',
       lineHeight: '2em',
     };
-    const wrapper = shallow(<Tooltip style={newStyles}></Tooltip>);
+    const wrapper = shallow(<Tooltip style={newStyles} />);
     const styles = wrapper.props().style;
     Object.entries(newStyles).forEach(([key, value]) => {
       expect(styles[key]).toBe(value);


### PR DESCRIPTION
#### :bug: Bug Fix

This fixes some problems with the implementation of `initialBrushPosition` from #618 
- the type `BrushStartEnd` expected both `x` and `y` of `start`/`end` to be defined, which doesn't work if you have a `vertical-` or `horizontal-`only brush. Fixed to handle partials.
- the initial brush worked if you dragged in a new position, or extended a side, but not if you dragged the initial brush window. to fix this I updated some of the initial `state.start/end` logic which is used by `BrushSelection` upon moving a selection.

**Before**
![broken-brush-move](https://user-images.githubusercontent.com/4496521/80850746-542f4b00-8bd2-11ea-88e3-29532d97d609.gif)

**After**
![fixed-brush-move](https://user-images.githubusercontent.com/4496521/80850741-509bc400-8bd2-11ea-88ab-c1ded7400258.gif)

Also updates the demo to include an `initialBrushPosition` which should be useful for peeps
![image](https://user-images.githubusercontent.com/4496521/80850526-154cc580-8bd1-11ea-816a-475f2b231a21.png)

#### :house: Internal
Jest was failing locally to collect coverage due to a missing react component function name. I added one to fix locally, and see if it fixes anything on CI.

@hshoff @kristw 
cc @maryschmidt 




