### PR TITLE
new(vx-demo): convert Dendrogram to codesandbox

### DIFF
--- a/packages/vx-demo/src/components/Gallery.tsx
+++ b/packages/vx-demo/src/components/Gallery.tsx
@@ -31,7 +31,10 @@ import Heatmap from './tiles/Heatmap';
 import LineRadial from '../docs-v2/examples/vx-shape-line-radial/Example';
 import Pies from '../docs-v2/examples/vx-shape-pie/Example';
 import Trees from './tiles/Trees';
-import Dendrograms from './tiles/Dendrograms';
+import Dendrogram, {
+  background as dendrogramBackground,
+  green as dendrogramText,
+} from '../docs-v2/examples/vx-dendrogram/Example';
 import Voronoi from '../docs-v2/examples/vx-voronoi/Example';
 import Legends from '../docs-v2/examples/vx-legend/Example';
 import StatsPlot from '../docs-v2/examples/vx-stats/Example';
@@ -439,15 +442,13 @@ export default function Gallery() {
         </Tilt>
         <Tilt className="tilt" options={tiltOptions}>
           <Link href="/dendrograms">
-            <div className="gallery-item" style={{ background: '#306c90' }}>
+            <div className="gallery-item" style={{ background: dendrogramBackground }}>
               <div className="image">
                 <ParentSize>
-                  {({ width, height }) => (
-                    <Dendrograms width={width} height={height + detailsHeight} />
-                  )}
+                  {({ width, height }) => <Dendrogram width={width} height={height} />}
                 </ParentSize>
               </div>
-              <div className="details" style={{ color: '#5dc26f' }}>
+              <div className="details" style={{ color: dendrogramText }}>
                 <div className="title">Dendrograms</div>
                 <div className="description">
                   <pre>{'<Hierarchy.Cluster /> + <Shape.LinkVertical />'}</pre>

--- a/packages/vx-demo/src/docs-v2/examples/vx-dendrogram/Example.tsx
+++ b/packages/vx-demo/src/docs-v2/examples/vx-dendrogram/Example.tsx
@@ -1,17 +1,16 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Group } from '@vx/group';
 import { Cluster, hierarchy } from '@vx/hierarchy';
 import { HierarchyPointNode, HierarchyPointLink } from '@vx/hierarchy/lib/types';
 import { LinkVertical } from '@vx/shape';
 import { LinearGradient } from '@vx/gradient';
-import { ShowProvidedProps } from '../../types';
 
 const citrus = '#ddf163';
 const white = '#ffffff';
-const green = '#79d259';
+export const green = '#79d259';
 const aqua = '#37ac8c';
 const merlinsbeard = '#f7f7f3';
-const bg = '#306c90';
+export const background = '#306c90';
 
 interface NodeShape {
   name: string;
@@ -62,7 +61,7 @@ function Node({ node }: { node: HierarchyPointNode<NodeShape> }) {
       {node.depth !== 0 && (
         <circle
           r={12}
-          fill={bg}
+          fill={background}
           stroke={isParent ? white : citrus}
           onClick={() => {
             alert(`clicked: ${JSON.stringify(node.data.name)}`);
@@ -98,7 +97,7 @@ function RootNode({ node }: { node: HierarchyPointNode<NodeShape> }) {
         fontFamily="Arial"
         textAnchor="middle"
         style={{ pointerEvents: 'none' }}
-        fill={bg}
+        fill={background}
       >
         {node.data.name}
       </text>
@@ -106,26 +105,17 @@ function RootNode({ node }: { node: HierarchyPointNode<NodeShape> }) {
   );
 }
 
-export default ({
-  width,
-  height,
-  margin = {
-    top: 40,
-    left: 0,
-    right: 0,
-    bottom: 110,
-  },
-}: ShowProvidedProps) => {
-  if (width < 10) return null;
+const defaultMargin = { top: 40, left: 0, right: 0, bottom: 110 };
 
-  const data = hierarchy<NodeShape>(clusterData);
+export default function Example({ width, height, margin = defaultMargin }: Props) {
+  const data = useMemo(() => hierarchy<NodeShape>(clusterData), []);
   const xMax = width - margin.left - margin.right;
   const yMax = height - margin.top - margin.bottom;
 
-  return (
+  return width < 10 ? null : (
     <svg width={width} height={height}>
       <LinearGradient id="top" from={green} to={aqua} />
-      <rect width={width} height={height} rx={14} fill={bg} />
+      <rect width={width} height={height} rx={14} fill={background} />
       <Cluster<NodeShape> root={data} size={[xMax, yMax]}>
         {cluster => (
           <Group top={margin.top} left={margin.left}>
@@ -147,4 +137,4 @@ export default ({
       </Cluster>
     </svg>
   );
-};
+}

--- a/packages/vx-demo/src/docs-v2/examples/vx-dendrogram/Example.tsx
+++ b/packages/vx-demo/src/docs-v2/examples/vx-dendrogram/Example.tsx
@@ -105,7 +105,13 @@ function RootNode({ node }: { node: HierarchyPointNode<NodeShape> }) {
   );
 }
 
-const defaultMargin = { top: 40, left: 0, right: 0, bottom: 110 };
+const defaultMargin = { top: 40, left: 0, right: 0, bottom: 40 };
+
+type Props = {
+  width: number;
+  height: number;
+  margin?: { top: number; right: number; bottom: number; left: number };
+};
 
 export default function Example({ width, height, margin = defaultMargin }: Props) {
   const data = useMemo(() => hierarchy<NodeShape>(clusterData), []);

--- a/packages/vx-demo/src/docs-v2/examples/vx-dendrogram/index.tsx
+++ b/packages/vx-demo/src/docs-v2/examples/vx-dendrogram/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from 'react-dom';
+import ParentSize from '@vx/responsive/lib/components/ParentSize';
+
+import Example from './Example';
+import './sandbox-styles.css';
+
+render(
+  <ParentSize>{({ width, height }) => <Example width={width} height={height} />}</ParentSize>,
+  document.getElementById('root'),
+);

--- a/packages/vx-demo/src/docs-v2/examples/vx-dendrogram/package.json
+++ b/packages/vx-demo/src/docs-v2/examples/vx-dendrogram/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@vx/demo-dendrogram",
+  "description": "Standalone vx dendrogram demo.",
+  "main": "index.tsx",
+  "dependencies": {
+    "@babel/runtime": "^7.8.4",
+    "@types/react": "^16",
+    "@types/react-dom": "^16",
+    "@vx/gradient": "latest",
+    "@vx/group": "latest",
+    "@vx/hierarchy": "latest",
+    "@vx/responsive": "latest",
+    "@vx/shape": "latest",
+    "react": "^16.8",
+    "react-dom": "^16.8",
+    "react-scripts-ts": "3.1.0",
+    "typescript": "^3"
+  },
+  "keywords": [
+    "visualization",
+    "d3",
+    "react",
+    "vx",
+    "hierarchy",
+    "dendrogram"
+  ]
+}

--- a/packages/vx-demo/src/docs-v2/examples/vx-dendrogram/sandbox-styles.css
+++ b/packages/vx-demo/src/docs-v2/examples/vx-dendrogram/sandbox-styles.css
@@ -1,0 +1,8 @@
+html,
+body,
+#root {
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+    'Open Sans', 'Helvetica Neue', sans-serif;
+  line-height: 2em;
+}

--- a/packages/vx-demo/src/pages/Dendrograms.tsx
+++ b/packages/vx-demo/src/pages/Dendrograms.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import Show from '../components/Show';
-import Dendrograms from '../components/tiles/Dendrograms';
-import DendrogramsSource from '!!raw-loader!../components/tiles/Dendrograms';
+import Dendrograms from '../docs-v2/examples/vx-dendrogram/Example';
+import DendrogramsSource from '!!raw-loader!../docs-v2/examples/vx-dendrogram/Example';
 
 export default () => {
   return (
     <Show
       events
       title="Dendrograms"
+      codeSandboxDirectoryName="vx-dendrogram"
       component={Dendrograms}
       margin={{
         top: 80,


### PR DESCRIPTION
#### :memo: Documentation
#### :house: Internal

Part of #624, re-writes the `Dendrogram` demo to link out to code-sandbox. 
[Link](https://codesandbox.io/s/github/hshoff/vx/tree/chris--sandbox-dendrogram/packages/vx-demo/src/docs-v2/examples/vx-dendrogram) (update branch to master upon merge).

![image](https://user-images.githubusercontent.com/4496521/81641142-2cf82b00-93d5-11ea-9ac6-c558fc98a971.png)

![image](https://user-images.githubusercontent.com/4496521/81641152-31244880-93d5-11ea-936e-f9d6aec53aa3.png)

@kristw @hshoff 