### PR TITLE
minor fix to <Text> and re-enable unit tests.

### DIFF
--- a/packages/vx-text/package.json
+++ b/packages/vx-text/package.json
@@ -29,11 +29,10 @@
   "homepage": "https://github.com/hshoff/vx#readme",
   "dependencies": {
     "@types/classnames": "^2.2.9",
-    "@types/lodash": "^4.14.146",
+    "@types/lodash.memoize": "^4.1.6",
     "@types/react": "*",
     "classnames": "^2.2.5",
-    "lodash": "^4.17.15",
-    "prop-types": "^15.7.2",
+    "lodash.memoize": "^4.1.2",
     "reduce-css-calc": "^1.3.0"
   },
   "peerDependencies": {

--- a/packages/vx-text/package.json
+++ b/packages/vx-text/package.json
@@ -29,10 +29,11 @@
   "homepage": "https://github.com/hshoff/vx#readme",
   "dependencies": {
     "@types/classnames": "^2.2.9",
-    "@types/lodash.memoize": "^4.1.6",
+    "@types/lodash": "^4.14.160",
     "@types/react": "*",
     "classnames": "^2.2.5",
-    "lodash.memoize": "^4.1.2",
+    "lodash": "^4.17.20",
+    "prop-types": "^15.7.2",
     "reduce-css-calc": "^1.3.0"
   },
   "peerDependencies": {

--- a/packages/vx-text/src/util/getStringWidth.ts
+++ b/packages/vx-text/src/util/getStringWidth.ts
@@ -1,4 +1,4 @@
-import memoize from 'lodash/memoize';
+import memoize from 'lodash.memoize';
 
 const MEASUREMENT_ELEMENT_ID = '__react_svg_text_measurement_id';
 

--- a/packages/vx-text/src/util/getStringWidth.ts
+++ b/packages/vx-text/src/util/getStringWidth.ts
@@ -1,4 +1,4 @@
-import memoize from 'lodash.memoize';
+import memoize from 'lodash/memoize';
 
 const MEASUREMENT_ELEMENT_ID = '__react_svg_text_measurement_id';
 

--- a/packages/vx-text/test/Text.test.tsx
+++ b/packages/vx-text/test/Text.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { Text, getStringWidth } from '../src';
+import { addMock, removeMock } from './svgMock';
 
 describe('getStringWidth()', () => {
   it('should be defined', () => {
@@ -11,6 +12,9 @@ describe('getStringWidth()', () => {
 // TODO: Fix tests (jsdom does not support getComputedTextLength() or getBoundingClientRect()).  Maybe use puppeteer
 
 describe('<Text />', () => {
+  beforeEach(addMock);
+  afterEach(removeMock);
+
   it('should be defined', () => {
     expect(Text).toBeDefined();
   });
@@ -20,68 +24,81 @@ describe('<Text />', () => {
     expect(() => shallow(<Text>Hi</Text>)).not.toThrow();
   });
 
-  // it('Does not wrap long text if enough width', () => {
-  //   const wrapper = shallow(
-  //     <Text width={300} style={{ fontFamily: 'Courier' }}>This is really long text</Text>
-  //   );
+  it('Does not wrap long text if enough width', () => {
+    const wrapper = shallow<Text>(
+      <Text width={300} style={{ fontFamily: 'Courier' }}>
+        This is really long text
+      </Text>,
+    );
 
-  //   expect(wrapper.instance().state.wordsByLines.length).toEqual(1);
-  // });
+    expect(wrapper.instance().state.wordsByLines).toHaveLength(1);
+  });
 
-  // it('Wraps long text if not enough width', () => {
-  //   const wrapper = shallow(
-  //     <Text width={200} style={{ fontFamily: 'Courier' }}>This is really long text</Text>
-  //   );
+  it('Wraps text if not enough width', () => {
+    const wrapper = shallow<Text>(
+      <Text width={200} style={{ fontFamily: 'Courier' }}>
+        This is really long text
+      </Text>,
+    );
 
-  //   expect(wrapper.instance().state.wordsByLines.length).toEqual(2);
-  // });
+    expect(wrapper.instance().state.wordsByLines).toHaveLength(2);
+  });
 
-  // it('Wraps long text if styled but would have had enough room', () => {
-  //   const wrapper = shallow(
-  //     <Text width={300} style={{ fontSize: '2em', fontFamily: 'Courier' }}>This is really long text</Text>
-  //   );
+  it('Does not wrap text if there is enough width', () => {
+    const wrapper = shallow<Text>(
+      <Text width={300} style={{ fontSize: '2em', fontFamily: 'Courier' }}>
+        This is really long text
+      </Text>,
+    );
 
-  //   expect(wrapper.instance().state.wordsByLines.length).toEqual(2);
-  // });
+    expect(wrapper.instance().state.wordsByLines).toHaveLength(1);
+  });
 
-  // it('Does not perform word length calculation if width or scaleToFit props not set', () => {
-  //   const wrapper = shallow(
-  //     <Text>This is really long text</Text>
-  //   );
+  it('Does not perform word length calculation if width or scaleToFit props not set', () => {
+    const wrapper = shallow<Text>(<Text>This is really long text</Text>);
 
-  //   expect(wrapper.instance().state.wordsByLines.length).toEqual(1);
-  //   expect(wrapper.instance().state.wordsByLines[0].width).toEqual(undefined);
-  // });
+    expect(wrapper.instance().state.wordsByLines).toHaveLength(1);
+    expect(wrapper.instance().state.wordsByLines[0].width).toBeUndefined();
+  });
 
-  // it('Render 0 success when specify the width', () => {
-  //   const wrapper = render(
-  //     <Text x={0} y={0} width={30}>{0}</Text>
-  //   );
+  it('Render 0 success when specify the width', () => {
+    const wrapper = mount(
+      <Text x={0} y={0} width={30}>
+        0
+      </Text>,
+    );
 
-  //   expect(wrapper.text()).toContain('0');
-  // });
+    console.log('wrapper', wrapper.text());
+    expect(wrapper.text()).toContain('0');
+  });
 
-  // it('Render 0 success when not specify the width', () => {
-  //   const wrapper = render(
-  //     <Text x={0} y={0}>{0}</Text>
-  //   );
+  it('Render 0 success when not specify the width', () => {
+    const wrapper = mount(
+      <Text x={0} y={0}>
+        0
+      </Text>,
+    );
 
-  //   expect(wrapper.text()).toContain('0');
-  // });
+    expect(wrapper.text()).toContain('0');
+  });
 
-  // it('Render text when x or y is a percentage', () => {
-  //   const wrapper = render(
-  //     <Text x="50%" y="50%">anything</Text>
-  //   );
+  it('Render text when x or y is a percentage', () => {
+    const wrapper = mount(
+      <Text x="50%" y="50%">
+        anything
+      </Text>,
+    );
 
-  //   expect(wrapper.text()).toContain('anything');
-  // });
+    expect(wrapper.text()).toContain('anything');
+  });
 
-  // it("Don't Render text when x or y is NaN ", () => {
-  //   const wrapperNan = render(
-  //     <Text x={NaN} y={10}>anything</Text>
-  //   );
+  it("Don't Render text when x or y is NaN", () => {
+    const wrapperNan = mount(
+      <Text x={NaN} y={10}>
+        anything
+      </Text>,
+    );
 
-  //   expect(wrapperNan.text()).not.toContain('anything');
-  // });
+    expect(wrapperNan.text()).not.toContain('anything');
+  });
 });

--- a/packages/vx-text/test/svgMock.ts
+++ b/packages/vx-text/test/svgMock.ts
@@ -1,0 +1,25 @@
+// @ts-ignore
+let originalFn: typeof SVGElement.prototype.getComputedTextLength;
+
+/**
+ * JSDom does not implement getComputedTextLength()
+ * so this function add mock implementation for testing.
+ */
+export function addMock() {
+  // @ts-ignore
+  originalFn = SVGElement.prototype.getComputedTextLength;
+
+  // @ts-ignore
+  SVGElement.prototype.getComputedTextLength = function getComputedTextLength() {
+    // Make every character 10px wide
+    return (this.textContent?.length ?? 0) * 10;
+  };
+}
+
+/**
+ * Remove mock from addMock()
+ */
+export function removeMock() {
+  // @ts-ignore
+  SVGElement.prototype.getComputedTextLength = originalFn;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2836,6 +2836,18 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
+"@types/lodash.memoize@^4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.memoize/-/lodash.memoize-4.1.6.tgz#3221f981790a415cab1a239f25c17efd8b604c23"
+  integrity sha512-mYxjKiKzRadRJVClLKxS4wb3Iy9kzwJ1CkbyKiadVxejnswnRByyofmPMscFKscmYpl36BEEhCMPuWhA1R/1ZQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.160"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.160.tgz#2f1bba6500bc3cb9a732c6d66a083378fb0b0b29"
+  integrity sha512-aP03BShJoO+WVndoVj/WNcB/YBPt+CIU1mvaao2GRAHy2yg4pT/XS4XnVHEQBjPJGycWf/9seKEO9vopTJGkvA==
+
 "@types/lodash@^4.14.146":
   version "4.14.154"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.154.tgz#069e3c703fdb264e67be9e03b20a640bc0198ecc"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2836,22 +2836,15 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
-"@types/lodash.memoize@^4.1.6":
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.memoize/-/lodash.memoize-4.1.6.tgz#3221f981790a415cab1a239f25c17efd8b604c23"
-  integrity sha512-mYxjKiKzRadRJVClLKxS4wb3Iy9kzwJ1CkbyKiadVxejnswnRByyofmPMscFKscmYpl36BEEhCMPuWhA1R/1ZQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.14.160"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.160.tgz#2f1bba6500bc3cb9a732c6d66a083378fb0b0b29"
-  integrity sha512-aP03BShJoO+WVndoVj/WNcB/YBPt+CIU1mvaao2GRAHy2yg4pT/XS4XnVHEQBjPJGycWf/9seKEO9vopTJGkvA==
-
 "@types/lodash@^4.14.146":
   version "4.14.154"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.154.tgz#069e3c703fdb264e67be9e03b20a640bc0198ecc"
   integrity sha512-VoDZIJmg3P8vPEnTldLvgA+q7RkIbVkbYX4k0cAVFzGAOQwUehVgRHgIr2/wepwivDst/rVRqaiBSjCXRnoWwQ==
+
+"@types/lodash@^4.14.160":
+  version "4.14.160"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.160.tgz#2f1bba6500bc3cb9a732c6d66a083378fb0b0b29"
+  integrity sha512-aP03BShJoO+WVndoVj/WNcB/YBPt+CIU1mvaao2GRAHy2yg4pT/XS4XnVHEQBjPJGycWf/9seKEO9vopTJGkvA==
 
 "@types/micromatch@^4.0.1":
   version "4.0.1"
@@ -8920,6 +8913,11 @@ lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-driver@^1.2.7:
   version "1.2.7"


### PR DESCRIPTION
#### :bug: Bug Fix

- Fix complains when `NaN` or invalid values are passed as `x` or `y`

```
Warning: Received NaN for the `%s` attribute. If this is expected, cast the value to a string.%s
```

#### :house: Internal

- Remove `prop-types` from dependency. (no longer used)
- List `lodash.memoize` in dependency of `vx/text` which is smaller than entire `lodash`. 
- Fix issue with jsdom and re-enable unit tests.