### PR TITLE
fix(vx-responsive): fix debounce types

### DIFF
--- a/packages/vx-responsive/src/components/ParentSize.tsx
+++ b/packages/vx-responsive/src/components/ParentSize.tsx
@@ -35,21 +35,16 @@ export default class ParentSize extends React.Component<
     debounceTime: 300,
     parentSizeStyles: { width: '100%', height: '100%' },
   };
-  animationFrameID: number | null;
+  animationFrameID: number = 0;
   resizeObserver: ResizeObserver | undefined;
   target: HTMLDivElement | null = null;
 
-  constructor(props: ParentSizeProps) {
-    super(props);
-    this.state = {
-      width: 0,
-      height: 0,
-      top: 0,
-      left: 0,
-    };
-    this.resize = debounce(this.resize, props.debounceTime);
-    this.animationFrameID = null;
-  }
+  state = {
+    width: 0,
+    height: 0,
+    top: 0,
+    left: 0,
+  };
 
   componentDidMount() {
     this.resizeObserver = new ResizeObserver((entries = [] /** , observer */) => {
@@ -64,14 +59,14 @@ export default class ParentSize extends React.Component<
   }
 
   componentWillUnmount() {
-    if (this.animationFrameID) window.cancelAnimationFrame(this.animationFrameID);
+    window.cancelAnimationFrame(this.animationFrameID);
     if (this.resizeObserver) this.resizeObserver.disconnect();
     this.resize.cancel();
   }
 
-  resize = ({ width, height, top, left }: ParentSizeState) => {
+  resize = debounce(({ width, height, top, left }: ParentSizeState) => {
     this.setState(() => ({ width, height, top, left }));
-  };
+  }, this.props.debounceTime);
 
   setTarget = (ref: HTMLDivElement | null) => {
     this.target = ref;

--- a/packages/vx-responsive/src/enhancers/withScreenSize.tsx
+++ b/packages/vx-responsive/src/enhancers/withScreenSize.tsx
@@ -23,40 +23,33 @@ export default function withScreenSize<BaseComponentProps extends WithScreenSize
       windowResizeDebounceTime: 300,
     };
 
-    handleResize: () => void;
-
-    constructor(props: BaseComponentProps & WithScreenSizeProvidedProps) {
-      super(props);
-      this.state = {
-        screenWidth: undefined,
-        screenHeight: undefined,
-      };
-      this.handleResize = debounce(this.resize, props.windowResizeDebounceTime);
-    }
+    state = {
+      screenWidth: undefined,
+      screenHeight: undefined,
+    };
 
     componentDidMount() {
-      window.addEventListener('resize', this.handleResize, false);
+      window.addEventListener('resize', this.resize, false);
       this.resize();
     }
 
     componentWillUnmount() {
-      window.removeEventListener('resize', this.handleResize, false);
-      this.handleResize.cancel();
+      window.removeEventListener('resize', this.resize, false);
+      this.resize.cancel();
     }
 
-    resize = (/** event */) => {
+    resize = debounce(() => {
       this.setState((/** prevState, props */) => {
         return {
           screenWidth: window.innerWidth,
           screenHeight: window.innerHeight,
         };
       });
-    };
+    }, this.props.windowResizeDebounceTime);
 
     render() {
       const { screenWidth, screenHeight } = this.state;
-      if (screenWidth == null || screenHeight == null) return null;
-      return (
+      return screenWidth == null || screenHeight == null ? null : (
         <BaseComponent screenWidth={screenWidth} screenHeight={screenHeight} {...this.props} />
       );
     }


### PR DESCRIPTION
#### :bug: Bug Fix

The build is currently broken from #588 which doesn't seem to have triggered the `typescript` build. The way that `debounce` was added in `ParentSize`, `withParentSize`, and `withScreenSize` didn't yield the correct types / was not valid.

@hshoff @kristw 
