### PR TITLE
docs(Gallery): add package filters

### DIFF
--- a/packages/vx-demo/src/components/Gallery/AreaTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/AreaTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Area, { AreaProps, accentColor, background } from '../../sandboxes/vx-area/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-area/package.json';
+
 const tileStyles = { background };
 const detailsStyles = { color: accentColor };
 

--- a/packages/vx-demo/src/components/Gallery/AxisTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/AxisTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Axis, { AxisProps, backgroundColor, labelColor } from '../../sandboxes/vx-axis/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-axis/package.json';
+
 const tileStyles = { backgroundColor };
 const detailsStyles = { color: labelColor };
 

--- a/packages/vx-demo/src/components/Gallery/BarGroupHorizontalTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/BarGroupHorizontalTile.tsx
@@ -6,6 +6,8 @@ import BarGroupHorizontal, {
 } from '../../sandboxes/vx-bargroup-horizontal/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-bargroup-horizontal/package.json';
+
 const tileStyles = { background };
 const detailsStyles = { color: green };
 const exampleProps = { margin: { top: 20, bottom: 70, left: 50, right: 20 } };

--- a/packages/vx-demo/src/components/Gallery/BarGroupTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/BarGroupTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import BarGroup, { BarGroupProps, background, green } from '../../sandboxes/vx-bargroup/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-bargroup/package.json';
+
 const tileStyles = { background };
 const detailsStyles = { color: green };
 

--- a/packages/vx-demo/src/components/Gallery/BarStackHorizontalTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/BarStackHorizontalTile.tsx
@@ -6,6 +6,8 @@ import BarStackHorizontal, {
 } from '../../sandboxes/vx-barstack-horizontal/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-barstack-horizontal/package.json';
+
 const tileStyles = { background };
 const detailsStyles = { color: purple3, zIndex: 1 };
 

--- a/packages/vx-demo/src/components/Gallery/BarStackTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/BarStackTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import BarStack, { BarStackProps, background, purple3 } from '../../sandboxes/vx-barstack/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-barstack/package.json';
+
 const tileStyles = { background };
 const detailsStyles = { color: purple3, zIndex: 1 };
 

--- a/packages/vx-demo/src/components/Gallery/BarsTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/BarsTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Bars, { BarsProps } from '../../sandboxes/vx-bars/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-bars/package.json';
+
 const tileStyles = { background: '#5290e7' };
 const detailsStyles = { color: 'rgba(25, 231, 217, 1)' };
 

--- a/packages/vx-demo/src/components/Gallery/BrushTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/BrushTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Brush, { BrushProps, background, accentColor } from '../../sandboxes/vx-brush/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-brush/package.json';
+
 const tileStyles = { border: `1px solid ${accentColor}` };
 const detailsStyles = { color: background };
 const exampleProps = { compact: true, margin: { top: 10, left: 50, bottom: 60, right: 20 } };

--- a/packages/vx-demo/src/components/Gallery/ChordTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/ChordTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Chord, { ChordProps } from '../../sandboxes/vx-chord/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-chord/package.json';
+
 const tileStyles = { background: '#e4e3d8' };
 const detailsStyles = { color: '#111' };
 

--- a/packages/vx-demo/src/components/Gallery/CurvesTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/CurvesTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Curve, { CurveProps, gradientColor1 } from '../../sandboxes/vx-curve/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-curve/package.json';
+
 const tileStyles = { border: '1px solid lightgray' };
 const detailsStyles = { color: gradientColor1 };
 const exampleProps = { showControls: false };

--- a/packages/vx-demo/src/components/Gallery/DendrogramsTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/DendrogramsTile.tsx
@@ -6,6 +6,8 @@ import Dendrogram, {
 } from '../../sandboxes/vx-dendrogram/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-dendrogram/package.json';
+
 const tileStyles = { background };
 const detailsStyles = { color: green };
 const exampleProps = { margin: { top: 40, left: 0, right: 0, bottom: 90 } };

--- a/packages/vx-demo/src/components/Gallery/DotsTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/DotsTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Dots, { DotsProps } from '../../sandboxes/vx-dots/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-dots/package.json';
+
 const tileStyles = { background: '#fd6e7f' };
 const detailsStyles = { color: '#f6c431' };
 const exampleProps = { showControls: false };

--- a/packages/vx-demo/src/components/Gallery/DragIITile.tsx
+++ b/packages/vx-demo/src/components/Gallery/DragIITile.tsx
@@ -3,6 +3,8 @@ import DragII, { DragIIProps } from '../../sandboxes/vx-drag-ii/Example';
 import GalleryTile from '../GalleryTile';
 import drawData from '../util/drawData';
 
+export { default as packageJson } from '../../sandboxes/vx-drag-ii/package.json';
+
 const tileStyles = { background: '#04002b', borderRadius: 14 };
 const detailsStyles = { color: '#ff614e', zIndex: 1 };
 const exampleProps = { data: drawData };

--- a/packages/vx-demo/src/components/Gallery/DragITile.tsx
+++ b/packages/vx-demo/src/components/Gallery/DragITile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import DragI, { DragIProps } from '../../sandboxes/vx-drag-i/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-drag-i/package.json';
+
 const tileStyles = { background: '#c4c3cb', borderRadius: 14 };
 const detailsStyles = { color: '#6437d6', zIndex: 1 };
 

--- a/packages/vx-demo/src/components/Gallery/GeoCustomTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/GeoCustomTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import GeoCustom, { GeoCustomProps, background } from '../../sandboxes/vx-geo-custom/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-geo-custom/package.json';
+
 const tileStyles = { background };
 const detailsStyles = { color: '#019ece' };
 const exampleProps = { events: false };

--- a/packages/vx-demo/src/components/Gallery/GeoMercatorTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/GeoMercatorTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import GeoMercator, { GeoMercatorProps, background } from '../../sandboxes/vx-geo-mercator/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-geo-mercator/package.json';
+
 const tileStyles = { background };
 const detailsStyles = { color: '#f63a48' };
 

--- a/packages/vx-demo/src/components/Gallery/GlyphsTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/GlyphsTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Glyph, { GlyphProps, primaryColor, secondaryColor } from '../../sandboxes/vx-glyph/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-glyph/package.json';
+
 const tileStyles = { background: secondaryColor };
 const detailsStyles = { color: primaryColor };
 const exampleProps = { margin: { top: 30, left: 10, right: 10, bottom: 80 } };

--- a/packages/vx-demo/src/components/Gallery/GradientsTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/GradientsTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Gradient, { GradientProps } from '../../sandboxes/vx-gradient/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-gradient/package.json';
+
 const tileStyles = { background: 'white', boxShadow: '0 1px 6px rgba(0,0,0,0.1)' };
 const detailsStyles = { color: '#333' };
 

--- a/packages/vx-demo/src/components/Gallery/HeatmapsTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/HeatmapsTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Heatmap, { HeatmapProps, background } from '../../sandboxes/vx-heatmap/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-heatmap/package.json';
+
 const tileStyles = { background };
 const detailsStyles = { color: 'rgba(255,255,255,0.3)' };
 

--- a/packages/vx-demo/src/components/Gallery/LegendsTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/LegendsTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Legends from '../../sandboxes/vx-legend/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-legend/package.json';
+
 const tileStyles = { background: 'black' };
 const detailsStyles = { color: '#aaa' };
 

--- a/packages/vx-demo/src/components/Gallery/LineRadialTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/LineRadialTile.tsx
@@ -6,6 +6,8 @@ import LineRadial, {
 } from '../../sandboxes/vx-shape-line-radial/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-shape-line-radial/package.json';
+
 const tileStyles = { background };
 const detailsStyles = { color: blue };
 const exampleProps = { animate: false };

--- a/packages/vx-demo/src/components/Gallery/LinkTypesTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/LinkTypesTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import LinkTypes, { LinkTypesProps } from '../../sandboxes/vx-linktypes/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-linktypes/package.json';
+
 const tileStyles = { background: '#272b4d' };
 const detailsStyles = { color: '#269688' };
 

--- a/packages/vx-demo/src/components/Gallery/NetworkTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/NetworkTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Network, { NetworkProps, background } from '../../sandboxes/vx-network/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-network/package.json';
+
 const tileStyles = { background };
 
 export default function NetworkTile() {

--- a/packages/vx-demo/src/components/Gallery/PackTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/PackTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Pack, { PackProps } from '../../sandboxes/vx-pack/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-pack/package.json';
+
 const tileStyles = { background: 'white', boxShadow: 'rgba(0, 0, 0, 0.1) 0px 1px 6px' };
 const detailsStyles = { color: '#fd6c6f' };
 

--- a/packages/vx-demo/src/components/Gallery/PatternsTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/PatternsTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Patterns, { PatternProps } from '../../sandboxes/vx-pattern/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-pattern/package.json';
+
 const tileStyles = { background: '#f5f2e3' };
 const detailsStyles = { color: '#333' };
 

--- a/packages/vx-demo/src/components/Gallery/PiesTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/PiesTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Pie, { PieProps } from '../../sandboxes/vx-shape-pie/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-shape-pie/package.json';
+
 const tileStyles = { background: '#7f82e3' };
 const detailsStyles = { color: 'rgb(93,30,91)' };
 const exampleProps = { animate: false, margin: { top: 20, right: 20, bottom: 80, left: 20 } };

--- a/packages/vx-demo/src/components/Gallery/PolygonsTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/PolygonsTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Polygon, { PolygonProps, background } from '../../sandboxes/vx-polygons/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-polygons/package.json';
+
 const tileStyles = { background };
 const detailsStyles = { color: 'white' };
 const exampleProps = { margin: { top: 10, right: 0, bottom: 76, left: 0 } };

--- a/packages/vx-demo/src/components/Gallery/RadarTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/RadarTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Radar, { RadarProps, background, pumpkin } from '../../sandboxes/vx-radar/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-radar/package.json';
+
 const tileStyles = { background };
 const detailsStyles = { color: pumpkin };
 

--- a/packages/vx-demo/src/components/Gallery/ResponsiveTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/ResponsiveTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Responsive, { ResponsiveProps } from '../../sandboxes/vx-responsive/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-responsive/package.json';
+
 const tileStyles = { background: 'white' };
 const detailsStyles = {
   color: '#232323',

--- a/packages/vx-demo/src/components/Gallery/StackedAreasTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/StackedAreasTile.tsx
@@ -5,6 +5,8 @@ import StackedAreas, {
 } from '../../sandboxes/vx-stacked-areas/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-stacked-areas/package.json';
+
 const tileStyles = { background };
 const detailsStyles = { color: 'rgba(251, 224, 137, 1.000)' };
 

--- a/packages/vx-demo/src/components/Gallery/StatsPlotTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/StatsPlotTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import StatsPlot, { StatsPlotProps } from '../../sandboxes/vx-stats/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-stats/package.json';
+
 const tileStyles = { background: '#8a88e3' };
 const detailsStyles = { color: '#ffffff', zIndex: 1 };
 

--- a/packages/vx-demo/src/components/Gallery/StreamGraphTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/StreamGraphTile.tsx
@@ -5,6 +5,8 @@ import StreamGraph, {
 } from '../../sandboxes/vx-streamgraph/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-streamgraph/package.json';
+
 const tileStyles = { background };
 const detailsStyles = { color: 'rgb(93,30,91)' };
 const exampleProps = { animate: false };

--- a/packages/vx-demo/src/components/Gallery/TextTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/TextTile.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import GalleryTile from '../GalleryTile';
 
+export const packageJson = { name: 'vx-text', dependencies: { '@vx/text': 'current' } };
+
 const tileStyles = { background: 'white', border: '1px solid lightgray', borderRadius: '14px' };
 const detailsStyles = { color: '#232323', zIndex: 1 };
 const Text = () => (

--- a/packages/vx-demo/src/components/Gallery/ThresholdTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/ThresholdTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Threshold, { ThresholdProps, background } from '../../sandboxes/vx-threshold/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-threshold/package.json';
+
 const tileStyles = { background };
 const detailsStyles = { color: '#111' };
 const exampleProps = { margin: { top: 40, left: 40, right: 20, bottom: 30 } };

--- a/packages/vx-demo/src/components/Gallery/TreemapTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/TreemapTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Treemap, { TreemapProps, background, color1 } from '../../sandboxes/vx-treemap/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-treemap/package.json';
+
 const tileStyles = { background };
 const detailsStyles = { color: color1 };
 const exampleProps = { margin: { top: 0, left: 10, right: 10, bottom: 76 } };

--- a/packages/vx-demo/src/components/Gallery/TreesTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/TreesTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Tree, { TreeProps, background } from '../../sandboxes/vx-tree/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-tree/package.json';
+
 const tileStyles = { background };
 const detailsStyles = { color: '#269688' };
 const exampleProps = { margin: { top: 10, left: 30, right: 40, bottom: 76 } };

--- a/packages/vx-demo/src/components/Gallery/VoronoiTile.tsx
+++ b/packages/vx-demo/src/components/Gallery/VoronoiTile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Voronoi, { VoronoiProps } from '../../sandboxes/vx-voronoi/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-voronoi/package.json';
+
 const tileStyles = {
   background: '#eb6d88',
   borderRadius: 14,

--- a/packages/vx-demo/src/components/Gallery/ZoomITile.tsx
+++ b/packages/vx-demo/src/components/Gallery/ZoomITile.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import ZoomI, { ZoomIProps } from '../../sandboxes/vx-zoom-i/Example';
 import GalleryTile from '../GalleryTile';
 
+export { default as packageJson } from '../../sandboxes/vx-zoom-i/package.json';
+
 const tileStyles = { background: '#0a0a0a' };
 const detailsStyles = { color: '#ccc' };
 

--- a/packages/vx-demo/src/components/Gallery/index.tsx
+++ b/packages/vx-demo/src/components/Gallery/index.tsx
@@ -1,44 +1,51 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Tilt from 'react-tilt';
 
-import AreaTile from './AreaTile';
-import AxisTile from './AxisTile';
-import BarGroupHorizontalTile from './BarGroupHorizontalTile';
-import BarGroupTile from './BarGroupTile';
-import BarStackHorizontalTile from './BarStackHorizontalTile';
-import BarStackTile from './BarStackTile';
-import BarsTile from './BarsTile';
-import BrushTile from './BrushTile';
-import ChordTile from './ChordTile';
-import CurvesTile from './CurvesTile';
-import DendrogramsTile from './DendrogramsTile';
-import DotsTile from './DotsTile';
-import DragIITile from './DragIITile';
-import DragITile from './DragITile';
-import GeoCustomTile from './GeoCustomTile';
-import GeoMercatorTile from './GeoMercatorTile';
-import GlyphsTile from './GlyphsTile';
-import GradientsTile from './GradientsTile';
-import HeatmapsTile from './HeatmapsTile';
-import LegendsTile from './LegendsTile';
-import LineRadialTile from './LineRadialTile';
-import LinkTypesTile from './LinkTypesTile';
-import NetworkTile from './NetworkTile';
-import PackTile from './PackTile';
-import PatternsTile from './PatternsTile';
-import PiesTile from './PiesTile';
-import PolygonsTile from './PolygonsTile';
-import RadarTile from './RadarTile';
-import ResponsiveTile from './ResponsiveTile';
-import StackedAreasTile from './StackedAreasTile';
-import StatsPlotTile from './StatsPlotTile';
-import StreamGraphTile from './StreamGraphTile';
-import TextTile from './TextTile';
-import ThresholdTile from './ThresholdTile';
-import TreemapTile from './TreemapTile';
-import TreesTile from './TreesTile';
-import VoronoiTile from './VoronoiTile';
-import ZoomITile from './ZoomITile';
+import * as AreaTile from './AreaTile';
+import * as AxisTile from './AxisTile';
+import * as BarGroupHorizontalTile from './BarGroupHorizontalTile';
+import * as BarGroupTile from './BarGroupTile';
+import * as BarStackHorizontalTile from './BarStackHorizontalTile';
+import * as BarStackTile from './BarStackTile';
+import * as BarsTile from './BarsTile';
+import * as BrushTile from './BrushTile';
+import * as ChordTile from './ChordTile';
+import * as CurvesTile from './CurvesTile';
+import * as DendrogramsTile from './DendrogramsTile';
+import * as DotsTile from './DotsTile';
+import * as DragIITile from './DragIITile';
+import * as DragITile from './DragITile';
+import * as GeoCustomTile from './GeoCustomTile';
+import * as GeoMercatorTile from './GeoMercatorTile';
+import * as GlyphsTile from './GlyphsTile';
+import * as GradientsTile from './GradientsTile';
+import * as HeatmapsTile from './HeatmapsTile';
+import * as LegendsTile from './LegendsTile';
+import * as LineRadialTile from './LineRadialTile';
+import * as LinkTypesTile from './LinkTypesTile';
+import * as NetworkTile from './NetworkTile';
+import * as PackTile from './PackTile';
+import * as PatternsTile from './PatternsTile';
+import * as PiesTile from './PiesTile';
+import * as PolygonsTile from './PolygonsTile';
+import * as RadarTile from './RadarTile';
+import * as ResponsiveTile from './ResponsiveTile';
+import * as StackedAreasTile from './StackedAreasTile';
+import * as StatsPlotTile from './StatsPlotTile';
+import * as StreamGraphTile from './StreamGraphTile';
+import * as TextTile from './TextTile';
+import * as ThresholdTile from './ThresholdTile';
+import * as TreemapTile from './TreemapTile';
+import * as TreesTile from './TreesTile';
+import * as VoronoiTile from './VoronoiTile';
+import * as ZoomITile from './ZoomITile';
+import { VxPackage } from '../../types';
+import exampleToVxDependencyLookup, {
+  vxPackages,
+} from '../../sandboxes/exampleToVxDependencyLookup';
+
+const tiltOptions = { max: 8, scale: 1 };
+const columnCount = 3;
 
 const tiles = [
   AreaTile,
@@ -80,24 +87,93 @@ const tiles = [
   VoronoiTile,
   ZoomITile,
 ];
-const tiltOptions = { max: 8, scale: 1 };
 
 export default function Gallery() {
+  const [activePackageFilter, setActivePackageFilter] = useState<VxPackage | null>(null);
+  const filteredTiles = activePackageFilter
+    ? tiles.filter(Tile =>
+        exampleToVxDependencyLookup[Tile.packageJson.name]?.has(activePackageFilter),
+      )
+    : tiles;
+
   return (
     <>
       <div className="gallery">
-        {tiles.map((Tile, i) => (
-          <Tilt key={`tile-${i}`} className="tilt" options={tiltOptions}>
-            <Tile />
-          </Tilt>
-        ))}
+        <div className="filters">
+          <h6>Examples by package</h6>
+          {vxPackages.map(vxPackage => (
+            <button
+              key={vxPackage}
+              className={activePackageFilter === vxPackage ? 'emphasize' : undefined}
+              onClick={() =>
+                setActivePackageFilter(activePackageFilter === vxPackage ? null : vxPackage)
+              }
+            >
+              @vx/{vxPackage}
+            </button>
+          ))}
+        </div>
+        <div className="grid">
+          {filteredTiles.map((Tile, i) => (
+            <Tilt key={`tile-${i}`} className="tilt" options={tiltOptions}>
+              <Tile.default />
+            </Tilt>
+          ))}
+        </div>
       </div>
       <style jsx>{`
         .gallery {
+          display: flex;
+          flex-direction: row;
+        }
+        .grid {
+          flex-grow: 1;
           display: grid;
           grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
           overflow-x: hidden;
-          padding-bottom: 20px;
+          padding-bottom: 40px;
+        }
+        .filters {
+          margin-right: 24px;
+          width: 150px;
+          flex-shrink: 0;
+        }
+        h6 {
+          margin: 0 4px 0 0;
+        }
+        button {
+          display: block;
+          cursor: pointer;
+          border: none;
+          outline: none;
+          background: transparent;
+          color: #fc2e1c;
+          padding: 0;
+          margin: 4px 4px 12px 0;
+        }
+        .emphasize {
+          font-weight: bold;
+        }
+        @media (min-width: 800px) {
+          .emphasize::before {
+            content: '';
+            padding-left: 4px;
+            border-left: 2px solid #fc2e1c;
+          }
+        }
+        @media (max-width: 800px) {
+          .gallery {
+            flex-direction: column;
+            min-width: 90vw;
+            max-width: 90vw;
+            margin: 0;
+          }
+          .filters {
+            display: flex;
+            flex-wrap: wrap;
+            width: 100%;
+            justify-content: center;
+          }
         }
       `}</style>
     </>

--- a/packages/vx-demo/src/components/Gallery/index.tsx
+++ b/packages/vx-demo/src/components/Gallery/index.tsx
@@ -45,7 +45,6 @@ import exampleToVxDependencyLookup, {
 } from '../../sandboxes/exampleToVxDependencyLookup';
 
 const tiltOptions = { max: 8, scale: 1 };
-const columnCount = 3;
 
 const tiles = [
   AreaTile,

--- a/packages/vx-demo/src/components/Gallery/index.tsx
+++ b/packages/vx-demo/src/components/Gallery/index.tsx
@@ -127,7 +127,7 @@ export default function Gallery() {
           flex-direction: row;
         }
         .grid {
-          flex-grow: 1;
+          width: 100%;
           display: grid;
           grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
           overflow-x: hidden;

--- a/packages/vx-demo/src/components/GalleryTile.tsx
+++ b/packages/vx-demo/src/components/GalleryTile.tsx
@@ -16,13 +16,7 @@ type Props<ExampleProps extends WidthAndHeight> = {
 };
 
 const renderLinkWrapper = (url: string | undefined, node: React.ReactNode) =>
-  url ? (
-    <Link href={url}>
-      <a>{node}</a>
-    </Link>
-  ) : (
-    node
-  );
+  url ? <Link href={url}>{node}</Link> : node;
 
 export default function GalleryTile<ExampleProps extends WidthAndHeight>({
   description,
@@ -77,6 +71,7 @@ export default function GalleryTile<ExampleProps extends WidthAndHeight>({
           min-width: 300px;
           flex-direction: column;
           border-radius: 14px;
+          cursor: pointer;
         }
         .image {
           flex: 1;
@@ -102,12 +97,12 @@ export default function GalleryTile<ExampleProps extends WidthAndHeight>({
           min-width: unset;
         }
         @media (max-width: 960px) {
-          .gallery-item {
+          .gallery-tile {
             min-width: 45%;
           }
         }
         @media (max-width: 600px) {
-          .gallery-item {
+          .gallery-tile {
             min-width: 100%;
           }
         }

--- a/packages/vx-demo/src/components/GalleryTile.tsx
+++ b/packages/vx-demo/src/components/GalleryTile.tsx
@@ -16,7 +16,13 @@ type Props<ExampleProps extends WidthAndHeight> = {
 };
 
 const renderLinkWrapper = (url: string | undefined, node: React.ReactNode) =>
-  url ? <Link href={url}>{node}</Link> : node;
+  url ? (
+    <Link href={url}>
+      <a>{node}</a>
+    </Link>
+  ) : (
+    node
+  );
 
 export default function GalleryTile<ExampleProps extends WidthAndHeight>({
   description,

--- a/packages/vx-demo/src/components/PackageList.tsx
+++ b/packages/vx-demo/src/components/PackageList.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from 'next/link';
 import cx from 'classnames';
 import { VxPackage } from '../types';
 
@@ -19,43 +20,67 @@ export default function PackageList({
           <HeaderElement>Chart primitives</HeaderElement>
           <ul>
             <li className={cx(emphasizePackage === 'annotation' && 'emphasize')}>
-              <a href="/docs/annotation">@vx/annotation</a>
+              <Link href="/docs/annotation">
+                <a>
+                  <a>@vx/annotation</a>
+                </a>
+              </Link>
               {!compact && <p>Annotate elements of a chart</p>}
             </li>
             <li className={cx(cx(emphasizePackage === 'axis' && 'emphasize'))}>
-              <a href="/docs/axis">@vx/axis</a>
+              <Link href="/docs/axis">
+                <a>
+                  <a>@vx/axis</a>
+                </a>
+              </Link>
               {!compact && <p>Annotate your coordinate system</p>}
             </li>
             <li className={cx(cx(emphasizePackage === 'curve' && 'emphasize'))}>
-              <a href="/docs/curve">@vx/curve</a>
+              <Link href="/docs/curve">
+                <a>@vx/curve</a>
+              </Link>
               {!compact && <p>d3 line interpolators for @vx/shape</p>}
             </li>
             <li className={cx(emphasizePackage === 'glyph' && 'emphasize')}>
-              <a href="/docs/glyph">@vx/glyph</a>
+              <Link href="/docs/glyph">
+                <a>@vx/glyph</a>
+              </Link>
               {!compact && <p>Complex marks & symbols to be used in visuals</p>}
             </li>
             <li className={cx(emphasizePackage === 'grid' && 'emphasize')}>
-              <a href="/docs/grid">@vx/grid</a>
+              <Link href="/docs/grid">
+                <a>@vx/grid</a>
+              </Link>
               {!compact && <p>Grid lines for a chart</p>}
             </li>
             <li className={cx(emphasizePackage === 'legend' && 'emphasize')}>
-              <a href="/docs/legend">@vx/legend</a>
+              <Link href="/docs/legend">
+                <a>@vx/legend</a>
+              </Link>
               {!compact && <p>Make your visual encodings readable</p>}
             </li>
             <li className={cx(emphasizePackage === 'marker' && 'emphasize')}>
-              <a href="/docs/marker">@vx/marker</a>
+              <Link href="/docs/marker">
+                <a>@vx/marker</a>
+              </Link>
               {!compact && <p>Annotation lines with text</p>}
             </li>
             <li className={cx(emphasizePackage === 'scale' && 'emphasize')}>
-              <a href="/docs/scale">@vx/scale</a>
+              <Link href="/docs/scale">
+                <a>@vx/scale</a>
+              </Link>
               {!compact && <p>Map data to visual dimensions</p>}
             </li>
             <li className={cx(emphasizePackage === 'shape' && 'emphasize')}>
-              <a href="/docs/shape">@vx/shape</a>
+              <Link href="/docs/shape">
+                <a>@vx/shape</a>
+              </Link>
               {!compact && <p>Fundamental visualization shape primatives, the core of vx</p>}
             </li>
             <li className={cx(emphasizePackage === 'tooltip' && 'emphasize')}>
-              <a href="/docs/tooltip">@vx/tooltip</a>
+              <Link href="/docs/tooltip">
+                <a>@vx/tooltip</a>
+              </Link>
               {!compact && <p>Show details on demand</p>}
             </li>
           </ul>
@@ -64,31 +89,45 @@ export default function PackageList({
           <HeaderElement>Layouts & specialized</HeaderElement>
           <ul>
             <li className={cx(emphasizePackage === 'chord' && 'emphasize')}>
-              <a href="/docs/chord">@vx/chord</a>
+              <Link href="/docs/chord">
+                <a>@vx/chord</a>
+              </Link>
               {!compact && <p>Radial layout for matrix relationships</p>}
             </li>
             <li className={cx(emphasizePackage === 'geo' && 'emphasize')}>
-              <a href="/docs/geo">@vx/geo</a>
+              <Link href="/docs/geo">
+                <a>@vx/geo</a>
+              </Link>
               {!compact && <p>Geographic projections</p>}
             </li>
             <li className={cx(emphasizePackage === 'heatmap' && 'emphasize')}>
-              <a href="/docs/heatmap">@vx/heatmap</a>
+              <Link href="/docs/heatmap">
+                <a>@vx/heatmap</a>
+              </Link>
               {!compact && <p>Represent data values using color</p>}
             </li>
             <li className={cx(emphasizePackage === 'hierarchy' && 'emphasize')}>
-              <a href="/docs/hierarchy">@vx/hierarchy</a>
+              <Link href="/docs/hierarchy">
+                <a>@vx/hierarchy</a>
+              </Link>
               {!compact && <p>Components to visualize hierarchical or nested data</p>}
             </li>
             <li className={cx(emphasizePackage === 'network' && 'emphasize')}>
-              <a href="/docs/network">@vx/network</a>
+              <Link href="/docs/network">
+                <a>@vx/network</a>
+              </Link>
               {!compact && <p>Visualize nodes and links between them</p>}
             </li>
             <li className={cx(emphasizePackage === 'stats' && 'emphasize')}>
-              <a href="/docs/stats">@vx/stats</a>
+              <Link href="/docs/stats">
+                <a>@vx/stats</a>
+              </Link>
               {!compact && <p>Common ways to visualize distributions</p>}
             </li>
             <li className={cx(emphasizePackage === 'threshold' && 'emphasize')}>
-              <a href="/docs/threshold">@vx/threshold</a>
+              <Link href="/docs/threshold">
+                <a>@vx/threshold</a>
+              </Link>
               {!compact && <p>Difference charts to compare the delta between two time series</p>}
             </li>
           </ul>
@@ -97,19 +136,27 @@ export default function PackageList({
           <HeaderElement>Interactions</HeaderElement>
           <ul>
             <li className={cx(emphasizePackage === 'brush' && 'emphasize')}>
-              <a href="/docs/brush">@vx/brush</a>
+              <Link href="/docs/brush">
+                <a>@vx/brush</a>
+              </Link>
               {!compact && <p>Enable selection of a part of an interface</p>}
             </li>
             <li className={cx(emphasizePackage === 'drag' && 'emphasize')}>
-              <a href="/docs/drag">@vx/drag</a>
+              <Link href="/docs/drag">
+                <a>@vx/drag</a>
+              </Link>
               {!compact && <p>Make elements of an interface draggable</p>}
             </li>
             <li className={cx(emphasizePackage === 'voronoi' && 'emphasize')}>
-              <a href="/docs/voronoi">@vx/voronoi</a>
+              <Link href="/docs/voronoi">
+                <a>@vx/voronoi</a>
+              </Link>
               {!compact && <p>Partition points in a chart to improve user interaction</p>}
             </li>
             <li className={cx(emphasizePackage === 'zoom' && 'emphasize')}>
-              <a href="/docs/zoom">@vx/zoom</a>
+              <Link href="/docs/zoom">
+                <a>@vx/zoom</a>
+              </Link>
               {!compact && <p>Apply transforms to a viewport</p>}
             </li>
           </ul>
@@ -118,29 +165,41 @@ export default function PackageList({
           <HeaderElement>SVG utilities</HeaderElement>
           <ul>
             <li className={cx(emphasizePackage === 'clip-path' && 'emphasize')}>
-              <a href="/docs/clip-path">@vx/clip-path</a>
+              <Link href="/docs/clip-path">
+                <a>@vx/clip-path</a>
+              </Link>
               {!compact && <p>Utilities for clip-path elements</p>}
             </li>
             <li className={cx(emphasizePackage === 'event' && 'emphasize')}>
-              <a href="/docs/event">@vx/event</a>
+              <Link href="/docs/event">
+                <a>@vx/event</a>
+              </Link>
               {!compact && (
                 <p>Utilities for computing svg coordinates from mouse or touch events</p>
               )}
             </li>
             <li className={cx(emphasizePackage === 'group' && 'emphasize')}>
-              <a href="/docs/group">@vx/group</a>
+              <Link href="/docs/group">
+                <a>@vx/group</a>
+              </Link>
               {!compact && <p>Simplified API for &lt;g /&gt; elements</p>}
             </li>
             <li className={cx(emphasizePackage === 'gradient' && 'emphasize')}>
-              <a href="/docs/gradient">@vx/gradient</a>
+              <Link href="/docs/gradient">
+                <a>@vx/gradient</a>
+              </Link>
               {!compact && <p>Utilities for making making color gradient definitions</p>}
             </li>
             <li className={cx(emphasizePackage === 'pattern' && 'emphasize')}>
-              <a href="/docs/pattern">@vx/pattern</a>
+              <Link href="/docs/pattern">
+                <a>@vx/pattern</a>
+              </Link>
               {!compact && <p>Utilities for creating pattern definitions</p>}
             </li>
             <li className={cx(emphasizePackage === 'text' && 'emphasize')}>
-              <a href="/docs/text">@vx/text</a>
+              <Link href="/docs/text">
+                <a>@vx/text</a>
+              </Link>
               {!compact && <p>An improved SVG Text component</p>}
             </li>
           </ul>
@@ -149,19 +208,27 @@ export default function PackageList({
           <HeaderElement>Data utilities</HeaderElement>
           <ul>
             <li className={cx(emphasizePackage === 'bounds' && 'emphasize')}>
-              <a href="/docs/bounds">@vx/bounds</a>
+              <Link href="/docs/bounds">
+                <a>@vx/bounds</a>
+              </Link>
               {!compact && <p>Detect the bounding box of an element & its parent</p>}
             </li>
             <li className={cx(emphasizePackage === 'mock-data' && 'emphasize')}>
-              <a href="/docs/mock-data">@vx/mock-data</a>
+              <Link href="/docs/mock-data">
+                <a>@vx/mock-data</a>
+              </Link>
               {!compact && <p>Lots of mock data sets to play with</p>}
             </li>
             <li className={cx(emphasizePackage === 'responsive' && 'emphasize')}>
-              <a href="/docs/responsive">@vx/responsive</a>
+              <Link href="/docs/responsive">
+                <a>@vx/responsive</a>
+              </Link>
               {!compact && <p>Utilities to make responsive visualizations easy</p>}
             </li>
             <li className={cx(emphasizePackage === 'point' && 'emphasize')}>
-              <a href="/docs/point">@vx/point</a>
+              <Link href="/docs/point">
+                <a>@vx/point</a>
+              </Link>
               {!compact && <p>A simple class to represent an x,y coordinate</p>}
             </li>
           </ul>
@@ -171,7 +238,9 @@ export default function PackageList({
             <HeaderElement>Umbrella package</HeaderElement>
             <ul>
               <li className={cx(emphasizePackage === 'vx' && 'emphasize')}>
-                <a href="/docs/vx">@vx/vx</a>
+                <Link href="/docs/vx">
+                  <a>@vx/vx</a>
+                </Link>
               </li>
             </ul>
           </div>

--- a/packages/vx-demo/src/components/PackageList.tsx
+++ b/packages/vx-demo/src/components/PackageList.tsx
@@ -21,9 +21,7 @@ export default function PackageList({
           <ul>
             <li className={cx(emphasizePackage === 'annotation' && 'emphasize')}>
               <Link href="/docs/annotation">
-                <a>
-                  <a>@vx/annotation</a>
-                </a>
+                <a>@vx/annotation</a>
               </Link>
               {!compact && <p>Annotate elements of a chart</p>}
             </li>

--- a/packages/vx-demo/src/components/Show.tsx
+++ b/packages/vx-demo/src/components/Show.tsx
@@ -6,12 +6,11 @@ import withScreenSize, {
 import CodeSandboxLink from './CodeSandboxLink';
 import Page from './Page';
 import Codeblock from './Codeblock';
-import { MarginShape, ShowProvidedProps } from '../types';
+import { MarginShape, ShowProvidedProps, PackageJson } from '../types';
 import VxDocLink from './VxDocLink';
+import extractVxDepsFromPackageJson from './util/extractVxDepsFromPackageJson';
 
 type Component<P = {}> = React.FC<P> | React.ComponentClass<P>;
-
-type PackageJson = { dependencies?: { [packageName: string]: string } };
 
 type ShowProps = {
   children?: string;
@@ -25,15 +24,6 @@ type ShowProps = {
   windowResizeDebounceTime?: number;
   packageJson?: PackageJson;
 };
-
-function extractVxDepsFromPackage(packageJson?: PackageJson) {
-  const vxDeps: string[] = [];
-  Object.keys(packageJson?.dependencies ?? {}).forEach(dep => {
-    if (dep.startsWith('@vx/')) vxDeps.push(dep);
-  });
-
-  return vxDeps;
-}
 
 const padding = 40;
 
@@ -52,7 +42,7 @@ export default withScreenSize<ShowProps & WithScreenSizeProvidedProps>(
   }: ShowProps & WithScreenSizeProvidedProps) => {
     const width = Math.min(800, (screenWidth || 0) - padding);
     const height = width * 0.6;
-    const vxDeps = useMemo(() => extractVxDepsFromPackage(packageJson), [packageJson]);
+    const vxDeps = useMemo(() => extractVxDepsFromPackageJson(packageJson), [packageJson]);
 
     return (
       <Page title={title}>

--- a/packages/vx-demo/src/components/util/extractVxDepsFromPackageJson.ts
+++ b/packages/vx-demo/src/components/util/extractVxDepsFromPackageJson.ts
@@ -1,0 +1,11 @@
+import { PackageJson } from '../../types';
+
+export default function extractVxDepsFromPackageJson(packageJson?: PackageJson) {
+  const vxDeps: string[] = [];
+
+  Object.keys(packageJson?.dependencies ?? {}).forEach(dep => {
+    if (dep.startsWith('@vx/')) vxDeps.push(dep);
+  });
+
+  return vxDeps;
+}

--- a/packages/vx-demo/src/sandboxes/exampleToVxDependencyLookup.ts
+++ b/packages/vx-demo/src/sandboxes/exampleToVxDependencyLookup.ts
@@ -1,0 +1,101 @@
+import areaPackageJson from './vx-area/package.json';
+import axisPackageJson from './vx-axis/package.json';
+import bargroupPackageJson from './vx-bargroup/package.json';
+import bargroupHorizontalPackageJson from './vx-bargroup-horizontal/package.json';
+import barsPackageJson from './vx-bars/package.json';
+import barstackPackageJson from './vx-barstack/package.json';
+import barstackHorizontalPackageJson from './vx-barstack-horizontal/package.json';
+import brushPackageJson from './vx-brush/package.json';
+import chordPackageJson from './vx-chord/package.json';
+import curvePackageJson from './vx-curve/package.json';
+import dendrogramPackageJson from './vx-dendrogram/package.json';
+import dotsPackageJson from './vx-dots/package.json';
+import dragIPackageJson from './vx-drag-i/package.json';
+import dragIIPackageJson from './vx-drag-ii/package.json';
+import geoCustomPackageJson from './vx-geo-custom/package.json';
+import geoMercatorPackageJson from './vx-geo-mercator/package.json';
+import glyphPackageJson from './vx-glyph/package.json';
+import gradientPackageJson from './vx-gradient/package.json';
+import heatmapPackageJson from './vx-heatmap/package.json';
+import legendPackageJson from './vx-legend/package.json';
+import linktypesPackageJson from './vx-linktypes/package.json';
+import networkPackageJson from './vx-network/package.json';
+import packPackageJson from './vx-pack/package.json';
+import patternPackageJson from './vx-pattern/package.json';
+import polygonsPackageJson from './vx-polygons/package.json';
+import radarPackageJson from './vx-radar/package.json';
+import responsivePackageJson from './vx-responsive/package.json';
+import lineRadialPackageJson from './vx-shape-line-radial/package.json';
+import piePackageJson from './vx-shape-pie/package.json';
+import stackedAreasPackageJson from './vx-stacked-areas/package.json';
+import statsPackageJson from './vx-stats/package.json';
+import streamgraphPackageJson from './vx-streamgraph/package.json';
+import { packageJson as textPackageJson } from '../components/Gallery/TextTile';
+import thresholdPackageJson from './vx-threshold/package.json';
+import treePackageJson from './vx-tree/package.json';
+import treemapPackageJson from './vx-treemap/package.json';
+import voronoiPackageJson from './vx-voronoi/package.json';
+import zoomPackageJson from './vx-zoom-i/package.json';
+
+import extractVxDepsFromPackageJson from '../components/util/extractVxDepsFromPackageJson';
+import { VxPackage } from '../types';
+
+const examples = [
+  areaPackageJson,
+  axisPackageJson,
+  bargroupPackageJson,
+  bargroupHorizontalPackageJson,
+  barsPackageJson,
+  barstackPackageJson,
+  barstackHorizontalPackageJson,
+  brushPackageJson,
+  chordPackageJson,
+  curvePackageJson,
+  dendrogramPackageJson,
+  dotsPackageJson,
+  dragIPackageJson,
+  dragIIPackageJson,
+  geoCustomPackageJson,
+  geoMercatorPackageJson,
+  glyphPackageJson,
+  gradientPackageJson,
+  heatmapPackageJson,
+  legendPackageJson,
+  linktypesPackageJson,
+  networkPackageJson,
+  packPackageJson,
+  patternPackageJson,
+  polygonsPackageJson,
+  radarPackageJson,
+  responsivePackageJson,
+  lineRadialPackageJson,
+  piePackageJson,
+  stackedAreasPackageJson,
+  statsPackageJson,
+  streamgraphPackageJson,
+  textPackageJson,
+  thresholdPackageJson,
+  treePackageJson,
+  treemapPackageJson,
+  voronoiPackageJson,
+  zoomPackageJson,
+];
+
+const exampleToVxDependencyLookup: { [exampleName: string]: Set<VxPackage> } = {};
+const seenPackages = new Set<VxPackage>();
+
+examples.forEach(packageJson => {
+  // create a vx package set per example
+  const vxPackages = new Set<VxPackage>(
+    extractVxDepsFromPackageJson(packageJson).map(
+      vxPackage => vxPackage.split('@vx/')[1] ?? '',
+    ) as VxPackage[],
+  );
+
+  vxPackages.forEach(vxPackage => seenPackages.add(vxPackage));
+  exampleToVxDependencyLookup[packageJson.name] = vxPackages;
+});
+
+export const vxPackages = Array.from(seenPackages).sort();
+
+export default exampleToVxDependencyLookup;

--- a/packages/vx-demo/src/types/index.ts
+++ b/packages/vx-demo/src/types/index.ts
@@ -51,6 +51,8 @@ export type VxPackage =
   | 'vx'
   | 'zoom';
 
+export type PackageJson = { dependencies?: { [packageName: string]: string } };
+
 /** DocGenInfo for a single prop */
 export type PropInfo = {
   defaultValue?: { value?: unknown };


### PR DESCRIPTION
#### :memo: Documentation

This PR adds the ability to filter the `Gallery` by a specific `vx` package. 

I went back and forth on auto-generating the `example <> vx dep` map with a script but think it's probably easier to just manually import them all, no worse than an `index` file but let me know if you have thoughts. 

I also wish there was an easy way to re-use the `PackageList` component we use in `docs/` but the items are all `<Links />`s (I updated them from `<a />`s to `<Link />`s here which fixed an issue I'd seen `np-progress` loader), and we need `<button />`s with `onClick` handlers. An alternative would be to push the `vxPackageFilter` state to the url and try to use `<Link />`s 🤔  The way that the mapping is built now also ensures that we only show packages for which there are examples (not all packages have examples right now) ... this is both good and bad since someone could interpret the list as comprehensive.

Overall I think it's a good add, tho.

![gallery-package-filters](https://user-images.githubusercontent.com/4496521/83203481-6089c380-a0fe-11ea-9150-2c5d057391d1.gif)

**Responsive view**
<img src="https://user-images.githubusercontent.com/4496521/83208278-13135380-a10a-11ea-86c0-7d600e971779.png" width="300" />



@hshoff @kristw 