### PR TITLE
new(vx-tooltip): add useTooltipInPortal

### DIFF
--- a/packages/vx-demo/package.json
+++ b/packages/vx-demo/package.json
@@ -78,7 +78,6 @@
     "react-markdown": "^4.3.1",
     "react-spring": "^8.0.27",
     "react-tilt": "^0.1.4",
-    "react-use-measure": "^2.0.1",
     "recompose": "^0.26.0",
     "topojson-client": "^3.0.0"
   },

--- a/packages/vx-demo/src/pages/docs/tooltip.tsx
+++ b/packages/vx-demo/src/pages/docs/tooltip.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
 import TooltipReadme from '!!raw-loader!../../../../vx-tooltip/Readme.md';
+import Tooltip from '../../../../vx-tooltip/src/tooltips/Tooltip';
+import TooltipWithBounds from '../../../../vx-tooltip/src/tooltips/TooltipWithBounds';
+import useTooltip from '../../../../vx-tooltip/src/hooks/useTooltip';
+import useTooltipInPortal from '../../../../vx-tooltip/src/hooks/useTooltipInPortal';
+import Portal from '../../../../vx-tooltip/src/Portal';
+
 import DocPage from '../../components/DocPage';
 import TooltipTile from '../../components/Gallery/TooltipTile';
 import DotsTile from '../../components/Gallery/DotsTile';
@@ -9,4 +15,8 @@ import AreaTile from '../../components/Gallery/AreaTile';
 
 const examples = [TooltipTile, DotsTile, BarStackHorizontalTile, StatsPlotTile, AreaTile];
 
-export default () => <DocPage examples={examples} readme={TooltipReadme} vxPackage="tooltip" />;
+const components = [TooltipWithBounds, Tooltip, Portal, useTooltip, useTooltipInPortal];
+
+export default () => (
+  <DocPage components={components} examples={examples} readme={TooltipReadme} vxPackage="tooltip" />
+);

--- a/packages/vx-demo/src/sandboxes/vx-barstack/Example.tsx
+++ b/packages/vx-demo/src/sandboxes/vx-barstack/Example.tsx
@@ -7,7 +7,7 @@ import { AxisBottom } from '@vx/axis';
 import cityTemperature, { CityTemperature } from '@vx/mock-data/lib/mocks/cityTemperature';
 import { scaleBand, scaleLinear, scaleOrdinal } from '@vx/scale';
 import { timeParse, timeFormat } from 'd3-time-format';
-import { useTooltip, Tooltip, defaultStyles } from '@vx/tooltip';
+import { useTooltip, useTooltipInPortal, defaultStyles } from '@vx/tooltip';
 import { LegendOrdinal } from '@vx/legend';
 
 type CityName = 'New York' | 'San Francisco' | 'Austin';
@@ -92,6 +92,8 @@ export default function Example({
     showTooltip,
   } = useTooltip<TooltipData>();
 
+  const { containerRef, TooltipInPortal } = useTooltipInPortal();
+
   if (width < 10) return null;
   // bounds
   const xMax = width;
@@ -103,7 +105,7 @@ export default function Example({
   return width < 10 ? null : (
     // relative position is needed for correct tooltip positioning
     <div style={{ position: 'relative' }}>
-      <svg width={width} height={height}>
+      <svg ref={containerRef} width={width} height={height}>
         <rect x={0} y={0} width={width} height={height} fill={background} rx={14} />
         <Grid<string, number>
           top={margin.top}
@@ -146,8 +148,7 @@ export default function Example({
                     onMouseMove={event => {
                       if (tooltipTimeout) clearTimeout(tooltipTimeout);
                       const top = event.clientY - margin.top - bar.height;
-                      const offset = (dateScale.paddingInner() * dateScale.step()) / 2;
-                      const left = bar.x + bar.width + offset;
+                      const left = bar.x + bar.width / 2;
                       showTooltip({
                         tooltipData: bar,
                         tooltipTop: top,
@@ -187,7 +188,12 @@ export default function Example({
       </div>
 
       {tooltipOpen && tooltipData && (
-        <Tooltip top={tooltipTop} left={tooltipLeft} style={tooltipStyles}>
+        <TooltipInPortal
+          key={Math.random()} // update tooltip bounds each render
+          top={tooltipTop}
+          left={tooltipLeft}
+          style={tooltipStyles}
+        >
           <div style={{ color: colorScale(tooltipData.key) }}>
             <strong>{tooltipData.key}</strong>
           </div>
@@ -195,7 +201,7 @@ export default function Example({
           <div>
             <small>{formatDate(getDate(tooltipData.bar.data))}</small>
           </div>
-        </Tooltip>
+        </TooltipInPortal>
       )}
     </div>
   );

--- a/packages/vx-demo/src/sandboxes/vx-tooltip/package.json
+++ b/packages/vx-demo/src/sandboxes/vx-tooltip/package.json
@@ -12,7 +12,6 @@
     "react": "^16",
     "react-dom": "^16",
     "react-scripts-ts": "3.1.0",
-    "react-use-measure": "^2.0.1",
     "typescript": "^3"
   },
   "keywords": [

--- a/packages/vx-tooltip/package.json
+++ b/packages/vx-tooltip/package.json
@@ -32,7 +32,8 @@
     "@types/react": "*",
     "@vx/bounds": "0.0.197",
     "classnames": "^2.2.5",
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "react-use-measure": "2.0.1"
   },
   "peerDependencies": {
     "react": "^16.8.0-0",

--- a/packages/vx-tooltip/src/hooks/useTooltipInPortal.tsx
+++ b/packages/vx-tooltip/src/hooks/useTooltipInPortal.tsx
@@ -1,9 +1,15 @@
 import React, { useMemo } from 'react';
-import useMeasure from 'react-use-measure';
+import useMeasure, { RectReadOnly, Options as BaseUseMeasureOptions } from 'react-use-measure';
 
+import Portal from '../Portal';
 import Tooltip, { TooltipProps } from '../tooltips/Tooltip';
 import TooltipWithBounds from '../tooltips/TooltipWithBounds';
-import Portal from '../Portal';
+
+export type UseTooltipInPortal = {
+  containerRef: (element: HTMLElement | SVGElement | null) => void;
+  containerBounds: RectReadOnly;
+  TooltipInPortal: React.FC<TooltipProps>;
+};
 
 export type UseTooltipPortalParams = {
   /** Whether TooltipWithBounds should be used to auto-detect its container boundaries and update its position accordingly. */
@@ -18,7 +24,7 @@ export type UseMeasureOptions = {
   /** React to nested scroll changes, don't use this if you know your view is static */
   scroll?: boolean;
   /** You can optionally inject a ResizeObserver polyfill. */
-  polyfill?: any;
+  polyfill?: BaseUseMeasureOptions['polyfill'];
 };
 
 /**
@@ -28,7 +34,7 @@ export type UseMeasureOptions = {
 export default function useTooltipInPortal({
   scroll,
   detectBounds = true,
-}: UseTooltipPortalParams | undefined = {}) {
+}: UseTooltipPortalParams | undefined = {}): UseTooltipInPortal {
   const [containerRef, containerBounds] = useMeasure({ scroll });
 
   const TooltipInPortal = useMemo(

--- a/packages/vx-tooltip/src/hooks/useTooltipInPortal.tsx
+++ b/packages/vx-tooltip/src/hooks/useTooltipInPortal.tsx
@@ -1,0 +1,51 @@
+import React, { useMemo } from 'react';
+import useMeasure from 'react-use-measure';
+
+import Tooltip, { TooltipProps } from '../tooltips/Tooltip';
+import TooltipWithBounds from '../tooltips/TooltipWithBounds';
+import Portal from '../Portal';
+
+export type UseTooltipPortalParams = {
+  /** Whether TooltipWithBounds should be used to auto-detect its container boundaries and update its position accordingly. */
+  detectBounds?: boolean;
+} & UseMeasureOptions;
+
+export type UseMeasureOptions = {
+  /** whether TooltipWithBounds should be used to auto-detect (page) boundaries and reposition itself. */
+  detectBounds?: boolean;
+  /** Debounce resize or scroll events in milliseconds (needed for positioning) */
+  debounce?: number | { scroll: number; resize: number };
+  /** React to nested scroll changes, don't use this if you know your view is static */
+  scroll?: boolean;
+  /** You can optionally inject a ResizeObserver polyfill. */
+  polyfill?: any;
+};
+
+/**
+ * Hook that handles rendering of a Tooltip or TooltipWithBounds in a Portal.
+ * Handles conversion of container coordinates to page coordinates using the container bounds.
+ */
+export default function useTooltipInPortal({
+  scroll,
+  detectBounds = true,
+}: UseTooltipPortalParams | undefined = {}) {
+  const [containerRef, containerBounds] = useMeasure({ scroll });
+
+  const TooltipInPortal = useMemo(
+    () => ({ left: containerLeft = 0, top: containerTop = 0, ...tooltipProps }: TooltipProps) => {
+      const TooltipComponent = detectBounds ? TooltipWithBounds : Tooltip;
+      // convert container coordinates to page coordinates
+      const portalLeft = containerLeft + (containerBounds.left || 0) + window.scrollX;
+      const portalTop = containerTop + (containerBounds.top || 0) + window.scrollY;
+
+      return (
+        <Portal>
+          <TooltipComponent left={portalLeft} top={portalTop} {...tooltipProps} />
+        </Portal>
+      );
+    },
+    [detectBounds, containerBounds.left, containerBounds.top],
+  );
+
+  return { containerRef, containerBounds, TooltipInPortal };
+}

--- a/packages/vx-tooltip/src/hooks/useTooltipInPortal.tsx
+++ b/packages/vx-tooltip/src/hooks/useTooltipInPortal.tsx
@@ -11,12 +11,7 @@ export type UseTooltipInPortal = {
   TooltipInPortal: React.FC<TooltipProps>;
 };
 
-export type UseTooltipPortalParams = {
-  /** Whether TooltipWithBounds should be used to auto-detect its container boundaries and update its position accordingly. */
-  detectBounds?: boolean;
-} & UseMeasureOptions;
-
-export type UseMeasureOptions = {
+export type UseTooltipPortalOptions = {
   /** whether TooltipWithBounds should be used to auto-detect (page) boundaries and reposition itself. */
   detectBounds?: boolean;
   /** Debounce resize or scroll events in milliseconds (needed for positioning) */
@@ -32,10 +27,10 @@ export type UseMeasureOptions = {
  * Handles conversion of container coordinates to page coordinates using the container bounds.
  */
 export default function useTooltipInPortal({
-  scroll,
   detectBounds = true,
-}: UseTooltipPortalParams | undefined = {}): UseTooltipInPortal {
-  const [containerRef, containerBounds] = useMeasure({ scroll });
+  ...useMeasureOptions
+}: UseTooltipPortalOptions | undefined = {}): UseTooltipInPortal {
+  const [containerRef, containerBounds] = useMeasure(useMeasureOptions);
 
   const TooltipInPortal = useMemo(
     () => ({ left: containerLeft = 0, top: containerTop = 0, ...tooltipProps }: TooltipProps) => {
@@ -53,5 +48,11 @@ export default function useTooltipInPortal({
     [detectBounds, containerBounds.left, containerBounds.top],
   );
 
-  return { containerRef, containerBounds, TooltipInPortal };
+  return {
+    // react-use-measure doesn't currently accept SVGElement refs
+    // @ts-ignore fixed here https://github.com/react-spring/react-use-measure/pull/17
+    containerRef,
+    containerBounds,
+    TooltipInPortal,
+  };
 }

--- a/packages/vx-tooltip/src/index.ts
+++ b/packages/vx-tooltip/src/index.ts
@@ -1,5 +1,6 @@
 export { default as withTooltip } from './enhancers/withTooltip';
 export { default as useTooltip } from './hooks/useTooltip';
+export { default as useTooltipInPortal } from './hooks/useTooltipInPortal';
 export { default as Tooltip, defaultStyles } from './tooltips/Tooltip';
 export { default as TooltipWithBounds } from './tooltips/TooltipWithBounds';
 export { default as Portal } from './Portal';

--- a/packages/vx-tooltip/src/tooltips/Tooltip.tsx
+++ b/packages/vx-tooltip/src/tooltips/Tooltip.tsx
@@ -4,6 +4,8 @@ import cx from 'classnames';
 export type TooltipProps = {
   left?: number;
   top?: number;
+  offsetLeft?: number;
+  offsetTop?: number;
   className?: string;
   style?: React.CSSProperties;
   children?: React.ReactNode;
@@ -26,15 +28,21 @@ export default function Tooltip({
   className,
   top,
   left,
+  offsetLeft = 10,
+  offsetTop = 10,
   style = defaultStyles,
   children,
   unstyled = false,
   ...restProps
-}: TooltipProps & JSX.IntrinsicElements['div']) {
+}: TooltipProps & React.HTMLProps<HTMLDivElement>) {
   return (
     <div
       className={cx('vx-tooltip-portal', className)}
-      style={{ top, left, ...(!unstyled && style) }}
+      style={{
+        top: top == null || offsetTop == null ? top : top + offsetTop,
+        left: left == null || offsetLeft == null ? left : left + offsetLeft,
+        ...(!unstyled && style),
+      }}
       {...restProps}
     >
       {children}

--- a/packages/vx-tooltip/src/tooltips/TooltipWithBounds.tsx
+++ b/packages/vx-tooltip/src/tooltips/TooltipWithBounds.tsx
@@ -3,10 +3,11 @@ import { withBoundingRects, WithBoundingRectsProps } from '@vx/bounds';
 
 import Tooltip, { TooltipProps, defaultStyles } from './Tooltip';
 
-type Props = {
+export type TooltipWithBoundsProps = {
   offsetLeft?: number;
   offsetTop?: number;
 } & TooltipProps &
+  React.HTMLProps<HTMLDivElement> &
   WithBoundingRectsProps;
 
 function TooltipWithBounds({
@@ -21,7 +22,7 @@ function TooltipWithBounds({
   style = defaultStyles,
   unstyled = false,
   ...otherProps
-}: Props) {
+}: TooltipWithBoundsProps) {
   let left = initialLeft;
   let top = initialTop;
 

--- a/packages/vx-tooltip/test/useTooltip.test.tsx
+++ b/packages/vx-tooltip/test/useTooltip.test.tsx
@@ -1,4 +1,4 @@
-import useTooltip from '../src/hooks/useTooltip';
+import { useTooltip } from '../src';
 
 describe('useTooltip()', () => {
   test('it should be defined', () => {

--- a/packages/vx-tooltip/test/useTooltipInPortal.test.tsx
+++ b/packages/vx-tooltip/test/useTooltipInPortal.test.tsx
@@ -1,0 +1,7 @@
+import { useTooltipInPortal } from '../src';
+
+describe('useTooltipInPortal()', () => {
+  test('it should be defined', () => {
+    expect(useTooltipInPortal).toBeDefined();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -11283,7 +11283,7 @@ react-tilt@^0.1.4:
   resolved "https://registry.yarnpkg.com/react-tilt/-/react-tilt-0.1.4.tgz#0ac1f33674a3fff6c617cf411002d7ecdd2ebcb1"
   integrity sha512-bVeRumg+RIn6QN8S92UmubGqX/BG6/QeQISBeAcrS/70dpo/jVj+sjikIawDl5wTuPdubFH8zH0EMulWIctsnw==
 
-react-use-measure@^2.0.1:
+react-use-measure@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.0.1.tgz#4f23f94c832cd4512da55acb300d1915dcbf3ae8"
   integrity sha512-lFfHiqcXbJ2/6aUkZwt8g5YYM7EGqNVxJhMqMPqv1BVXRKp8D7jYLlmma0SvhRY4WYxxkZpCdbJvhDylb5gcEA==


### PR DESCRIPTION
#### :boom: Breaking Changes
#### :rocket: Enhancements
#### :memo: Documentation

This PR is into #755 and 
- adds a new `userTooltipInPortal` hook to addresses the issue of `Portal` not being easy to use by lib consumers. Notes: 
  - this adds a new [`react-use-measure`](https://github.com/react-spring/react-use-measure) dependency for the robust bounds logic
  - `react-use-measure` relies on `ResizeObserver`. rather than adding the polyfill here like we do in `@vx/responsive`, I'm opting to just expose the `useMeasure` polyfill injection system. So, users can add it themselves to `window` or pass it in directly to the hook. I've noted this in the `Readme`.
- updates the `tooltip` demo added in #755 to use this hook instead of `Portal` + `react-use-measure`
- updates the `vx-tooltip` Readme to include `useTooltipInPortal` and `Portal`
- updates the `barstack` example to use `useTooltipInPortal` as a validation point within `svg`s
- adds `offsetLeft/Top` to `TooltipProps`, making `TooltipProps === TooltipWithBoundsProps`. This simplifies type checking in the new `useTooltipInPortal`, and is a breaking change for `Tooltip` as it will add `10px` of padding to the `Tooltip` left/top.

Using `userTooltipInPortal`
![image](https://user-images.githubusercontent.com/4496521/85187351-e4455480-b253-11ea-9311-14b953801703.png)


TODO
- [x] remove `react-use-measure` dep in `vx-demo`

@hshoff @kristw @ktmud @techniq 