### PR TITLE
new(vx-demo): convert BarGroup, BarGroupHorizontal to codesandbox

### DIFF
--- a/packages/vx-demo/src/components/Gallery.tsx
+++ b/packages/vx-demo/src/components/Gallery.tsx
@@ -17,7 +17,10 @@ import Axis, {
   backgroundColor as axisBackgroundColor,
   labelColor as axisTextColor,
 } from '../docs-v2/examples/vx-axis/Example';
-import BarGroup from './tiles/BarGroup';
+import BarGroup, {
+  background as bargroupBackground,
+  green as bargroupText,
+} from '../docs-v2/examples/vx-bargroup/Example';
 import BarGroupHorizontal from './tiles/BarGroupHorizontal';
 import BarStack from './tiles/BarStack';
 import BarStackHorizontal from './tiles/BarStackHorizontal';
@@ -294,7 +297,7 @@ export default function Gallery() {
         </Tilt>
         <Tilt className="tilt" options={tiltOptions}>
           <Link href="/bargroup">
-            <div className="gallery-item" style={{ background: '#612efb' }}>
+            <div className="gallery-item" style={{ background: bargroupBackground }}>
               <div className="image">
                 <ParentSize>
                   {({ width, height }) => (
@@ -302,7 +305,7 @@ export default function Gallery() {
                   )}
                 </ParentSize>
               </div>
-              <div className="details" style={{ color: '#e5fd3d' }}>
+              <div className="details" style={{ color: bargroupText }}>
                 <div className="title">Bar Group</div>
                 <div className="description">
                   <pre>{'<Shape.BarGroup />'}</pre>

--- a/packages/vx-demo/src/components/Gallery.tsx
+++ b/packages/vx-demo/src/components/Gallery.tsx
@@ -21,7 +21,10 @@ import BarGroup, {
   background as bargroupBackground,
   green as bargroupText,
 } from '../docs-v2/examples/vx-bargroup/Example';
-import BarGroupHorizontal from './tiles/BarGroupHorizontal';
+import BarGroupHorizontal, {
+  background as horizontalBargroupBackground,
+  green as horizontalBargroupText,
+} from '../docs-v2/examples/vx-bargroup-horizontal/Example';
 import BarStack from './tiles/BarStack';
 import BarStackHorizontal from './tiles/BarStackHorizontal';
 import Heatmap from './tiles/Heatmap';
@@ -316,7 +319,7 @@ export default function Gallery() {
         </Tilt>
         <Tilt className="tilt" options={tiltOptions}>
           <Link href="/bargrouphorizontal">
-            <div className="gallery-item" style={{ background: '#612efb' }}>
+            <div className="gallery-item" style={{ background: horizontalBargroupBackground }}>
               <div className="image">
                 <ParentSize>
                   {({ width, height }) => (
@@ -324,7 +327,7 @@ export default function Gallery() {
                   )}
                 </ParentSize>
               </div>
-              <div className="details" style={{ color: '#e5fd3d' }}>
+              <div className="details" style={{ color: horizontalBargroupText }}>
                 <div className="title">Bar Group Horizontal</div>
                 <div className="description">
                   <pre>{'<Shape.BarGroupHorizontal />'}</pre>

--- a/packages/vx-demo/src/components/Gallery.tsx
+++ b/packages/vx-demo/src/components/Gallery.tsx
@@ -323,7 +323,11 @@ export default function Gallery() {
               <div className="image">
                 <ParentSize>
                   {({ width, height }) => (
-                    <BarGroupHorizontal width={width} height={height + detailsHeight} />
+                    <BarGroupHorizontal
+                      width={width}
+                      height={height + detailsHeight}
+                      margin={{ top: 20, bottom: detailsHeight, left: 50, right: 20 }}
+                    />
                   )}
                 </ParentSize>
               </div>

--- a/packages/vx-demo/src/docs-v2/examples/vx-bargroup-horizontal/Example.tsx
+++ b/packages/vx-demo/src/docs-v2/examples/vx-bargroup-horizontal/Example.tsx
@@ -5,9 +5,21 @@ import { AxisLeft } from '@vx/axis';
 import cityTemperature, { CityTemperature } from '@vx/mock-data/lib/mocks/cityTemperature';
 import { scaleBand, scaleLinear, scaleOrdinal } from '@vx/scale';
 import { timeParse, timeFormat } from 'd3-time-format';
-import { ShowProvidedProps } from '../../types';
+
+type Props = {
+  width: number;
+  height: number;
+  margin?: { top: number; right: number; bottom: number; left: number };
+  events?: boolean;
+};
 
 type CityName = 'New York' | 'San Francisco' | 'Austin';
+
+const blue = '#aeeef8';
+export const green = '#e5fd3d';
+const purple = '#9caff6';
+export const background = '#612efb';
+const defaultMargin = { top: 20, right: 10, bottom: 0, left: 50 };
 
 const parseDate = timeParse('%Y%m%d');
 const format = timeFormat('%b %d');
@@ -36,34 +48,22 @@ const tempScale = scaleLinear<number>({
 });
 const colorScale = scaleOrdinal<string, string>({
   domain: keys,
-  range: ['#aeeef8', '#e5fd3d', '#9caff6'],
+  range: [blue, green, purple],
 });
 
-export default ({
-  width,
-  height,
-  margin = {
-    top: 20,
-    left: 50,
-    right: 10,
-    bottom: 0,
-  },
-  events = false,
-}: ShowProvidedProps) => {
-  if (width < 10) return null;
-
+export default function Example({ width, height, margin = defaultMargin, events = false }: Props) {
   // bounds
   const xMax = width - margin.left - margin.right;
   const yMax = height - 100;
 
-  // scales
+  // update scale output dimensions
   dateScale.rangeRound([0, yMax]);
   cityScale.rangeRound([0, dateScale.bandwidth()]);
   tempScale.rangeRound([0, xMax]);
 
-  return (
+  return width < 10 ? null : (
     <svg width={width} height={height}>
-      <rect x={0} y={0} width={width} height={height} fill="#612efb" rx={14} />
+      <rect x={0} y={0} width={width} height={height} fill={background} rx={14} />
       <Group top={margin.top} left={margin.left}>
         <BarGroupHorizontal<CityTemperature, CityName>
           data={data}
@@ -101,12 +101,12 @@ export default ({
         </BarGroupHorizontal>
         <AxisLeft
           scale={dateScale}
-          stroke="#e5fd3d"
-          tickStroke="#e5fd3d"
+          stroke={green}
+          tickStroke={green}
           tickFormat={formatDate}
           hideAxisLine
           tickLabelProps={() => ({
-            fill: '#e5fd3d',
+            fill: green,
             fontSize: 11,
             textAnchor: 'end',
             dy: '0.33em',
@@ -115,4 +115,4 @@ export default ({
       </Group>
     </svg>
   );
-};
+}

--- a/packages/vx-demo/src/docs-v2/examples/vx-bargroup-horizontal/Example.tsx
+++ b/packages/vx-demo/src/docs-v2/examples/vx-bargroup-horizontal/Example.tsx
@@ -19,7 +19,7 @@ const blue = '#aeeef8';
 export const green = '#e5fd3d';
 const purple = '#9caff6';
 export const background = '#612efb';
-const defaultMargin = { top: 20, right: 10, bottom: 0, left: 50 };
+const defaultMargin = { top: 20, right: 20, bottom: 20, left: 50 };
 
 const parseDate = timeParse('%Y%m%d');
 const format = timeFormat('%b %d');
@@ -54,7 +54,7 @@ const colorScale = scaleOrdinal<string, string>({
 export default function Example({ width, height, margin = defaultMargin, events = false }: Props) {
   // bounds
   const xMax = width - margin.left - margin.right;
-  const yMax = height - 100;
+  const yMax = height - margin.top - margin.bottom;
 
   // update scale output dimensions
   dateScale.rangeRound([0, yMax]);

--- a/packages/vx-demo/src/docs-v2/examples/vx-bargroup-horizontal/index.tsx
+++ b/packages/vx-demo/src/docs-v2/examples/vx-bargroup-horizontal/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from 'react-dom';
+import ParentSize from '@vx/responsive/lib/components/ParentSize';
+
+import Example from './Example';
+import './sandbox-styles.css';
+
+render(
+  <ParentSize>{({ width, height }) => <Example width={width} height={height} />}</ParentSize>,
+  document.getElementById('root'),
+);

--- a/packages/vx-demo/src/docs-v2/examples/vx-bargroup-horizontal/package.json
+++ b/packages/vx-demo/src/docs-v2/examples/vx-bargroup-horizontal/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@vx/demo-bargroup-horizontal",
+  "description": "Standalone vx horizontal grouped bar demo.",
+  "main": "index.tsx",
+  "dependencies": {
+    "@babel/runtime": "^7.8.4",
+    "@types/react": "^16",
+    "@types/react-dom": "^16",
+    "@vx/axis": "latest",
+    "@vx/group": "latest",
+    "@vx/mock-data": "latest",
+    "@vx/responsive": "latest",
+    "@vx/scale": "latest",
+    "@vx/shape": "latest",
+    "d3-time-format": "^2.2.3",
+    "react": "^16",
+    "react-dom": "^16",
+    "react-scripts-ts": "3.1.0",
+    "typescript": "^3"
+  },
+  "keywords": [
+    "visualization",
+    "d3",
+    "react",
+    "vx", 
+    "bargroup"
+  ]
+}

--- a/packages/vx-demo/src/docs-v2/examples/vx-bargroup-horizontal/sandbox-styles.css
+++ b/packages/vx-demo/src/docs-v2/examples/vx-bargroup-horizontal/sandbox-styles.css
@@ -1,0 +1,8 @@
+html,
+body,
+#root {
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+    'Open Sans', 'Helvetica Neue', sans-serif;
+  line-height: 2em;
+}

--- a/packages/vx-demo/src/docs-v2/examples/vx-bargroup/Example.tsx
+++ b/packages/vx-demo/src/docs-v2/examples/vx-bargroup/Example.tsx
@@ -5,17 +5,24 @@ import { AxisBottom } from '@vx/axis';
 import cityTemperature, { CityTemperature } from '@vx/mock-data/lib/mocks/cityTemperature';
 import { scaleBand, scaleLinear, scaleOrdinal } from '@vx/scale';
 import { timeParse, timeFormat } from 'd3-time-format';
-import { ShowProvidedProps } from '../../types';
+
+type Props = {
+  width: number;
+  height: number;
+  margin?: { top: number; right: number; bottom: number; left: number };
+  events?: boolean;
+};
 
 type CityName = 'New York' | 'San Francisco' | 'Austin';
 
 const blue = '#aeeef8';
-const green = '#e5fd3d';
+export const green = '#e5fd3d';
 const purple = '#9caff6';
-const bg = '#612efb';
+export const background = '#612efb';
 
 const data = cityTemperature.slice(0, 8);
 const keys = Object.keys(data[0]).filter(d => d !== 'date') as CityName[];
+const defaultMargin = { top: 40, right: 0, bottom: 40, left: 0 };
 
 const parseDate = timeParse('%Y%m%d');
 const format = timeFormat('%b %d');
@@ -41,31 +48,20 @@ const colorScale = scaleOrdinal<string, string>({
   range: [blue, green, purple],
 });
 
-export default ({
-  width,
-  height,
-  events = false,
-  margin = {
-    top: 40,
-    right: 0,
-    bottom: 0,
-    left: 0,
-  },
-}: ShowProvidedProps) => {
-  if (width < 10) return null;
-
+export default function Example({ width, height, events = false, margin = defaultMargin }: Props) {
   // bounds
-  const xMax = width;
-  const yMax = height - margin.top - 100;
+  const xMax = width - margin.left - margin.right;
+  const yMax = height - margin.top - margin.bottom;
 
+  // update scale output dimensions
   dateScale.rangeRound([0, xMax]);
   cityScale.rangeRound([0, dateScale.bandwidth()]);
   tempScale.range([yMax, 0]);
 
-  return (
+  return width < 10 ? null : (
     <svg width={width} height={height}>
-      <rect x={0} y={0} width={width} height={height} fill={bg} rx={14} />
-      <Group top={margin.top}>
+      <rect x={0} y={0} width={width} height={height} fill={background} rx={14} />
+      <Group top={margin.top} left={margin.left}>
         <BarGroup<CityTemperature, string>
           data={data}
           keys={keys}
@@ -115,4 +111,4 @@ export default ({
       />
     </svg>
   );
-};
+}

--- a/packages/vx-demo/src/docs-v2/examples/vx-bargroup/index.tsx
+++ b/packages/vx-demo/src/docs-v2/examples/vx-bargroup/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from 'react-dom';
+import ParentSize from '@vx/responsive/lib/components/ParentSize';
+
+import Example from './Example';
+import './sandbox-styles.css';
+
+render(
+  <ParentSize>{({ width, height }) => <Example width={width} height={height} />}</ParentSize>,
+  document.getElementById('root'),
+);

--- a/packages/vx-demo/src/docs-v2/examples/vx-bargroup/package.json
+++ b/packages/vx-demo/src/docs-v2/examples/vx-bargroup/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@vx/demo-bargroup",
+  "description": "Standalone vx grouped bar demo.",
+  "main": "index.tsx",
+  "dependencies": {
+    "@babel/runtime": "^7.8.4",
+    "@types/react": "^16",
+    "@types/react-dom": "^16",
+    "@vx/axis": "latest",
+    "@vx/group": "latest",
+    "@vx/mock-data": "latest",
+    "@vx/responsive": "latest",
+    "@vx/scale": "latest",
+    "@vx/shape": "latest",
+    "d3-time-format": "^2.2.3",
+    "react": "^16",
+    "react-dom": "^16",
+    "react-scripts-ts": "3.1.0",
+    "typescript": "^3"
+  },
+  "keywords": [
+    "visualization",
+    "d3",
+    "react",
+    "vx",
+    "bargroup"
+  ]
+}

--- a/packages/vx-demo/src/docs-v2/examples/vx-bargroup/sandbox-styles.css
+++ b/packages/vx-demo/src/docs-v2/examples/vx-bargroup/sandbox-styles.css
@@ -1,0 +1,8 @@
+html,
+body,
+#root {
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+    'Open Sans', 'Helvetica Neue', sans-serif;
+  line-height: 2em;
+}

--- a/packages/vx-demo/src/pages/BarGroup.tsx
+++ b/packages/vx-demo/src/pages/BarGroup.tsx
@@ -1,17 +1,16 @@
 import React from 'react';
 import Show from '../components/Show';
-import BarGroup from '../components/tiles/BarGroup';
-import BarGroupSource from '!!raw-loader!../components/tiles/BarGroup';
+import BarGroup from '../docs-v2/examples/vx-bargroup/Example';
+import BarGroupSource from '!!raw-loader!../docs-v2/examples/vx-bargroup/Example';
 
-export default () => {
-  return (
-    <Show
-      events
-      margin={{ top: 80, right: 0, bottom: 0, left: 0 }}
-      component={BarGroup}
-      title="Bar Group"
-    >
-      {BarGroupSource}
-    </Show>
-  );
-};
+export default () => (
+  <Show
+    events
+    margin={{ top: 80, right: 0, bottom: 80, left: 0 }}
+    component={BarGroup}
+    title="Bar Group"
+    codeSandboxDirectoryName="vx-bargroup"
+  >
+    {BarGroupSource}
+  </Show>
+);

--- a/packages/vx-demo/src/pages/BarGroupHorizontal.tsx
+++ b/packages/vx-demo/src/pages/BarGroupHorizontal.tsx
@@ -1,17 +1,16 @@
 import React from 'react';
 import Show from '../components/Show';
-import BarGroupHorizontal from '../components/tiles/BarGroupHorizontal';
-import BarGroupHorizontalSource from '!!raw-loader!../components/tiles/BarGroupHorizontal';
+import BarGroupHorizontal from '../docs-v2/examples/vx-bargroup-horizontal/Example';
+import BarGroupHorizontalSource from '!!raw-loader!../docs-v2/examples/vx-bargroup-horizontal/Example';
 
-export default () => {
-  return (
-    <Show
-      events
-      margin={{ top: 45, left: 60, right: 20, bottom: 0 }}
-      component={BarGroupHorizontal}
-      title="Bar Group Horizontal"
-    >
-      {BarGroupHorizontalSource}
-    </Show>
-  );
-};
+export default () => (
+  <Show
+    events
+    margin={{ top: 45, left: 60, right: 20, bottom: 0 }}
+    component={BarGroupHorizontal}
+    title="Bar Group Horizontal"
+    codeSandboxDirectoryName="vx-bargroup-horizontal"
+  >
+    {BarGroupHorizontalSource}
+  </Show>
+);

--- a/packages/vx-demo/src/pages/BarGroupHorizontal.tsx
+++ b/packages/vx-demo/src/pages/BarGroupHorizontal.tsx
@@ -6,7 +6,7 @@ import BarGroupHorizontalSource from '!!raw-loader!../docs-v2/examples/vx-bargro
 export default () => (
   <Show
     events
-    margin={{ top: 45, left: 60, right: 20, bottom: 0 }}
+    margin={{ top: 45, left: 60, right: 20, bottom: 45 }}
     component={BarGroupHorizontal}
     title="Bar Group Horizontal"
     codeSandboxDirectoryName="vx-bargroup-horizontal"


### PR DESCRIPTION
#### :memo: Documentation
#### :house: Internal

Part of #624, re-writes the `BarGroup` and `BarGroupHorizontal` demos to link out to code-sandbox. Links: [BarGroup](https://codesandbox.io/s/github/hshoff/vx/tree/chris--bargroup/packages/vx-demo/src/docs-v2/examples/vx-bargroup), [BarGroupHorizontal](https://codesandbox.io/s/github/hshoff/vx/tree/chris--bargroup/packages/vx-demo/src/docs-v2/examples/vx-bargroup-horizontal) (update branches to master upon merge).

**BarGroup**
![image](https://user-images.githubusercontent.com/4496521/81624866-2903e300-93ac-11ea-9383-ec2f60cad411.png)

![image](https://user-images.githubusercontent.com/4496521/81624924-52247380-93ac-11ea-8b25-e9f37cadaf72.png)

**BarGroupHorizontal**
![image](https://user-images.githubusercontent.com/4496521/81624845-18536d00-93ac-11ea-88f4-561c8168c105.png)

![image](https://user-images.githubusercontent.com/4496521/81625077-b6dfce00-93ac-11ea-888a-428f6287eb93.png)

**Gallery**
![image](https://user-images.githubusercontent.com/4496521/81624829-0a055100-93ac-11ea-8ec1-1e427c8b5076.png)

@hshoff @kristw 