### PR TITLE
Fix tooltip with bounds

### DIFF
--- a/packages/vx-tooltip/Readme.md
+++ b/packages/vx-tooltip/Readme.md
@@ -86,7 +86,7 @@ component (i.e., ...restProps):
 | offsetRight | number | 10      | Vertical offset of the tooltip from the passed `top` value, functions as a vertical padding.                                                                                     |
 | style       | object | --      | Sets / overrides any styles on the tooltip container (including top and left)                                                                                                    |
 | children    | node   | --      | Sets the children of the tooltip, i.e., the actual content                                                                                                                       |
-| unstyled  | bool             | true    | Whether the tooltip should render with default styles or not                       |
+| unstyled  | bool             | true    | Whether the tooltip should use styles from the style prop or not              |
 
 Note that this component is positioned using a `transform`, so overriding `left` and `top` via
 styles may have no effect.

--- a/packages/vx-tooltip/Readme.md
+++ b/packages/vx-tooltip/Readme.md
@@ -69,7 +69,7 @@ accepts the following props, and will spread any additional props on the tooltip
 | className | string           | --      | Adds a class (in addition to `vx-tooltip-portal`) to the tooltip container    |
 | style     | object           | --      | Sets / overrides any styles on the tooltip container (including top and left) |
 | children  | node             | --      | Sets the children of the tooltip, i.e., the actual content                    |
-| unstyled  | bool             | true    | Whether the tooltip use styles from the style prop or not                     |
+| unstyled  | bool             | true    | Whether the tooltip should use styles from the style prop or not              |
 
 #### TooltipWithBounds
 
@@ -86,6 +86,7 @@ component (i.e., ...restProps):
 | offsetRight | number | 10      | Vertical offset of the tooltip from the passed `top` value, functions as a vertical padding.                                                                                     |
 | style       | object | --      | Sets / overrides any styles on the tooltip container (including top and left)                                                                                                    |
 | children    | node   | --      | Sets the children of the tooltip, i.e., the actual content                                                                                                                       |
+| unstyled  | bool             | true    | Whether the tooltip should render with default styles or not                       |
 
 Note that this component is positioned using a `transform`, so overriding `left` and `top` via
 styles may have no effect.

--- a/packages/vx-tooltip/src/tooltips/TooltipWithBounds.tsx
+++ b/packages/vx-tooltip/src/tooltips/TooltipWithBounds.tsx
@@ -34,7 +34,7 @@ function TooltipWithBounds({
   getRects,
   children,
   style = defaultStyles,
-  unstyled,
+  unstyled = false,
   ...otherProps
 }: Props) {
   let left = initialLeft;
@@ -62,6 +62,7 @@ function TooltipWithBounds({
         transform: `translate(${left}px, ${top}px)`,
         ...(!unstyled && style),
       }}
+      unstyled={unstyled}
       {...otherProps}
     >
       {children}

--- a/packages/vx-tooltip/src/tooltips/TooltipWithBounds.tsx
+++ b/packages/vx-tooltip/src/tooltips/TooltipWithBounds.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { withBoundingRects } from '@vx/bounds';
 
-import Tooltip from './Tooltip';
+import Tooltip, { TooltipProps, defaultStyles } from './Tooltip';
 
 type RectShape = {
   top: number;
@@ -16,14 +16,6 @@ type WithBoundingRectsProps = {
   getRects?: () => RectShape;
   rect?: RectShape;
   parentRect?: RectShape;
-};
-
-type TooltipProps = {
-  left?: number;
-  top?: number;
-  className?: string;
-  style?: React.CSSProperties;
-  children?: React.ReactNode;
 };
 
 type Props = {
@@ -42,6 +34,7 @@ function TooltipWithBounds({
   getRects,
   children,
   style,
+  unstyled,
   ...otherProps
 }: Props) {
   let left = initialLeft;
@@ -64,7 +57,12 @@ function TooltipWithBounds({
 
   return (
     <Tooltip
-      style={{ top: 0, transform: `translate(${left}px, ${top}px)`, ...style }}
+      style={{
+        top: 0,
+        transform: `translate(${left}px, ${top}px)`,
+        ...style,
+        ...(!unstyled && defaultStyles),
+      }}
       {...otherProps}
     >
       {children}

--- a/packages/vx-tooltip/src/tooltips/TooltipWithBounds.tsx
+++ b/packages/vx-tooltip/src/tooltips/TooltipWithBounds.tsx
@@ -33,7 +33,7 @@ function TooltipWithBounds({
   parentRect,
   getRects,
   children,
-  style,
+  style = defaultStyles,
   unstyled,
   ...otherProps
 }: Props) {
@@ -60,8 +60,7 @@ function TooltipWithBounds({
       style={{
         top: 0,
         transform: `translate(${left}px, ${top}px)`,
-        ...style,
-        ...(!unstyled && defaultStyles),
+        ...(!unstyled && style),
       }}
       {...otherProps}
     >

--- a/packages/vx-tooltip/test/TooltipWithBounds.test.tsx
+++ b/packages/vx-tooltip/test/TooltipWithBounds.test.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { TooltipWithBounds, defaultStyles, Tooltip } from '../src';
 
+type CSSPropertiesKey = keyof React.CSSProperties;
+type CSSPropertiesValue = React.CSSProperties[CSSPropertiesKey];
+
 describe('<TooltipWithBounds />', () => {
   test('it should be defined', () => {
     expect(TooltipWithBounds).toBeDefined();
@@ -10,15 +13,17 @@ describe('<TooltipWithBounds />', () => {
   it('should render the Tooltip with default styles by default', () => {
     const wrapper = mount(<TooltipWithBounds>Hello</TooltipWithBounds>);
     const styles = wrapper.find(Tooltip).props().style!;
-    Object.entries(defaultStyles).forEach(([key, value]) => {
-      expect(styles[key]).toBe(value);
-    });
+    Object.entries(defaultStyles).forEach(
+      ([key, value]: [CSSPropertiesKey, CSSPropertiesValue]) => {
+        expect(styles[key]).toBe(value);
+      },
+    );
   });
 
   it('should render the tooltip without default styles if unstyled is set to true', () => {
     const wrapper = mount(<TooltipWithBounds unstyled>Hello</TooltipWithBounds>);
     const styles = wrapper.find(Tooltip).props().style!;
-    Object.keys(defaultStyles).forEach(key => {
+    Object.keys(defaultStyles).forEach((key: CSSPropertiesKey) => {
       expect(styles[key]).toBeUndefined();
     });
   });

--- a/packages/vx-tooltip/test/TooltipWithBounds.test.tsx
+++ b/packages/vx-tooltip/test/TooltipWithBounds.test.tsx
@@ -1,7 +1,25 @@
-import { TooltipWithBounds } from '../src';
+import React from 'react';
+import { mount } from 'enzyme';
+import { TooltipWithBounds, defaultStyles, Tooltip } from '../src';
 
 describe('<TooltipWithBounds />', () => {
   test('it should be defined', () => {
     expect(TooltipWithBounds).toBeDefined();
+  });
+
+  it('should render the Tooltip with default styles by default', () => {
+    const wrapper = mount(<TooltipWithBounds>Hello</TooltipWithBounds>);
+    const styles = wrapper.find(Tooltip).prop('style');
+    Object.entries(defaultStyles).forEach(([key, value]) => {
+      expect(styles[key]).toBe(value);
+    });
+  });
+
+  it('should render the tooltip without default styles if unstyled is set to true', () => {
+    const wrapper = mount(<TooltipWithBounds unstyled>Hello</TooltipWithBounds>);
+    const styles = wrapper.find(Tooltip).prop('style');
+    Object.keys(defaultStyles).forEach(key => {
+      expect(styles[key]).toBeUndefined();
+    });
   });
 });

--- a/packages/vx-tooltip/test/TooltipWithBounds.test.tsx
+++ b/packages/vx-tooltip/test/TooltipWithBounds.test.tsx
@@ -9,7 +9,7 @@ describe('<TooltipWithBounds />', () => {
 
   it('should render the Tooltip with default styles by default', () => {
     const wrapper = mount(<TooltipWithBounds>Hello</TooltipWithBounds>);
-    const styles = wrapper.find(Tooltip).prop('style');
+    const styles = wrapper.find(Tooltip).props().style!;
     Object.entries(defaultStyles).forEach(([key, value]) => {
       expect(styles[key]).toBe(value);
     });
@@ -17,7 +17,7 @@ describe('<TooltipWithBounds />', () => {
 
   it('should render the tooltip without default styles if unstyled is set to true', () => {
     const wrapper = mount(<TooltipWithBounds unstyled>Hello</TooltipWithBounds>);
-    const styles = wrapper.find(Tooltip).prop('style');
+    const styles = wrapper.find(Tooltip).props().style!;
     Object.keys(defaultStyles).forEach(key => {
       expect(styles[key]).toBeUndefined();
     });

--- a/packages/vx-tooltip/test/TooltipWithBounds.test.tsx
+++ b/packages/vx-tooltip/test/TooltipWithBounds.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { mount } from 'enzyme';
-import { TooltipWithBounds, defaultStyles, Tooltip } from '../src';
+import { shallow } from 'enzyme';
+import { TooltipWithBounds, defaultStyles } from '../src';
 
 describe('<TooltipWithBounds />', () => {
   test('it should be defined', () => {
@@ -8,16 +8,20 @@ describe('<TooltipWithBounds />', () => {
   });
 
   it('should render the Tooltip with default styles by default', () => {
-    const wrapper = mount(<TooltipWithBounds>Hello</TooltipWithBounds>);
-    const styles = wrapper.find(Tooltip).props().style as any;
+    const wrapper = shallow(<TooltipWithBounds>Hello</TooltipWithBounds>, {
+      disableLifecycleMethods: true,
+    }).dive();
+    const styles = wrapper.find('Tooltip').props().style as any;
     Object.entries(defaultStyles).forEach(([key, value]) => {
       expect(styles[key]).toBe(value);
     });
   });
 
   it('should render the tooltip without default styles if unstyled is set to true', () => {
-    const wrapper = mount(<TooltipWithBounds unstyled>Hello</TooltipWithBounds>);
-    const styles = wrapper.find(Tooltip).props().style as any;
+    const wrapper = shallow(<TooltipWithBounds unstyled>Hello</TooltipWithBounds>, {
+      disableLifecycleMethods: true,
+    }).dive();
+    const styles = wrapper.find('Tooltip').props().style as any;
     Object.keys(defaultStyles).forEach(key => {
       expect(styles[key]).toBeUndefined();
     });

--- a/packages/vx-tooltip/test/TooltipWithBounds.test.tsx
+++ b/packages/vx-tooltip/test/TooltipWithBounds.test.tsx
@@ -2,9 +2,6 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { TooltipWithBounds, defaultStyles, Tooltip } from '../src';
 
-type CSSPropertiesKey = keyof React.CSSProperties;
-type CSSPropertiesValue = React.CSSProperties[CSSPropertiesKey];
-
 describe('<TooltipWithBounds />', () => {
   test('it should be defined', () => {
     expect(TooltipWithBounds).toBeDefined();
@@ -12,18 +9,16 @@ describe('<TooltipWithBounds />', () => {
 
   it('should render the Tooltip with default styles by default', () => {
     const wrapper = mount(<TooltipWithBounds>Hello</TooltipWithBounds>);
-    const styles = wrapper.find(Tooltip).props().style!;
-    Object.entries(defaultStyles).forEach(
-      ([key, value]: [CSSPropertiesKey, CSSPropertiesValue]) => {
-        expect(styles[key]).toBe(value);
-      },
-    );
+    const styles = wrapper.find(Tooltip).props().style as any;
+    Object.entries(defaultStyles).forEach(([key, value]) => {
+      expect(styles[key]).toBe(value);
+    });
   });
 
   it('should render the tooltip without default styles if unstyled is set to true', () => {
     const wrapper = mount(<TooltipWithBounds unstyled>Hello</TooltipWithBounds>);
-    const styles = wrapper.find(Tooltip).props().style!;
-    Object.keys(defaultStyles).forEach((key: CSSPropertiesKey) => {
+    const styles = wrapper.find(Tooltip).props().style as any;
+    Object.keys(defaultStyles).forEach(key => {
       expect(styles[key]).toBeUndefined();
     });
   });


### PR DESCRIPTION
#### :boom: Breaking Changes

-

#### :rocket: Enhancements

- Add unstyled prop to TooltipWithbounds

#### :memo: Documentation

- Update Tooltips documentation

#### :bug: Bug Fix

- Make Typescript happy when the `unstyled` prop is passed to `TooltipWithBounds`

#### :house: Internal

-
Fixes https://github.com/hshoff/vx/issues/691