### PR TITLE
new(vx-legend): add Line, legendLabelProps, more props in renderShape

### DIFF
--- a/packages/vx-legend/src/legends/Legend/LegendLabel.tsx
+++ b/packages/vx-legend/src/legends/Legend/LegendLabel.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 
-export type LegendLabelProps = {
+export type LegendLabelOwnProps = {
   align?: string;
   label?: React.ReactNode;
   flex?: string | number;
   margin?: string | number;
   children?: React.ReactNode;
 };
+
+export type LegendLabelProps = LegendLabelOwnProps &
+  Omit<React.HTMLProps<HTMLDivElement>, keyof LegendLabelOwnProps>;
 
 export default function LegendLabel({
   flex = '1',
@@ -15,7 +18,7 @@ export default function LegendLabel({
   align = 'left',
   children,
   ...restProps
-}: LegendLabelProps & Omit<React.HTMLProps<HTMLDivElement>, keyof LegendLabelProps>) {
+}: LegendLabelProps) {
   return (
     <div
       className="vx-legend-label"

--- a/packages/vx-legend/src/legends/Legend/LegendShape.tsx
+++ b/packages/vx-legend/src/legends/Legend/LegendShape.tsx
@@ -5,6 +5,8 @@ import { FormattedLabel, LegendShape as LegendShapeType } from '../../types';
 
 export type LegendShapeProps<Data, Output> = {
   label: FormattedLabel<Data, Output>;
+  item: Data;
+  itemIndex: number;
   margin?: string | number;
   shape?: LegendShapeType<Data, Output>;
   fill?: (label: FormattedLabel<Data, Output>) => any;
@@ -20,6 +22,8 @@ export default function LegendShape<Data, Output>({
   height,
   margin,
   label,
+  item,
+  itemIndex,
   fill,
   size,
   shapeStyle,
@@ -36,6 +40,8 @@ export default function LegendShape<Data, Output>({
     >
       {renderShape<Data, Output>({
         shape,
+        item,
+        itemIndex,
         label,
         width,
         height,

--- a/packages/vx-legend/src/legends/Legend/index.tsx
+++ b/packages/vx-legend/src/legends/Legend/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
 import LegendItem from './LegendItem';
-import LegendLabel from './LegendLabel';
+import LegendLabel, { LegendLabelProps } from './LegendLabel';
 import LegendShape from './LegendShape';
 import valueOrIdentity, { valueOrIdentityString } from '../../util/valueOrIdentity';
 import labelTransformFactory from '../../util/labelTransformFactory';
@@ -55,6 +55,8 @@ export type LegendProps<Datum, Output, Scale = ScaleType<Datum, Output>> = {
   labelFormat?: LabelFormatter<Datum>;
   /** Given the legend scale and labelFormatter, returns a label with datum, index, value, and label. */
   labelTransform?: LabelFormatterFactory<Datum, Output, Scale>;
+  /** Additional props to be set on LegendLabel. */
+  legendLabelProps?: Partial<LegendLabelProps>;
 };
 
 const defaultStyle = {
@@ -81,6 +83,7 @@ export default function Legend<Datum, Output, Scale = ScaleType<Datum, Output>>(
   itemMargin = '0',
   direction = 'column',
   itemDirection = 'row',
+  legendLabelProps,
   children,
   ...legendItemProps
 }: LegendProps<Datum, Output, Scale>) {
@@ -112,6 +115,8 @@ export default function Legend<Datum, Output, Scale = ScaleType<Datum, Output>>(
             height={shapeHeight}
             width={shapeWidth}
             margin={shapeMargin}
+            item={domain[i]}
+            itemIndex={i}
             label={label}
             fill={fill}
             size={size}
@@ -122,6 +127,7 @@ export default function Legend<Datum, Output, Scale = ScaleType<Datum, Output>>(
             flex={labelFlex}
             margin={labelMargin}
             align={labelAlign}
+            {...legendLabelProps}
           />
         </LegendItem>
       ))}

--- a/packages/vx-legend/src/shapes/Circle.tsx
+++ b/packages/vx-legend/src/shapes/Circle.tsx
@@ -16,7 +16,7 @@ export default function ShapeCircle({ fill, width, height, style }: ShapeCircleP
   return (
     <svg width={size} height={size}>
       <Group top={radius} left={radius}>
-        <circle r={radius} fill={String(fill)} style={style} />
+        <circle r={radius} fill={fill} style={style} />
       </Group>
     </svg>
   );

--- a/packages/vx-legend/src/shapes/Line.tsx
+++ b/packages/vx-legend/src/shapes/Line.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Group } from '@vx/group';
+
+export type ShapeShapeLineProps = {
+  fill?: string;
+  width?: string | number;
+  height?: string | number;
+  style?: React.CSSProperties;
+};
+
+export default function ShapeLine({ fill, width, height, style }: ShapeShapeLineProps) {
+  const cleanHeight = typeof height === 'string' || typeof height === 'undefined' ? 0 : height;
+  const lineThickness = Number(style?.strokeWidth ?? 2);
+  return (
+    <svg width={width} height={height}>
+      <Group top={cleanHeight / 2 - lineThickness / 2}>
+        <line
+          x1={0}
+          x2={width}
+          y1={0}
+          y2={0}
+          stroke={fill}
+          strokeWidth={lineThickness}
+          style={style}
+        />
+      </Group>
+    </svg>
+  );
+}

--- a/packages/vx-legend/src/shapes/Line.tsx
+++ b/packages/vx-legend/src/shapes/Line.tsx
@@ -10,7 +10,7 @@ export type ShapeShapeLineProps = {
 
 export default function ShapeLine({ fill, width, height, style }: ShapeShapeLineProps) {
   const cleanHeight = typeof height === 'string' || typeof height === 'undefined' ? 0 : height;
-  const lineThickness = Number(style?.strokeWidth ?? 2);
+  const lineThickness = typeof style?.strokeWidth === 'number' ? style?.strokeWidth : 2;
   return (
     <svg width={width} height={height}>
       <Group top={cleanHeight / 2 - lineThickness / 2}>

--- a/packages/vx-legend/src/types/index.ts
+++ b/packages/vx-legend/src/types/index.ts
@@ -51,16 +51,18 @@ export type ItemTransformer<Datum, Output> = (
 export type RenderShapeProvidedProps<Data, Output> = {
   width?: string | number;
   height?: string | number;
-  label?: FormattedLabel<Data, Output>;
+  label: FormattedLabel<Data, Output>;
+  item: Data;
+  itemIndex: number;
   fill?: string;
   size?: string | number;
-  // TODO: ideally this would support SVGProps, but this is invalid for Rect/Circle shapes
   style?: React.CSSProperties;
 };
 
 export type LegendShape<Data, Output> =
   | 'rect'
   | 'circle'
+  | 'line'
   | React.FC<RenderShapeProvidedProps<Data, Output>>
   | React.ComponentClass<RenderShapeProvidedProps<Data, Output>>;
 

--- a/packages/vx-legend/src/util/renderShape.ts
+++ b/packages/vx-legend/src/util/renderShape.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import RectShape from '../shapes/Rect';
 import CircleShape from '../shapes/Circle';
+import LineShape from '../shapes/Line';
 
 import {
   LegendShape,
@@ -14,6 +15,8 @@ import {
 type RenderShapeArgs<Data, Output> = {
   shape?: LegendShape<Data, Output>;
   label: FormattedLabel<Data, Output>;
+  item: Data;
+  itemIndex: number;
   fill?: FillAccessor<Data, Output>;
   size?: SizeAccessor<Data, Output>;
   shapeStyle?: ShapeStyleAccessor<Data, Output>;
@@ -30,11 +33,15 @@ export default function renderShape<Data, Output>({
   width,
   height,
   label,
+  item,
+  itemIndex,
   shapeStyle = NO_OP,
 }: RenderShapeArgs<Data, Output>) {
   const props: RenderShapeProvidedProps<Data, Output> = {
     width,
     height,
+    item,
+    itemIndex,
     label,
     fill: fill({ ...label }),
     size: size({ ...label }),
@@ -42,10 +49,13 @@ export default function renderShape<Data, Output>({
   };
 
   if (typeof shape === 'string') {
-    if (shape === 'rect') {
-      return React.createElement(RectShape, props);
+    if (shape === 'circle') {
+      return React.createElement(CircleShape, props);
     }
-    return React.createElement(CircleShape, props);
+    if (shape === 'line') {
+      return React.createElement(LineShape, props);
+    }
+    return React.createElement(RectShape, props);
   }
   if (React.isValidElement(shape)) {
     return React.cloneElement(shape, props);

--- a/packages/vx-legend/test/Legend.test.tsx
+++ b/packages/vx-legend/test/Legend.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { scaleLinear } from '@vx/scale';
 
-import { Legend } from '../src';
+import { Legend, LegendLabel } from '../src';
 
 const defaultProps = {
   scale: scaleLinear<number>({
@@ -38,5 +38,12 @@ describe('<Legend />', () => {
       display: 'flex',
       flexDirection: 'row',
     });
+  });
+
+  test('it should pass through legendLabelProps to legend labels', () => {
+    const style = { fontFamily: 'Comic Sans' };
+    const wrapper = shallow(<Legend {...defaultProps} legendLabelProps={{ style }} />);
+    const label = wrapper.find(LegendLabel).first();
+    expect(label.prop('style')).toEqual(style);
   });
 });


### PR DESCRIPTION
#### :rocket: Enhancements

This adds some additional features + hooks to `@vx/legend` which were needed for me to integrate the `Legend` component in the [`XYChart` POC](https://github.com/hshoff/vx/pull/745).

- Add `Line` shape (now have `Line`, `Rect`, and `Circle`)
- Add `legendLabelProps` to `Legend` to support customization of label styles (and integration of the `XYChart` `theme`)
- Pass `item` + `itemIndex` in `RenderShapeProvidedProps`; it currently passes `label` which doesn't help if your logic is based off of the `Legend` `scale` `domain`

![image](https://user-images.githubusercontent.com/4496521/84940397-a0f0b780-b094-11ea-89b2-50faa6a38d32.png)

@hshoff @kristw 