### PR TITLE
fix getting coords from touch event for y typo

### DIFF
--- a/packages/vx-event/src/getXAndYFromEvent.ts
+++ b/packages/vx-event/src/getXAndYFromEvent.ts
@@ -10,7 +10,7 @@ export default function getXAndYFromEvent(event?: EventType) {
     return event.changedTouches.length > 0
       ? {
           x: event.changedTouches[0].clientX,
-          y: event.changedTouches[0].clientX,
+          y: event.changedTouches[0].clientY,
         }
       : { ...DEFAULT_POINT };
   }


### PR DESCRIPTION
#### :bug: Bug Fix
Zoom component's zoom.dragMove worked incorrectly on touchmove event, moving only alongside 135 degree angle. Fixing the typo fixes this problem.