### PR TITLE
new(vx-demo): convert Areas, StackedAreas to codesandbox

### DIFF
--- a/packages/vx-demo/src/components/Gallery.tsx
+++ b/packages/vx-demo/src/components/Gallery.tsx
@@ -10,7 +10,7 @@ import Bars from '../docs-v2/examples/vx-bars/Example';
 import Curves from '../docs-v2/examples/vx-curve/Example';
 import Dots from './tiles/Dots';
 import Gradients from '../docs-v2/examples/vx-gradient/Example';
-import Areas from './tiles/Areas';
+import Area, { background as areaBackground } from '../docs-v2/examples/vx-area/Example';
 import StackedAreas, {
   background as stackedAreaBackground,
 } from '../docs-v2/examples/vx-stacked-areas/Example';
@@ -177,25 +177,14 @@ export default function Gallery() {
         </Tilt>
         <Tilt className="tilt" options={tiltOptions}>
           <Link href="/areas">
-            <div className="gallery-item" style={{ background: items[5] }}>
+            <div className="gallery-item" style={{ background: areaBackground }}>
               <div className="image">
                 <ParentSize>
-                  {({ width, height }) => (
-                    <Areas
-                      width={width}
-                      height={height + detailsHeight}
-                      margin={{
-                        top: 0,
-                        left: 0,
-                        right: 0,
-                        bottom: 80,
-                      }}
-                    />
-                  )}
+                  {({ width, height }) => <Area width={width} height={height} />}
                 </ParentSize>
               </div>
               <div className="details" style={{ zIndex: 1 }}>
-                <div className="title">Areas</div>
+                <div className="title">AreaClosed</div>
                 <div className="description">
                   <pre>{'<Shape.AreaClosed />'}</pre>
                 </div>

--- a/packages/vx-demo/src/components/Gallery.tsx
+++ b/packages/vx-demo/src/components/Gallery.tsx
@@ -11,7 +11,9 @@ import Curves from '../docs-v2/examples/vx-curve/Example';
 import Dots from './tiles/Dots';
 import Gradients from '../docs-v2/examples/vx-gradient/Example';
 import Areas from './tiles/Areas';
-import StackedAreas from './tiles/Stacked-Areas';
+import StackedAreas, {
+  background as stackedAreaBackground,
+} from '../docs-v2/examples/vx-stacked-areas/Example';
 import Glyphs, { primary as glyphTextColor } from '../docs-v2/examples/vx-glyph/Example';
 import Axis, {
   backgroundColor as axisBackgroundColor,
@@ -203,21 +205,10 @@ export default function Gallery() {
         </Tilt>
         <Tilt className="tilt" options={tiltOptions}>
           <Link href="/stacked-areas">
-            <div className="gallery-item" style={{ background: items[6] }}>
+            <div className="gallery-item" style={{ background: stackedAreaBackground }}>
               <div className="image">
                 <ParentSize>
-                  {({ width, height }) => (
-                    <StackedAreas
-                      width={width}
-                      height={height + detailsHeight}
-                      margin={{
-                        top: 0,
-                        left: 0,
-                        right: 0,
-                        bottom: 80,
-                      }}
-                    />
-                  )}
+                  {({ width, height }) => <StackedAreas width={width} height={height} />}
                 </ParentSize>
               </div>
               <div className="details" style={{ color: 'rgba(251, 224, 137, 1.000)' }}>

--- a/packages/vx-demo/src/docs-v2/examples/vx-area/index.tsx
+++ b/packages/vx-demo/src/docs-v2/examples/vx-area/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from 'react-dom';
+import ParentSize from '@vx/responsive/lib/components/ParentSize';
+
+import Example from './Example';
+import './sandbox-styles.css';
+
+render(
+  <ParentSize>{({ width, height }) => <Example width={width} height={height} />}</ParentSize>,
+  document.getElementById('root'),
+);

--- a/packages/vx-demo/src/docs-v2/examples/vx-area/package.json
+++ b/packages/vx-demo/src/docs-v2/examples/vx-area/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@vx/demo-area",
+  "description": "Standalone vx area demo.",
+  "main": "index.tsx",
+  "dependencies": {
+    "@babel/runtime": "^7.8.4",
+    "@types/react": "^16",
+    "@types/react-dom": "^16",
+    "@vx/curve": "latest",
+    "@vx/event": "latest",
+    "@vx/gradient": "latest",
+    "@vx/grid": "latest",
+    "@vx/mock-data": "latest",
+    "@vx/responsive": "latest",
+    "@vx/scale": "latest",
+    "@vx/shape": "latest",
+    "@vx/tooltip": "latest",
+    "d3-array": "^2.4.0",
+    "d3-time-format": "2.2.3",
+    "react": "^16.8",
+    "react-dom": "^16.8",
+    "react-scripts-ts": "3.1.0",
+    "typescript": "^3"
+  },
+  "keywords": [
+    "visualization",
+    "d3",
+    "react",
+    "vx",
+    "area"
+  ]
+}

--- a/packages/vx-demo/src/docs-v2/examples/vx-area/sandbox-styles.css
+++ b/packages/vx-demo/src/docs-v2/examples/vx-area/sandbox-styles.css
@@ -1,0 +1,8 @@
+html,
+body,
+#root {
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+    'Open Sans', 'Helvetica Neue', sans-serif;
+  line-height: 2em;
+}

--- a/packages/vx-demo/src/docs-v2/examples/vx-stacked-areas/Example.tsx
+++ b/packages/vx-demo/src/docs-v2/examples/vx-stacked-areas/Example.tsx
@@ -5,26 +5,31 @@ import { GradientOrangeRed } from '@vx/gradient';
 import browserUsage, { BrowserUsage } from '@vx/mock-data/lib/mocks/browserUsage';
 import { scaleTime, scaleLinear } from '@vx/scale';
 import { timeParse } from 'd3-time-format';
-import { ShowProvidedProps } from '../../types';
 
 type BrowserNames = keyof BrowserUsage;
 
 const data = browserUsage;
 const keys = Object.keys(data[0]).filter(k => k !== 'date') as BrowserNames[];
 const parseDate = timeParse('%Y %b %d');
+export const background = '#f38181';
 
 const getDate = (d: BrowserUsage) => (parseDate(d.date) as Date).valueOf();
 const getY0 = (d: SeriesPoint<BrowserUsage>) => d[0] / 100;
 const getY1 = (d: SeriesPoint<BrowserUsage>) => d[1] / 100;
 
-export default ({
+type Props = {
+  width: number;
+  height: number;
+  events?: boolean;
+  margin?: { top: number; right: number; bottom: number; left: number };
+};
+
+export default function Example({
   width,
   height,
   margin = { top: 0, right: 0, bottom: 0, left: 0 },
   events = false,
-}: ShowProvidedProps) => {
-  if (width < 10) return null;
-
+}: Props) {
   // bounds
   const yMax = height - margin.top - margin.bottom;
   const xMax = width - margin.left - margin.right;
@@ -38,10 +43,10 @@ export default ({
     range: [yMax, 0],
   });
 
-  return (
+  return width < 10 ? null : (
     <svg width={width} height={height}>
-      <GradientOrangeRed id="OrangeRed" />
-      <rect x={0} y={0} width={width} height={height} fill="#f38181" rx={14} />
+      <GradientOrangeRed id="stacked-area-orangered" />
+      <rect x={0} y={0} width={width} height={height} fill={background} rx={14} />
       <AreaStack
         top={margin.top}
         left={margin.left}
@@ -57,7 +62,7 @@ export default ({
               key={`stack-${stack.key}`}
               d={path(stack) || ''}
               stroke="transparent"
-              fill="url(#OrangeRed)"
+              fill="url(#stacked-area-orangered)"
               onClick={() => {
                 if (events) alert(`${stack.key}`);
               }}
@@ -67,4 +72,4 @@ export default ({
       </AreaStack>
     </svg>
   );
-};
+}

--- a/packages/vx-demo/src/docs-v2/examples/vx-stacked-areas/index.tsx
+++ b/packages/vx-demo/src/docs-v2/examples/vx-stacked-areas/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from 'react-dom';
+import ParentSize from '@vx/responsive/lib/components/ParentSize';
+
+import Example from './Example';
+import './sandbox-styles.css';
+
+render(
+  <ParentSize>{({ width, height }) => <Example width={width} height={height} />}</ParentSize>,
+  document.getElementById('root'),
+);

--- a/packages/vx-demo/src/docs-v2/examples/vx-stacked-areas/package.json
+++ b/packages/vx-demo/src/docs-v2/examples/vx-stacked-areas/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@vx/demo-stacked-areas",
+  "description": "Standalone vx stacked area demo.",
+  "main": "index.tsx",
+  "dependencies": {
+    "@babel/runtime": "^7.8.4",
+    "@types/react": "^16",
+    "@types/react-dom": "^16",
+    "@vx/gradient": "latest",
+    "@vx/mock-data": "latest",
+    "@vx/responsive": "latest",
+    "@vx/scale": "latest",
+    "@vx/shape": "latest",
+    "d3-time-format": "2.2.3",
+    "react": "^16",
+    "react-dom": "^16",
+    "react-scripts-ts": "3.1.0",
+    "typescript": "^3"
+  },
+  "keywords": [
+    "visualization",
+    "d3",
+    "react",
+    "vx",
+    "stackedarea"
+  ]
+}

--- a/packages/vx-demo/src/docs-v2/examples/vx-stacked-areas/sandbox-styles.css
+++ b/packages/vx-demo/src/docs-v2/examples/vx-stacked-areas/sandbox-styles.css
@@ -1,0 +1,8 @@
+html,
+body,
+#root {
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+    'Open Sans', 'Helvetica Neue', sans-serif;
+  line-height: 2em;
+}

--- a/packages/vx-demo/src/pages/Areas.tsx
+++ b/packages/vx-demo/src/pages/Areas.tsx
@@ -1,21 +1,10 @@
 import React from 'react';
 import Show from '../components/Show';
-import Areas from '../components/tiles/Areas';
-import AreasSource from '!!raw-loader!../components/tiles/Areas';
+import Area from '../docs-v2/examples/vx-area/Example';
+import AreaSource from '!!raw-loader!../docs-v2/examples/vx-area/Example';
 
-export default () => {
-  return (
-    <Show
-      component={Areas}
-      title="Areas"
-      margin={{
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-      }}
-    >
-      {AreasSource}
-    </Show>
-  );
-};
+export default () => (
+  <Show component={Area} title="Areas" codeSandboxDirectoryName="vx-area">
+    {AreaSource}
+  </Show>
+);

--- a/packages/vx-demo/src/pages/Stacked-Areas.tsx
+++ b/packages/vx-demo/src/pages/Stacked-Areas.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import Show from '../components/Show';
-import StackedAreas from '../components/tiles/Stacked-Areas';
-import StackedAreasSource from '!!raw-loader!../components/tiles/Stacked-Areas';
+import StackedAreas from '../docs-v2/examples/vx-stacked-areas/Example';
+import StackedAreasSource from '!!raw-loader!../docs-v2/examples/vx-stacked-areas/Example';
 
 export default () => {
   return (
     <Show
       component={StackedAreas}
       title="Stacked Areas"
+      codeSandboxDirectoryName="vx-stacked-areas"
       margin={{
         top: 0,
         left: 0,


### PR DESCRIPTION

#### :memo: Documentation
#### :house: Internal

Part of #624, re-writes the `Areas` and `StackedAreas` demos to link out to code-sandbox. 
Links: [StackedAreas](https://codesandbox.io/s/github/hshoff/vx/tree/chris--sandbox-stackedareas/packages/vx-demo/src/docs-v2/examples/vx-stacked-areas), [Areas](https://codesandbox.io/s/github/hshoff/vx/tree/chris--sandbox-stackedareas/packages/vx-demo/src/docs-v2/examples/vx-area) (update branch to master upon merge).

**StackedAreas**
![image](https://user-images.githubusercontent.com/4496521/81737631-3cb35600-944d-11ea-95e7-f17097b0220f.png)

![image](https://user-images.githubusercontent.com/4496521/81737742-6e2c2180-944d-11ea-976d-45c38410f34d.png)

**Areas**
![image](https://user-images.githubusercontent.com/4496521/81738704-f9f27d80-944e-11ea-898c-a41e8dbdfcc9.png)

![image](https://user-images.githubusercontent.com/4496521/81739053-869d3b80-944f-11ea-9706-f88d3f65bf0f.png)

@kristw @hshoff 