### PR TITLE
new(vx-demo): convert Network to codesandbox

### DIFF
--- a/packages/vx-demo/src/components/Gallery.tsx
+++ b/packages/vx-demo/src/components/Gallery.tsx
@@ -37,7 +37,9 @@ import Legends from '../docs-v2/examples/vx-legend/Example';
 import StatsPlot from '../docs-v2/examples/vx-stats/Example';
 import GeoCustom from '../docs-v2/examples/vx-geo-custom/Example';
 import GeoMercator from '../docs-v2/examples/vx-geo-mercator/Example';
-import Network from './tiles/Network';
+import Network, {
+  backgroundColor as networkBackground,
+} from '../docs-v2/examples/vx-network/Example';
 import Streamgraph, {
   BACKGROUND as streamgraphBackgroundColor,
 } from '../docs-v2/examples/vx-streamgraph/Example';
@@ -581,7 +583,7 @@ export default function Gallery() {
 
         <Tilt className="tilt" options={tiltOptions}>
           <Link href="/network">
-            <div className="gallery-item" style={{ background: '#272b4d' }}>
+            <div className="gallery-item" style={{ background: networkBackground }}>
               <div className="image">
                 <ParentSize>
                   {({ width, height }) => <Network width={width} height={height + detailsHeight} />}

--- a/packages/vx-demo/src/docs-v2/examples/vx-network/Example.tsx
+++ b/packages/vx-demo/src/docs-v2/examples/vx-network/Example.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import { Graph } from '@vx/network';
-import { ShowProvidedProps } from '../../types';
+
+type Props = {
+  width: number;
+  height: number;
+};
 
 const nodes = [
   { x: 50, y: 20 },
   { x: 200, y: 300 },
   { x: 300, y: 40 },
 ];
+
 const links = [
   { source: nodes[0], target: nodes[1] },
   { source: nodes[1], target: nodes[2] },
@@ -18,12 +23,13 @@ const graph = {
   links,
 };
 
-export default ({ width, height }: ShowProvidedProps) => {
-  if (width < 10) return <div />;
-  return (
+export const backgroundColor = '#272b4d';
+
+export default function Example({ width, height }: Props) {
+  return width < 10 ? null : (
     <svg width={width} height={height}>
-      <rect width={width} height={height} rx={14} fill="#272b4d" />
+      <rect width={width} height={height} rx={14} fill={backgroundColor} />
       <Graph graph={graph} />
     </svg>
   );
-};
+}

--- a/packages/vx-demo/src/docs-v2/examples/vx-network/index.tsx
+++ b/packages/vx-demo/src/docs-v2/examples/vx-network/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from 'react-dom';
+import ParentSize from '@vx/responsive/lib/components/ParentSize';
+
+import Example from './Example';
+import './sandbox-styles.css';
+
+render(
+  <ParentSize>{({ width, height }) => <Example width={width} height={height} />}</ParentSize>,
+  document.getElementById('root'),
+);

--- a/packages/vx-demo/src/docs-v2/examples/vx-network/package.json
+++ b/packages/vx-demo/src/docs-v2/examples/vx-network/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@vx/demo-network",
+  "description": "Standalone vx network demo.",
+  "main": "index.tsx",
+  "dependencies": {
+    "@babel/runtime": "^7.8.4",
+    "@types/react": "^16",
+    "@types/react-dom": "^16",
+    "@vx/responsive": "latest",
+    "@vx/network": "latest",
+    "react": "^16",
+    "react-dom": "^16",
+    "react-scripts-ts": "3.1.0",
+    "typescript": "^3"
+  },
+  "keywords": [
+    "visualization",
+    "d3",
+    "react",
+    "vx",
+    "network"
+  ]
+}

--- a/packages/vx-demo/src/docs-v2/examples/vx-network/sandbox-styles.css
+++ b/packages/vx-demo/src/docs-v2/examples/vx-network/sandbox-styles.css
@@ -1,0 +1,8 @@
+html,
+body,
+#root {
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+    'Open Sans', 'Helvetica Neue', sans-serif;
+  line-height: 2em;
+}

--- a/packages/vx-demo/src/pages/Network.tsx
+++ b/packages/vx-demo/src/pages/Network.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import Show from '../components/Show';
-import Network from '../components/tiles/Network';
-import NetworkSource from '!!raw-loader!../components/tiles/Network';
+import Network from '../docs-v2/examples/vx-network/Example';
+import NetworkSource from '!!raw-loader!../docs-v2/examples/vx-network/Example';
 
-export default () => {
-  return (
-    <Show component={Network} title="Network">
-      {NetworkSource}
-    </Show>
-  );
-};
+export default () => (
+  <Show component={Network} title="Network" codeSandboxDirectoryName="vx-network">
+    {NetworkSource}
+  </Show>
+);


### PR DESCRIPTION
#### :memo: Documentation
#### :house: Internal

Part of #624, re-writes the `Network` demo to link out to code-sandbox. 
[Link](https://codesandbox.io/s/github/hshoff/vx/tree/chris--sandbox-network/packages/vx-demo/src/docs-v2/examples/vx-network) (update branch to master upon merge).

![image](https://user-images.githubusercontent.com/4496521/81632009-0e3a6a00-93be-11ea-97f8-2f7792a7c15d.png)

![image](https://user-images.githubusercontent.com/4496521/81632033-1eeae000-93be-11ea-81d3-59c708e78f49.png)

@kristw @hshoff 