### PR TITLE
perf(vx-tooltip): use useCallback in useTooltip

### DIFF
--- a/packages/vx-tooltip/src/hooks/useTooltip.ts
+++ b/packages/vx-tooltip/src/hooks/useTooltip.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 
 export type UseTooltipParams<TooltipData> = {
   tooltipOpen: boolean;
@@ -19,40 +19,41 @@ type UpdateTooltipArgs<TooltipData> = UseTooltipState<TooltipData>;
 export default function useTooltip<TooltipData = {}>(): UseTooltipParams<TooltipData> {
   const [tooltipState, setTooltipState] = useState<UseTooltipState<TooltipData>>({
     tooltipOpen: false,
-    tooltipLeft: undefined,
-    tooltipTop: undefined,
-    tooltipData: undefined,
   });
 
-  const updateTooltip = ({
-    tooltipOpen,
-    tooltipLeft,
-    tooltipTop,
-    tooltipData,
-  }: UpdateTooltipArgs<TooltipData>) =>
-    setTooltipState(prevState => ({
-      ...prevState,
-      tooltipOpen,
-      tooltipLeft,
-      tooltipTop,
-      tooltipData,
-    }));
+  const updateTooltip = useCallback(
+    ({ tooltipOpen, tooltipLeft, tooltipTop, tooltipData }: UpdateTooltipArgs<TooltipData>) =>
+      setTooltipState(prevState => ({
+        ...prevState,
+        tooltipOpen,
+        tooltipLeft,
+        tooltipTop,
+        tooltipData,
+      })),
+    [],
+  );
 
-  const showTooltip = ({ tooltipLeft, tooltipTop, tooltipData }: ShowTooltipArgs<TooltipData>) =>
-    updateTooltip({
-      tooltipOpen: true,
-      tooltipLeft,
-      tooltipTop,
-      tooltipData,
-    });
+  const showTooltip = useCallback(
+    ({ tooltipLeft, tooltipTop, tooltipData }: ShowTooltipArgs<TooltipData>) =>
+      updateTooltip({
+        tooltipOpen: true,
+        tooltipLeft,
+        tooltipTop,
+        tooltipData,
+      }),
+    [updateTooltip],
+  );
 
-  const hideTooltip = () =>
-    updateTooltip({
-      tooltipOpen: false,
-      tooltipLeft: undefined,
-      tooltipTop: undefined,
-      tooltipData: undefined,
-    });
+  const hideTooltip = useCallback(
+    () =>
+      updateTooltip({
+        tooltipOpen: false,
+        tooltipLeft: undefined,
+        tooltipTop: undefined,
+        tooltipData: undefined,
+      }),
+    [updateTooltip],
+  );
 
   return {
     tooltipOpen: tooltipState.tooltipOpen,


### PR DESCRIPTION
#### :rocket: Enhancements

When using `useTooltip` introduced in #631 I noticed that passing `showTooltip` or `hideTooltip` to a child component causes unnecessary and potentially expensive render cascades / child updates even though `tooltipLeft`, `tooltipTop`, or `tooltipData` didn't change.

This should be fixable by using the `useCallback` hook, where the callbacks are not instantiated each render, and thus `PureComponent`s or `React.memo`ized components should not update unless `tooltipLeft`, `tooltipTop`, or `tooltipData` update.

@kristw @hshoff 
cc @ptmx 
