### PR TITLE
new(vx-axis): use numTicks when falling back on scale.domain

### DIFF
--- a/packages/vx-axis/src/axis/Axis.tsx
+++ b/packages/vx-axis/src/axis/Axis.tsx
@@ -54,7 +54,16 @@ export default function Axis<ScaleInput>({
   tickComponent,
   top = 0,
 }: AxisProps<ScaleInput>) {
-  const values = tickValues || (scale.ticks ? scale.ticks(numTicks) : scale.domain());
+  const values =
+    tickValues ||
+    (scale.ticks
+      ? scale.ticks(numTicks)
+      : scale
+          .domain()
+          .filter(
+            (_, index, arr) =>
+              numTicks == null || index % Math.round((arr.length - 1) / numTicks) === 0,
+          ));
   const format = tickFormat || (scale.tickFormat ? scale.tickFormat() : toString);
 
   const range = scale.range();

--- a/packages/vx-axis/src/axis/Axis.tsx
+++ b/packages/vx-axis/src/axis/Axis.tsx
@@ -62,7 +62,9 @@ export default function Axis<ScaleInput>({
           .domain()
           .filter(
             (_, index, arr) =>
-              numTicks == null || index % Math.round((arr.length - 1) / numTicks) === 0,
+              numTicks == null ||
+              arr.length <= numTicks ||
+              index % Math.round((arr.length - 1) / numTicks) === 0,
           ));
   const format = tickFormat || (scale.tickFormat ? scale.tickFormat() : toString);
 


### PR DESCRIPTION
#### :rocket: Enhancements

This makes a small update to `@vx/axis` for _non-continuous_ scales. [Continuous scales support `.ticks([count])`](https://github.com/d3/d3-scale#continuous_ticks), but things like band scales do not. 

Currently `Axis` will use `.ticks()` if it exists, and falls back to `.domain()` for scales that don't have it. This is fine except for charts with a very large `domain`, in which case it'd be an improvement to account for `numTicks` if it's passed, to allow filtering to a reasonable number without requiring full specification of `tickValues`. I added that logic here.

**Before**
```tsx
<Axis numTicks={5} scale={bandScale} />
```

![image](https://user-images.githubusercontent.com/4496521/84946904-39d80080-b09e-11ea-91e2-e5b1c19515a6.png)

**After**
![image](https://user-images.githubusercontent.com/4496521/84946933-45c3c280-b09e-11ea-9d97-ab626a88c284.png)


@hshoff @kristw 