### PR TITLE
new(vx-responsive): add leading option to resize debounce

### DIFF
--- a/packages/vx-responsive/src/components/ParentSize.tsx
+++ b/packages/vx-responsive/src/components/ParentSize.tsx
@@ -66,7 +66,7 @@ export default class ParentSize extends React.Component<
 
   resize = debounce(({ width, height, top, left }: ParentSizeState) => {
     this.setState(() => ({ width, height, top, left }));
-  }, this.props.debounceTime);
+  }, this.props.debounceTime, { leading: true });
 
   setTarget = (ref: HTMLDivElement | null) => {
     this.target = ref;

--- a/packages/vx-responsive/src/components/ParentSize.tsx
+++ b/packages/vx-responsive/src/components/ParentSize.tsx
@@ -7,6 +7,8 @@ export type ParentSizeProps = {
   className?: string;
   /** Child render updates upon resize are delayed until `debounceTime` milliseconds _after_ the last resize event is observed. */
   debounceTime?: number;
+  /** Optional flag to toggle leading debounce calls. When set to true this will ensure that the component always renders immediately. (defaults to true) */
+  enableDebounceLeadingCall?: boolean;
   /** Optional `style` object to apply to the parent `div` wrapper used for size measurement. */
   parentSizeStyles?: React.CSSProperties;
   /** Child render function `({ width, height, top, left, ref, resize }) => ReactNode`. */
@@ -33,6 +35,7 @@ export default class ParentSize extends React.Component<
 > {
   static defaultProps = {
     debounceTime: 300,
+    enableDebounceLeadingCall: true,
     parentSizeStyles: { width: '100%', height: '100%' },
   };
   animationFrameID: number = 0;
@@ -69,7 +72,7 @@ export default class ParentSize extends React.Component<
       this.setState(() => ({ width, height, top, left }));
     },
     this.props.debounceTime,
-    { leading: true },
+    { leading: this.props.enableDebounceLeadingCall },
   );
 
   setTarget = (ref: HTMLDivElement | null) => {

--- a/packages/vx-responsive/src/components/ParentSize.tsx
+++ b/packages/vx-responsive/src/components/ParentSize.tsx
@@ -64,9 +64,13 @@ export default class ParentSize extends React.Component<
     this.resize.cancel();
   }
 
-  resize = debounce(({ width, height, top, left }: ParentSizeState) => {
-    this.setState(() => ({ width, height, top, left }));
-  }, this.props.debounceTime, { leading: true });
+  resize = debounce(
+    ({ width, height, top, left }: ParentSizeState) => {
+      this.setState(() => ({ width, height, top, left }));
+    },
+    this.props.debounceTime,
+    { leading: true },
+  );
 
   setTarget = (ref: HTMLDivElement | null) => {
     this.target = ref;

--- a/packages/vx-responsive/src/enhancers/withParentSize.tsx
+++ b/packages/vx-responsive/src/enhancers/withParentSize.tsx
@@ -58,12 +58,16 @@ export default function withParentSize<BaseComponentProps extends WithParentSize
       this.container = ref;
     };
 
-    resize = debounce(({ width, height }: { width: number; height: number }) => {
-      this.setState({
-        parentWidth: width,
-        parentHeight: height,
-      });
-    }, this.props.debounceTime, { leading: true });
+    resize = debounce(
+      ({ width, height }: { width: number; height: number }) => {
+        this.setState({
+          parentWidth: width,
+          parentHeight: height,
+        });
+      },
+      this.props.debounceTime,
+      { leading: true },
+    );
 
     render() {
       const { parentWidth, parentHeight } = this.state;

--- a/packages/vx-responsive/src/enhancers/withParentSize.tsx
+++ b/packages/vx-responsive/src/enhancers/withParentSize.tsx
@@ -63,7 +63,7 @@ export default function withParentSize<BaseComponentProps extends WithParentSize
         parentWidth: width,
         parentHeight: height,
       });
-    }, this.props.debounceTime);
+    }, this.props.debounceTime, { leading: true });
 
     render() {
       const { parentWidth, parentHeight } = this.state;

--- a/packages/vx-responsive/src/enhancers/withParentSize.tsx
+++ b/packages/vx-responsive/src/enhancers/withParentSize.tsx
@@ -6,6 +6,7 @@ const CONTAINER_STYLES = { width: '100%', height: '100%' };
 
 export type WithParentSizeProps = {
   debounceTime?: number;
+  enableDebounceLeadingCall?: boolean;
 };
 
 type WithParentSizeState = {
@@ -24,6 +25,7 @@ export default function withParentSize<BaseComponentProps extends WithParentSize
   > {
     static defaultProps = {
       debounceTime: 300,
+      enableDebounceLeadingCall: true,
     };
     state = {
       parentWidth: undefined,
@@ -66,7 +68,7 @@ export default function withParentSize<BaseComponentProps extends WithParentSize
         });
       },
       this.props.debounceTime,
-      { leading: true },
+      { leading: this.props.enableDebounceLeadingCall },
     );
 
     render() {

--- a/packages/vx-responsive/src/enhancers/withScreenSize.tsx
+++ b/packages/vx-responsive/src/enhancers/withScreenSize.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 export type WithScreenSizeProps = {
   windowResizeDebounceTime?: number;
+  enableDebounceLeadingCall?: boolean;
 };
 
 type WithScreenSizeState = {
@@ -21,6 +22,7 @@ export default function withScreenSize<BaseComponentProps extends WithScreenSize
   > {
     static defaultProps = {
       windowResizeDebounceTime: 300,
+      enableDebounceLeadingCall: true,
     };
 
     state = {
@@ -48,7 +50,7 @@ export default function withScreenSize<BaseComponentProps extends WithScreenSize
         });
       },
       this.props.windowResizeDebounceTime,
-      { leading: true },
+      { leading: this.props.enableDebounceLeadingCall },
     );
 
     render() {

--- a/packages/vx-responsive/src/enhancers/withScreenSize.tsx
+++ b/packages/vx-responsive/src/enhancers/withScreenSize.tsx
@@ -45,7 +45,7 @@ export default function withScreenSize<BaseComponentProps extends WithScreenSize
           screenHeight: window.innerHeight,
         };
       });
-    }, this.props.windowResizeDebounceTime);
+    }, this.props.windowResizeDebounceTime, { leading: true });
 
     render() {
       const { screenWidth, screenHeight } = this.state;

--- a/packages/vx-responsive/src/enhancers/withScreenSize.tsx
+++ b/packages/vx-responsive/src/enhancers/withScreenSize.tsx
@@ -38,14 +38,18 @@ export default function withScreenSize<BaseComponentProps extends WithScreenSize
       this.resize.cancel();
     }
 
-    resize = debounce(() => {
-      this.setState((/** prevState, props */) => {
-        return {
-          screenWidth: window.innerWidth,
-          screenHeight: window.innerHeight,
-        };
-      });
-    }, this.props.windowResizeDebounceTime, { leading: true });
+    resize = debounce(
+      () => {
+        this.setState((/** prevState, props */) => {
+          return {
+            screenWidth: window.innerWidth,
+            screenHeight: window.innerHeight,
+          };
+        });
+      },
+      this.props.windowResizeDebounceTime,
+      { leading: true },
+    );
 
     render() {
       const { screenWidth, screenHeight } = this.state;


### PR DESCRIPTION
#### :rocket: Enhancements

- add leading calls to debounced resize function in all @vx/responsive HOCs and components. This prevents the initial render from blocking, increasing perceived page load speed.

Fixes #753 

The gifs below represent a page refresh. I set the debounceTime to 1000ms for demonstration purposes. The **Before** image shows a 1 second delay before the chart gets rendered on reload. The **After** image immediately renders the component on reload.

**Before:**
![vx-responsive-before](https://user-images.githubusercontent.com/4850521/85042615-b268bb00-b18b-11ea-9ed8-ec224259106b.gif)
**After:**
![vx-responsive-after](https://user-images.githubusercontent.com/4850521/85042622-b4cb1500-b18b-11ea-8f39-173da6b7e238.gif)


