### PR TITLE
test(xychart): add DataProvider tests

### DIFF
--- a/packages/vx-xychart/src/components/series/LineSeries.tsx
+++ b/packages/vx-xychart/src/components/series/LineSeries.tsx
@@ -33,7 +33,7 @@ export default function LineSeries<
   dataKey,
   ...lineProps
 }: LineSeriesProps<XScaleConfig, YScaleConfig, Datum>) {
-  const { xScale, yScale, colorScale, dataRegistry } = useContext(DataContext);
+  const { xScale, yScale, colorScale, dataRegistry, theme } = useContext(DataContext);
 
   // register data on mount
   // @TODO(chris) make this easier with HOC
@@ -64,7 +64,7 @@ export default function LineSeries<
 
   if (!data || !xAccessor || !yAccessor) return null;
 
-  const color = colorScale?.(dataKey) ?? '#222';
+  const color = colorScale?.(dataKey) ?? theme?.colors?.[0] ?? '#222';
 
   return (
     <LinePath

--- a/packages/vx-xychart/test/DataProvider.test.tsx
+++ b/packages/vx-xychart/test/DataProvider.test.tsx
@@ -1,0 +1,68 @@
+import React, { useContext } from 'react';
+import { mount } from 'enzyme';
+import { DataProvider, DataContext } from '../src';
+import { DataProviderProps } from '../lib/providers/DataProvider';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getWrapper = (consumer: React.ReactNode, props?: DataProviderProps<any, any>) => {
+  mount(
+    <DataProvider xScale={{ type: 'linear' }} yScale={{ type: 'linear' }} {...props}>
+      {consumer}
+    </DataProvider>,
+  );
+};
+describe('<DataProvider />', () => {
+  it('should be defined', () => {
+    expect(DataProvider).toBeDefined();
+  });
+
+  it('should provide a XYChartTheme', () => {
+    expect.assertions(1);
+
+    const DataConsumer = () => {
+      const data = useContext(DataContext);
+      expect(data.theme).toBeDefined();
+
+      return null;
+    };
+
+    getWrapper(<DataConsumer />);
+  });
+
+  it('should provide dimensions', () => {
+    expect.assertions(5);
+
+    const DataConsumer = () => {
+      const data = useContext(DataContext);
+      expect(data.width).toEqual(expect.any(Number));
+      expect(data.height).toEqual(expect.any(Number));
+      expect(data.innerWidth).toEqual(expect.any(Number));
+      expect(data.innerHeight).toEqual(expect.any(Number));
+      expect(data.margin).toMatchObject({
+        top: expect.any(Number),
+        right: expect.any(Number),
+        bottom: expect.any(Number),
+        left: expect.any(Number),
+      });
+
+      return null;
+    };
+
+    getWrapper(<DataConsumer />);
+  });
+
+  it('should provide scales', () => {
+    expect.assertions(3);
+
+    const DataConsumer = () => {
+      const data = useContext(DataContext);
+      expect(data.xScale).toBeDefined();
+      expect(data.yScale).toBeDefined();
+      expect(data.colorScale).toBeDefined();
+
+      return null;
+    };
+
+    getWrapper(<DataConsumer />);
+  });
+});

--- a/packages/vx-xychart/test/DataRegistry.test.ts
+++ b/packages/vx-xychart/test/DataRegistry.test.ts
@@ -1,0 +1,33 @@
+import DataRegistry from '../src/classes/DataRegistry';
+
+const data = { key: 'visx', data: [], xAccessor: () => 'x', yAccessor: () => 'y' };
+
+describe('DataRegistry', () => {
+  it('should be defined', () => {
+    expect(DataRegistry).toBeDefined();
+  });
+
+  it('should register one data', () => {
+    const reg = new DataRegistry();
+    reg.registerData(data);
+    expect(reg.get('visx')).toBe(data);
+    expect(reg.keys()).toEqual(['visx']);
+  });
+
+  it('should register multiple data', () => {
+    const data2 = { key: 'd3', data: [], xAccessor: () => 'x2', yAccessor: () => 'y2' };
+    const reg = new DataRegistry();
+    reg.registerData([data, data2]);
+    expect(reg.get('visx')).toBe(data);
+    expect(reg.get('d3')).toBe(data2);
+    expect(reg.keys()).toEqual(['visx', 'd3']);
+  });
+
+  it('should de-register data', () => {
+    const reg = new DataRegistry();
+    reg.registerData(data);
+    expect(reg.get('visx')).toBe(data);
+    reg.unregisterData('visx');
+    expect(reg.get('visx')).toBeUndefined();
+  });
+});

--- a/packages/vx-xychart/test/LineSeries.test.tsx
+++ b/packages/vx-xychart/test/LineSeries.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { LinePath } from '@vx/shape';
+import { LineSeries } from '../src';
+
+describe('<LineSeries />', () => {
+  it('should be defined', () => {
+    expect(LineSeries).toBeDefined();
+  });
+
+  it('should render a LinePath', () => {
+    const wrapper = shallow(
+      <LineSeries dataKey="line" data={[]} xAccessor={() => 'x'} yAccessor={() => 'y'} />,
+    );
+    expect(wrapper.find(LinePath)).toHaveLength(1);
+  });
+});

--- a/packages/vx-xychart/test/ThemeProvider.test.tsx
+++ b/packages/vx-xychart/test/ThemeProvider.test.tsx
@@ -1,0 +1,26 @@
+import React, { useContext } from 'react';
+import { mount } from 'enzyme';
+import { ThemeProvider, ThemeContext } from '../src';
+
+describe('<ThemeProvider />', () => {
+  it('should be defined', () => {
+    expect(ThemeProvider).toBeDefined();
+  });
+
+  it('should provide a XYChartTheme', () => {
+    expect.assertions(1);
+
+    const ThemeConsumer = () => {
+      const theme = useContext(ThemeContext);
+      expect(theme).toBeDefined();
+
+      return null;
+    };
+
+    mount(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+  });
+});

--- a/packages/vx-xychart/test/XYChart.test.tsx
+++ b/packages/vx-xychart/test/XYChart.test.tsx
@@ -1,0 +1,60 @@
+import React, { useContext } from 'react';
+import { mount, shallow } from 'enzyme';
+import ParentSize from '@vx/responsive/lib/components/ParentSize';
+import { XYChart, DataContext, DataProvider } from '../src';
+
+describe('<XYChart />', () => {
+  it('should be defined', () => {
+    expect(XYChart).toBeDefined();
+  });
+
+  it('should render an svg', () => {
+    const wrapper = shallow(
+      <XYChart width={300} height={300}>
+        <rect />
+      </XYChart>,
+    );
+    expect(wrapper.find('svg')).toHaveLength(1);
+  });
+
+  it('should render children', () => {
+    const wrapper = shallow(
+      <XYChart width={300} height={300}>
+        <rect id="xychart-child" />
+      </XYChart>,
+    );
+    expect(wrapper.find('#xychart-child')).toHaveLength(1);
+  });
+
+  it('should render a ParentSize if width or height is not provided', () => {
+    const wrapper = shallow(
+      <XYChart height={300}>
+        <rect />
+      </XYChart>,
+    );
+    expect(wrapper.find(ParentSize)).toHaveLength(1);
+  });
+
+  it('should update the registry dimensions', () => {
+    expect.assertions(2);
+    const width = 123;
+    const height = 456;
+
+    const DataConsumer = () => {
+      const data = useContext(DataContext);
+      if (data.width && data.height) {
+        expect(data.width).toBe(width);
+        expect(data.height).toBe(height);
+      }
+      return null;
+    };
+
+    mount(
+      <DataProvider xScale={{ type: 'linear' }} yScale={{ type: 'linear' }}>
+        <XYChart width={width} height={height}>
+          <DataConsumer />
+        </XYChart>
+      </DataProvider>,
+    );
+  });
+});

--- a/packages/vx-xychart/test/theme.test.tsx
+++ b/packages/vx-xychart/test/theme.test.tsx
@@ -1,5 +1,3 @@
-import React, { useContext } from 'react';
-import { mount } from 'enzyme';
 import {
   lightTheme,
   darkTheme,
@@ -7,32 +5,7 @@ import {
   defaultColors,
   grayColors,
   buildChartTheme,
-  ThemeProvider,
-  ThemeContext,
 } from '../src';
-
-describe('<ThemeProvider />', () => {
-  it('should be defined', () => {
-    expect(ThemeProvider).toBeDefined();
-  });
-
-  it('should provide a XYChartTheme', () => {
-    expect.assertions(1);
-
-    const ThemeConsumer = () => {
-      const theme = useContext(ThemeContext);
-      expect(theme).toBeDefined();
-
-      return null;
-    };
-
-    mount(
-      <ThemeProvider>
-        <ThemeConsumer />
-      </ThemeProvider>,
-    );
-  });
-});
 
 describe('colors', () => {
   it('should export allColors', () => {


### PR DESCRIPTION
#### :house: Internal

This PR adds tests to #789 (separate for easier review)

@kristw @hshoff 